### PR TITLE
git commitStdout buffering fix

### DIFF
--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1121,6 +1121,8 @@ int main(int argc, char* argv[])
 	DWORD now;
 	BUS::phase_t phase;
 	BYTE data;
+	// added setvbuf to overtime stdout buffering, so logs are written immediately and not when the process exits.
+	setvbuf(stdout, NULL, _IONBF, 0);
 #ifndef BAREMETAL
 	struct sched_param schparam;
 #endif	// BAREMETAL


### PR DESCRIPTION
Determined that logging for the rascsi daemon wouldn't flush until the service exited.  stdout is buffered when redirected to a file, so we disable buffering on stdout, and log files get populated while the daemon is running. win win!