### PR TITLE
Use exception for unsupported LUN handling, reduces duplicate code

### DIFF
--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -502,7 +502,8 @@ void FASTCALL SASIDEV::Command()
                 try {
                         Execute();
                 }
-                catch (const lunexception& e) {
+                catch (lunexception& e) {
+                        LOGINFO("%s unsupported LUN %d", __PRETTY_FUNCTION__, (int)e.getlun());
                         Error();
                 }
 		#else
@@ -924,7 +925,7 @@ void FASTCALL SASIDEV::CmdTestUnitReady()
 
 	LOGTRACE("%s TEST UNIT READY Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->TestUnitReady(ctrl.cmd);
@@ -951,7 +952,7 @@ void FASTCALL SASIDEV::CmdRezero()
 
 	LOGTRACE( "%s REZERO UNIT Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Rezero(ctrl.cmd);
@@ -976,7 +977,7 @@ void FASTCALL SASIDEV::CmdRequestSense()
 
 	LOGTRACE( "%s REQUEST SENSE Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	ctrl.length = ctrl.unit[lun]->RequestSense(ctrl.cmd, ctrl.buffer);
 	ASSERT(ctrl.length > 0);
@@ -1001,7 +1002,7 @@ void FASTCALL SASIDEV::CmdFormat()
 
 	LOGTRACE( "%s FORMAT UNIT Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Format(ctrl.cmd);
@@ -1028,7 +1029,7 @@ void FASTCALL SASIDEV::CmdReassign()
 
 	LOGTRACE("%s REASSIGN BLOCKS Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Reassign(ctrl.cmd);
@@ -1091,7 +1092,7 @@ void FASTCALL SASIDEV::CmdRead6()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Get record number and block number
 	record = ctrl.cmd[1] & 0x1f;
@@ -1141,7 +1142,7 @@ void FASTCALL SASIDEV::DaynaPortWrite()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Error if not a host bridge
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')) {
@@ -1199,7 +1200,7 @@ void FASTCALL SASIDEV::CmdWrite6()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Special receive function for the DaynaPort
 	if (ctrl.unit[lun]->GetID() == MAKEID('S', 'C', 'D', 'P')){
@@ -1249,7 +1250,7 @@ void FASTCALL SASIDEV::CmdSeek6()
 
 	LOGTRACE("%s SEEK(6) Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Seek(ctrl.cmd);
@@ -1276,7 +1277,7 @@ void FASTCALL SASIDEV::CmdAssign()
 
 	LOGTRACE("%s ASSIGN Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Assign(ctrl.cmd);
@@ -1306,7 +1307,7 @@ void FASTCALL SASIDEV::CmdSpecify()
 
 	LOGTRACE("%s SPECIFY Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Assign(ctrl.cmd);
@@ -1915,11 +1916,11 @@ void SASIDEV::GetPhaseStr(char *str)
 //	Validate LUN
 //
 //---------------------------------------------------------------------------
-DWORD FASTCALL SASIDEV::ValidateLun()
+DWORD FASTCALL SASIDEV::GetLun()
 {
         DWORD lun = (ctrl.cmd[1] >> 5) & 0x07;
         if (!ctrl.unit[lun]) {
-                throw lunexception();
+                throw lunexception(lun);
         }
 
         return lun;

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -163,7 +163,7 @@ protected:
 	// Special operations
 	void FASTCALL FlushUnit();						// Flush the logical unit
 
-        DWORD FASTCALL ValidateLun();                                           // LUN validation
+        DWORD FASTCALL GetLun();                                           // Get the validated LUN
 
 protected:
 	#ifndef RASCSI

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -163,6 +163,8 @@ protected:
 	// Special operations
 	void FASTCALL FlushUnit();						// Flush the logical unit
 
+        DWORD FASTCALL ValidateLun();                                           // LUN validation
+
 protected:
 	#ifndef RASCSI
 	Device *host;								// Host device

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -18,6 +18,7 @@
 #include "gpiobus.h"
 #include "devices/scsi_host_bridge.h"
 #include "devices/scsi_daynaport.h"
+#include "exceptions.h"
 
 //===========================================================================
 //
@@ -611,18 +612,11 @@ void FASTCALL SCSIDEV::CmdInquiry()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdModeSelect()
 {
-	DWORD lun;
-
 	ASSERT(this);
 
 	LOGTRACE( "%s MODE SELECT Command", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->SelectCheck(ctrl.cmd);
@@ -720,18 +714,11 @@ void FASTCALL SCSIDEV::CmdRelease10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdModeSense()
 {
-	DWORD lun;
-
 	ASSERT(this);
 
 	LOGTRACE( "%s MODE SENSE Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->ModeSense(ctrl.cmd, ctrl.buffer);
@@ -755,19 +742,13 @@ void FASTCALL SCSIDEV::CmdModeSense()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdStartStop()
 {
-	DWORD lun;
 	BOOL status;
 
 	ASSERT(this);
 
 	LOGTRACE( "%s START STOP UNIT Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->StartStop(ctrl.cmd);
@@ -788,19 +769,13 @@ void FASTCALL SCSIDEV::CmdStartStop()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSendDiag()
 {
-	DWORD lun;
 	BOOL status;
 
 	ASSERT(this);
 
 	LOGTRACE( "%s SEND DIAGNOSTIC Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->SendDiag(ctrl.cmd);
@@ -821,19 +796,13 @@ void FASTCALL SCSIDEV::CmdSendDiag()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdRemoval()
 {
-	DWORD lun;
 	BOOL status;
 
 	ASSERT(this);
 
 	LOGTRACE( "%s PREVENT/ALLOW MEDIUM REMOVAL Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Removal(ctrl.cmd);
@@ -854,19 +823,13 @@ void FASTCALL SCSIDEV::CmdRemoval()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdReadCapacity()
 {
-	DWORD lun;
 	int length;
 
 	ASSERT(this);
 
 	LOGTRACE( "%s READ CAPACITY Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	length = ctrl.unit[lun]->ReadCapacity(ctrl.cmd, ctrl.buffer);
@@ -890,17 +853,11 @@ void FASTCALL SCSIDEV::CmdReadCapacity()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdRead10()
 {
-	DWORD lun;
 	DWORD record;
 
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Receive message if host bridge
 	if (ctrl.unit[lun]->GetID() == MAKEID('S', 'C', 'B', 'R')) {
@@ -950,17 +907,11 @@ void FASTCALL SCSIDEV::CmdRead10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdWrite10()
 {
-	DWORD lun;
 	DWORD record;
 
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Receive message with host bridge
 	if (ctrl.unit[lun]->GetID() == MAKEID('S', 'C', 'B', 'R')) {
@@ -1010,19 +961,13 @@ void FASTCALL SCSIDEV::CmdWrite10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSeek10()
 {
-	DWORD lun;
 	BOOL status;
 
 	ASSERT(this);
 
 	LOGTRACE( "%s SEEK(10) Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Seek(ctrl.cmd);
@@ -1043,18 +988,12 @@ void FASTCALL SCSIDEV::CmdSeek10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdVerify()
 {
-	DWORD lun;
 	BOOL status;
 	DWORD record;
 
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Get record number and block number
 	record = ctrl.cmd[2];
@@ -1113,16 +1052,9 @@ void FASTCALL SCSIDEV::CmdVerify()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSynchronizeCache()
 {
-	DWORD lun;
-
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        ValidateLun();
 
 	// Make it do something (not implemented)...
 
@@ -1137,17 +1069,11 @@ void FASTCALL SCSIDEV::CmdSynchronizeCache()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdReadDefectData10()
 {
-	DWORD lun;
 	ASSERT(this);
 
 	LOGTRACE( "%s READ DEFECT DATA(10) Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->ReadDefectData10(ctrl.cmd, ctrl.buffer);
@@ -1169,15 +1095,9 @@ void FASTCALL SCSIDEV::CmdReadDefectData10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdReadToc()
 {
-	DWORD lun;
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->ReadToc(ctrl.cmd, ctrl.buffer);
@@ -1198,17 +1118,11 @@ void FASTCALL SCSIDEV::CmdReadToc()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdPlayAudio10()
 {
-	DWORD lun;
 	BOOL status;
 
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->PlayAudio(ctrl.cmd);
@@ -1229,17 +1143,11 @@ void FASTCALL SCSIDEV::CmdPlayAudio10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdPlayAudioMSF()
 {
-	DWORD lun;
 	BOOL status;
 
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->PlayAudioMSF(ctrl.cmd);
@@ -1260,17 +1168,11 @@ void FASTCALL SCSIDEV::CmdPlayAudioMSF()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdPlayAudioTrack()
 {
-	DWORD lun;
 	BOOL status;
 
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->PlayAudioTrack(ctrl.cmd);
@@ -1291,18 +1193,11 @@ void FASTCALL SCSIDEV::CmdPlayAudioTrack()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdModeSelect10()
 {
-	DWORD lun;
-
 	ASSERT(this);
 
 	LOGTRACE( "%s MODE SELECT10 Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->SelectCheck10(ctrl.cmd);
@@ -1323,18 +1218,11 @@ void FASTCALL SCSIDEV::CmdModeSelect10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdModeSense10()
 {
-	DWORD lun;
-
 	ASSERT(this);
 
 	LOGTRACE( "%s MODE SENSE(10) Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->ModeSense10(ctrl.cmd, ctrl.buffer);
@@ -1358,17 +1246,11 @@ void FASTCALL SCSIDEV::CmdModeSense10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdGetMessage10()
 {
-	DWORD lun;
 	SCSIBR *bridge;
 
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Error if not a host bridge
 	if ((ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'B', 'R')) &&
@@ -1412,16 +1294,9 @@ void FASTCALL SCSIDEV::CmdGetMessage10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSendMessage10()
 {
-	DWORD lun;
-
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Error if not a host bridge
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'B', 'R')) {
@@ -1465,17 +1340,11 @@ void FASTCALL SCSIDEV::CmdSendMessage10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdRetrieveStats()
 {
-	DWORD lun;
 	SCSIDaynaPort *dayna_port;
 
 	ASSERT(this);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Error if not a DaynaPort SCSI Link
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')){
@@ -1509,20 +1378,13 @@ void FASTCALL SCSIDEV::CmdRetrieveStats()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSetIfaceMode()
 {
-	DWORD lun;
-	// BOOL status;
 	SCSIDaynaPort *dayna_port;
 
 	ASSERT(this);
 
 	LOGTRACE("%s",__PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Error if not a DaynaPort SCSI Link
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')){
@@ -1560,18 +1422,11 @@ void FASTCALL SCSIDEV::CmdSetIfaceMode()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSetMcastAddr()
 {
-	DWORD lun;
-
 	ASSERT(this);
 
 	LOGTRACE("%s Set Multicast Address Command ", __PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')){
 		LOGWARN("Received a SetMcastAddress command for a non-daynaport unit");
@@ -1601,7 +1456,6 @@ void FASTCALL SCSIDEV::CmdSetMcastAddr()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdEnableInterface()
 {
-	DWORD lun=0;
 	BOOL status;
 	SCSIDaynaPort *dayna_port;
 
@@ -1609,12 +1463,7 @@ void FASTCALL SCSIDEV::CmdEnableInterface()
 
 	LOGTRACE("%s",__PRETTY_FUNCTION__);
 
-	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
-	if (!ctrl.unit[lun]) {
-		Error();
-		return;
-	}
+        DWORD lun = ValidateLun();
 
 	// Error if not a DaynaPort SCSI Link
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')){
@@ -1907,7 +1756,12 @@ void FASTCALL SCSIDEV::Receive()
 			}
 
 			// Execution Phase
-			Execute();
+                        try {
+                                Execute();
+                        }
+                        catch (const lunexception& e) {
+                                Error();
+                        }
 			break;
 
 		// Message out phase

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -616,7 +616,7 @@ void FASTCALL SCSIDEV::CmdModeSelect()
 
 	LOGTRACE( "%s MODE SELECT Command", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->SelectCheck(ctrl.cmd);
@@ -718,7 +718,7 @@ void FASTCALL SCSIDEV::CmdModeSense()
 
 	LOGTRACE( "%s MODE SENSE Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->ModeSense(ctrl.cmd, ctrl.buffer);
@@ -748,7 +748,7 @@ void FASTCALL SCSIDEV::CmdStartStop()
 
 	LOGTRACE( "%s START STOP UNIT Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->StartStop(ctrl.cmd);
@@ -775,7 +775,7 @@ void FASTCALL SCSIDEV::CmdSendDiag()
 
 	LOGTRACE( "%s SEND DIAGNOSTIC Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->SendDiag(ctrl.cmd);
@@ -802,7 +802,7 @@ void FASTCALL SCSIDEV::CmdRemoval()
 
 	LOGTRACE( "%s PREVENT/ALLOW MEDIUM REMOVAL Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Removal(ctrl.cmd);
@@ -829,7 +829,7 @@ void FASTCALL SCSIDEV::CmdReadCapacity()
 
 	LOGTRACE( "%s READ CAPACITY Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	length = ctrl.unit[lun]->ReadCapacity(ctrl.cmd, ctrl.buffer);
@@ -857,7 +857,7 @@ void FASTCALL SCSIDEV::CmdRead10()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Receive message if host bridge
 	if (ctrl.unit[lun]->GetID() == MAKEID('S', 'C', 'B', 'R')) {
@@ -911,7 +911,7 @@ void FASTCALL SCSIDEV::CmdWrite10()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Receive message with host bridge
 	if (ctrl.unit[lun]->GetID() == MAKEID('S', 'C', 'B', 'R')) {
@@ -967,7 +967,7 @@ void FASTCALL SCSIDEV::CmdSeek10()
 
 	LOGTRACE( "%s SEEK(10) Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->Seek(ctrl.cmd);
@@ -993,7 +993,7 @@ void FASTCALL SCSIDEV::CmdVerify()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Get record number and block number
 	record = ctrl.cmd[2];
@@ -1054,7 +1054,7 @@ void FASTCALL SCSIDEV::CmdSynchronizeCache()
 {
 	ASSERT(this);
 
-        ValidateLun();
+        GetLun();
 
 	// Make it do something (not implemented)...
 
@@ -1073,7 +1073,7 @@ void FASTCALL SCSIDEV::CmdReadDefectData10()
 
 	LOGTRACE( "%s READ DEFECT DATA(10) Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->ReadDefectData10(ctrl.cmd, ctrl.buffer);
@@ -1097,7 +1097,7 @@ void FASTCALL SCSIDEV::CmdReadToc()
 {
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->ReadToc(ctrl.cmd, ctrl.buffer);
@@ -1122,7 +1122,7 @@ void FASTCALL SCSIDEV::CmdPlayAudio10()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->PlayAudio(ctrl.cmd);
@@ -1147,7 +1147,7 @@ void FASTCALL SCSIDEV::CmdPlayAudioMSF()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->PlayAudioMSF(ctrl.cmd);
@@ -1172,7 +1172,7 @@ void FASTCALL SCSIDEV::CmdPlayAudioTrack()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	status = ctrl.unit[lun]->PlayAudioTrack(ctrl.cmd);
@@ -1197,7 +1197,7 @@ void FASTCALL SCSIDEV::CmdModeSelect10()
 
 	LOGTRACE( "%s MODE SELECT10 Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->SelectCheck10(ctrl.cmd);
@@ -1222,7 +1222,7 @@ void FASTCALL SCSIDEV::CmdModeSense10()
 
 	LOGTRACE( "%s MODE SENSE(10) Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Command processing on drive
 	ctrl.length = ctrl.unit[lun]->ModeSense10(ctrl.cmd, ctrl.buffer);
@@ -1250,7 +1250,7 @@ void FASTCALL SCSIDEV::CmdGetMessage10()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Error if not a host bridge
 	if ((ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'B', 'R')) &&
@@ -1296,7 +1296,7 @@ void FASTCALL SCSIDEV::CmdSendMessage10()
 {
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Error if not a host bridge
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'B', 'R')) {
@@ -1344,7 +1344,7 @@ void FASTCALL SCSIDEV::CmdRetrieveStats()
 
 	ASSERT(this);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Error if not a DaynaPort SCSI Link
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')){
@@ -1384,7 +1384,7 @@ void FASTCALL SCSIDEV::CmdSetIfaceMode()
 
 	LOGTRACE("%s",__PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Error if not a DaynaPort SCSI Link
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')){
@@ -1426,7 +1426,7 @@ void FASTCALL SCSIDEV::CmdSetMcastAddr()
 
 	LOGTRACE("%s Set Multicast Address Command ", __PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')){
 		LOGWARN("Received a SetMcastAddress command for a non-daynaport unit");
@@ -1463,7 +1463,7 @@ void FASTCALL SCSIDEV::CmdEnableInterface()
 
 	LOGTRACE("%s",__PRETTY_FUNCTION__);
 
-        DWORD lun = ValidateLun();
+        DWORD lun = GetLun();
 
 	// Error if not a DaynaPort SCSI Link
 	if (ctrl.unit[lun]->GetID() != MAKEID('S', 'C', 'D', 'P')){
@@ -1759,7 +1759,8 @@ void FASTCALL SCSIDEV::Receive()
                         try {
                                 Execute();
                         }
-                        catch (const lunexception& e) {
+                        catch (lunexception& e) {
+                                LOGINFO("%s unsupported LUN %d", __PRETTY_FUNCTION__, (int)e.getlun());
                                 Error();
                         }
 			break;

--- a/src/raspberrypi/exceptions.h
+++ b/src/raspberrypi/exceptions.h
@@ -1,3 +1,15 @@
-using namespace std;
+class lunexception : public std::exception {
+private:
+        DWORD lun;
 
-class lunexception : public exception { };
+public:
+        lunexception(DWORD lun) {
+                this->lun = lun;
+        }
+
+        ~lunexception() { }
+
+        DWORD getlun() {
+            return lun;
+        }
+};

--- a/src/raspberrypi/exceptions.h
+++ b/src/raspberrypi/exceptions.h
@@ -1,0 +1,3 @@
+using namespace std;
+
+class lunexception : public exception { };

--- a/src/raspberrypi/exceptions.h
+++ b/src/raspberrypi/exceptions.h
@@ -1,3 +1,17 @@
+//---------------------------------------------------------------------------
+//
+//      SCSI Target Emulator RaSCSI (*^..^*)
+//      for Raspberry Pi
+//
+//      Powered by XM6 TypeG Technology.
+//      Copyright (C) 2016-2020 GIMONS
+//      [ Exceptions ]
+//
+//---------------------------------------------------------------------------
+
+#if !defined(exceptions_h)
+#define exceptions_h
+
 class lunexception : public std::exception {
 private:
         DWORD lun;
@@ -13,3 +27,5 @@ public:
             return lun;
         }
 };
+
+#endif


### PR DESCRIPTION
I'd like to suggest this change, which introduces an exception to deal with unsupported LUNs. This reduces the amount of duplicated code when checking for a valid LUN.