### PR TITLE
Fixes for gcc 10.3.0

### DIFF
--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -162,7 +162,7 @@ BOOL FASTCALL DiskTrack::Load(const Filepath& path)
 
 	if (dt.buffer == NULL) {
 		#if defined(RASCSI) && !defined(BAREMETAL)
-		posix_memalign((void **)&dt.buffer, 512, ((length + 511) / 512) * 512);
+		(void)!posix_memalign((void **)&dt.buffer, 512, ((length + 511) / 512) * 512);
 		#else
 		dt.buffer = (BYTE *)malloc(length * sizeof(BYTE));
 		#endif	// RASCSI && !BAREMETAL
@@ -177,7 +177,7 @@ BOOL FASTCALL DiskTrack::Load(const Filepath& path)
 	if (dt.length != (DWORD)length) {
 		free(dt.buffer);
 		#if defined(RASCSI) && !defined(BAREMETAL)
-		posix_memalign((void **)&dt.buffer, 512, ((length + 511) / 512) * 512);
+		(void)!posix_memalign((void **)&dt.buffer, 512, ((length + 511) / 512) * 512);
 		#else
 		dt.buffer = (BYTE *)malloc(length * sizeof(BYTE));
 		#endif	// RASCSI && !BAREMETAL

--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -162,7 +162,9 @@ BOOL FASTCALL DiskTrack::Load(const Filepath& path)
 
 	if (dt.buffer == NULL) {
 		#if defined(RASCSI) && !defined(BAREMETAL)
-		(void)!posix_memalign((void **)&dt.buffer, 512, ((length + 511) / 512) * 512);
+                if (posix_memalign((void **)&dt.buffer, 512, ((length + 511) / 512) * 512)) {
+                        LOGWARN("%s posix_memalign failed", __PRETTY_FUNCTION__);
+                }
 		#else
 		dt.buffer = (BYTE *)malloc(length * sizeof(BYTE));
 		#endif	// RASCSI && !BAREMETAL
@@ -177,7 +179,9 @@ BOOL FASTCALL DiskTrack::Load(const Filepath& path)
 	if (dt.length != (DWORD)length) {
 		free(dt.buffer);
 		#if defined(RASCSI) && !defined(BAREMETAL)
-		(void)!posix_memalign((void **)&dt.buffer, 512, ((length + 511) / 512) * 512);
+		if (posix_memalign((void **)&dt.buffer, 512, ((length + 511) / 512) * 512)) {
+                  LOGWARN("%s posix_memalign failed", __PRETTY_FUNCTION__);  
+                }
 		#else
 		dt.buffer = (BYTE *)malloc(length * sizeof(BYTE));
 		#endif	// RASCSI && !BAREMETAL

--- a/src/raspberrypi/filepath.cpp
+++ b/src/raspberrypi/filepath.cpp
@@ -208,24 +208,6 @@ void FASTCALL Filepath::Split()
 
 //---------------------------------------------------------------------------
 //
-//	パス合成
-//
-//---------------------------------------------------------------------------
-void FASTCALL Filepath::Make()
-{
-	ASSERT(this);
-
-	// パス初期化
-	m_szPath[0] = _T('\0');
-
-	// 合成
-	strncat(m_szPath, m_szDir, ARRAY_SIZE(m_szPath) - strlen(m_szPath));
-	strncat(m_szPath, m_szFile, ARRAY_SIZE(m_szPath) - strlen(m_szPath));
-	strncat(m_szPath, m_szExt, ARRAY_SIZE(m_szPath) - strlen(m_szPath));
-}
-
-//---------------------------------------------------------------------------
-//
 //	クリアされているか
 //
 //---------------------------------------------------------------------------

--- a/src/raspberrypi/filepath.h
+++ b/src/raspberrypi/filepath.h
@@ -59,8 +59,6 @@ public:
 private:
 	void FASTCALL Split();
 										// パス分割
-	void FASTCALL Make();
-										// パス合成
 	void FASTCALL SetCurDir();
 										// カレントディレクトリ設定
 	TCHAR m_szPath[_MAX_PATH];

--- a/src/raspberrypi/gpiobus.cpp
+++ b/src/raspberrypi/gpiobus.cpp
@@ -1245,7 +1245,7 @@ int FASTCALL GPIOBUS::PollSelectEvent()
 		return -1;
 	}
 
-	(void)read(selevreq.fd, &gpev, sizeof(gpev));
+	(void)!read(selevreq.fd, &gpev, sizeof(gpev));
 #endif	// BAREMETAL
 
 	return 0;

--- a/src/raspberrypi/gpiobus.cpp
+++ b/src/raspberrypi/gpiobus.cpp
@@ -1242,10 +1242,14 @@ int FASTCALL GPIOBUS::PollSelectEvent()
 	struct gpioevent_data gpev;
 
 	if (epoll_wait(epfd, &epev, 1, -1) <= 0) {
+                LOGWARN("%s epoll_wait failed", __PRETTY_FUNCTION__);
 		return -1;
 	}
 
-	(void)!read(selevreq.fd, &gpev, sizeof(gpev));
+	if (read(selevreq.fd, &gpev, sizeof(gpev)) < 0) {
+            LOGWARN("%s read failed", __PRETTY_FUNCTION__);
+            return -1;
+        }
 #endif	// BAREMETAL
 
 	return 0;

--- a/src/raspberrypi/scsimon.cpp
+++ b/src/raspberrypi/scsimon.cpp
@@ -19,6 +19,7 @@
 #include "rascsi_version.h"
 #include "spdlog/spdlog.h"
 #include <sys/time.h>
+#include <climits>
 
 //---------------------------------------------------------------------------
 //


### PR DESCRIPTION
These changes fix issues with gcc 10.3.0:

- "ignoring return value of ... declared with attribute ‘warn_unused_result’". Fixed by negating the unused return value according to comment 34 on https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425#c34
- "accessing 1 byte at offsets x and y may overlap 1 byte at offset y" in filepath.ccp. Looks as if the affected method Filepath::Make is never called, so I just removed it.
- "climits" has to be included for the LLONG_MAX definition

Note that I stumbled upon these issues when cross-compiling on Ubuntu 21.04.