### PR TITLE
Added EXTRA_FLAGS to Makefile and fixed typo

### DIFF
--- a/src/raspberrypi/Makefile
+++ b/src/raspberrypi/Makefile
@@ -30,8 +30,12 @@ else
 	CXXFLAGS += -O3 -Wall -Werror -DNDEBUG
 	BUILD_TYPE = Release
 endif
-CFLAGS += -iquote . -MD -MP 
-CXXFLAGS += -std=c++14 -iquote . -MD -MP 
+CFLAGS += -iquote . -MD -MP
+CXXFLAGS += -std=c++14 -iquote . -MD -MP
+
+## EXTRA_FLAGS : Can be used to pass special purpose flags
+CFLAGS += $(EXTRA_FLAGS)
+CXXFLAGS += $(EXTRA_FLAGS)
 
 ##   CONNECT_TYPE=FULLSPEC : Specify the type of RaSCSI board type
 ##              that you are using. The typical options are 

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -1742,7 +1742,7 @@ BOOL FASTCALL SASIDEV::XferOut(BOOL cont)
 
 			// Special case Write function for DaynaPort
 			if (ctrl.unit[lun]->GetID() == MAKEID('S', 'C', 'D', 'P')) {
-				LOGTRACE("%s Doing special case write for DayanPort", __PRETTY_FUNCTION__);
+				LOGTRACE("%s Doing special case write for DaynaPort", __PRETTY_FUNCTION__);
 				if (!(SCSIDaynaPort*)ctrl.unit[lun]->Write(ctrl.cmd, ctrl.buffer, ctrl.length)) {
 					// write failed
 					return FALSE;

--- a/src/raspberrypi/devices/scsi_daynaport.cpp
+++ b/src/raspberrypi/devices/scsi_daynaport.cpp
@@ -137,7 +137,7 @@ int FASTCALL SCSIDaynaPort::Inquiry(
 	// 	LOGWARN(":::::::::: Doing runtime pointer conversion: %04X", ((scsi_cdb_6_byte_t*)cdb)->length);
 	// }
 
-	LOGTRACE("%s Inquiry with major %ld, minor %ld. Allocaiton length: %d",__PRETTY_FUNCTION__, major, minor, (int)allocation_length);
+	LOGTRACE("%s Inquiry with major %ld, minor %ld. Allocation length: %d",__PRETTY_FUNCTION__, major, minor, (int)allocation_length);
 
 	if(cdb[1] & 0x3) {
 		LOGWARN("Tiny SCSI Emulator says this is an invalid request");


### PR DESCRIPTION
Depending on the compile environment it is useful if additional flags can be passed. I sometimes need "-fpermissive", for instance.