### PR TITLE
Option for setting the log level at rascsi startup, improved device file support

### DIFF
--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -30,6 +30,7 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <spdlog/async.h>
+#include <iostream>
 
 //---------------------------------------------------------------------------
 //
@@ -548,7 +549,7 @@ BOOL ProcessCmd(FILE *fp, int id, int un, int cmd, int type, char *file)
 			// 	break;
 			case rasctl_dev_daynaport: // DaynaPort SCSI Link
 				pUnit = new SCSIDaynaPort();
-				LOGTRACE("Done creating SCSIDayanPort");
+				LOGTRACE("Done creating SCSIDaynaPort");
 				break;
 			default:
 				FPRT(fp,	"Error : Invalid device type\n");
@@ -872,9 +873,10 @@ bool ParseArgument(int argc, char* argv[])
 	int id = -1;
 	bool is_sasi = false;
 	int max_id = 7;
+	const char* log_level = "trace";
 
 	int opt;
-	while ((opt = getopt(argc, argv, "-IiHhD:d:")) != -1) {
+	while ((opt = getopt(argc, argv, "-IiHhL:l:D:d:")) != -1) {
 		switch (opt) {
 			case 'I':
 			case 'i':
@@ -888,6 +890,11 @@ bool ParseArgument(int argc, char* argv[])
 				is_sasi = true;
 				max_id = 15;
 				id = -1;
+				continue;
+
+			case 'L':
+			case 'l':
+				log_level = optarg;
 				continue;
 
 			case 'D':
@@ -952,6 +959,32 @@ bool ParseArgument(int argc, char* argv[])
 			return false;
 		}
 		id = -1;
+	}
+
+	// Evaluate log level
+	if (!strcasecmp(log_level, "trace")) {
+		spdlog::set_level(spdlog::level::trace);
+	}
+	else if (!strcasecmp(log_level, "debug")) {
+		spdlog::set_level(spdlog::level::debug);
+	}
+	else if (!strcasecmp(log_level, "info")) {
+		spdlog::set_level(spdlog::level::info);
+	}
+	else if (!strcasecmp(log_level, "warn")) {
+		spdlog::set_level(spdlog::level::warn);
+	}
+	else if (!strcasecmp(log_level, "err")) {
+		spdlog::set_level(spdlog::level::err);
+	}
+	else if (!strcasecmp(log_level, "critical")) {
+		spdlog::set_level(spdlog::level::critical);
+	}
+	else if (!strcasecmp(log_level, "off")) {
+		spdlog::set_level(spdlog::level::off);
+	}
+	else {
+		std::cerr << "Unknown log level '" << log_level << "', using 'trace'" << std::endl;
 	}
 
 	// Display the device list
@@ -1127,11 +1160,10 @@ int main(int argc, char* argv[])
 	struct sched_param schparam;
 #endif	// BAREMETAL
 
-    spdlog::set_level(spdlog::level::trace);
+	spdlog::set_level(spdlog::level::trace);
 	// Create a thread-safe stdout logger to process the log messages
 	auto logger = spdlog::stdout_color_mt("rascsi stdout logger");
 
-    LOGTRACE("Entering the function %s with %d arguments", __PRETTY_FUNCTION__, argc);
 	// Output the Banner
 	Banner(argc, argv);
 

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -30,7 +30,10 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <spdlog/async.h>
+#include <string>
 #include <iostream>
+
+using namespace std;
 
 //---------------------------------------------------------------------------
 //
@@ -559,8 +562,12 @@ BOOL ProcessCmd(FILE *fp, int id, int un, int cmd, int type, char *file)
 
 		// drive checks files
 		if (type <= rasctl_dev_scsi_hd || ((type <= rasctl_dev_cd || type == rasctl_dev_daynaport) && xstrcasecmp(file, "-") != 0)) {
+			// Strip the image file extension from device file names, so that device files can be used as drive images
+			string f = file;
+			string effective_file = f.find("/dev/") ? f : f.substr(0, f.length() - 4);
+
 			// Set the Path
-			filepath.SetPath(file);
+			filepath.SetPath(effective_file.c_str());
 
 			// Open the file path
 			if (!pUnit->Open(filepath)) {
@@ -873,7 +880,7 @@ bool ParseArgument(int argc, char* argv[])
 	int id = -1;
 	bool is_sasi = false;
 	int max_id = 7;
-	const char* log_level = "trace";
+	string log_level = "trace";
 
 	int opt;
 	while ((opt = getopt(argc, argv, "-IiHhL:l:D:d:")) != -1) {
@@ -962,29 +969,29 @@ bool ParseArgument(int argc, char* argv[])
 	}
 
 	// Evaluate log level
-	if (!strcasecmp(log_level, "trace")) {
+	if (log_level == "trace") {
 		spdlog::set_level(spdlog::level::trace);
 	}
-	else if (!strcasecmp(log_level, "debug")) {
+	else if (log_level == "debug") {
 		spdlog::set_level(spdlog::level::debug);
 	}
-	else if (!strcasecmp(log_level, "info")) {
+	else if (log_level == "info") {
 		spdlog::set_level(spdlog::level::info);
 	}
-	else if (!strcasecmp(log_level, "warn")) {
+	else if (log_level == "warn") {
 		spdlog::set_level(spdlog::level::warn);
 	}
-	else if (!strcasecmp(log_level, "err")) {
+	else if (log_level == "err") {
 		spdlog::set_level(spdlog::level::err);
 	}
-	else if (!strcasecmp(log_level, "critical")) {
+	else if (log_level == "critical") {
 		spdlog::set_level(spdlog::level::critical);
 	}
-	else if (!strcasecmp(log_level, "off")) {
+	else if (log_level == "off") {
 		spdlog::set_level(spdlog::level::off);
 	}
 	else {
-		std::cerr << "Unknown log level '" << log_level << "', using 'trace'" << std::endl;
+		cerr << "Invalid log level '" << log_level << "', falling back to 'trace'" << endl;
 	}
 
 	// Display the device list

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -679,7 +679,7 @@ BOOL ProcessCmd(FILE *fp, int id, int un, int cmd, int type, char *file)
 bool has_suffix(const char* string, const char* suffix) {
 	int string_len = strlen(string);
 	int suffix_len = strlen(suffix);
-	return (string_len >= suffix_len)
+	return (string_len > suffix_len)
 		&& (xstrcasecmp(string + (string_len - suffix_len), suffix) == 0);
 }
 
@@ -942,9 +942,9 @@ bool ParseArgument(int argc, char* argv[])
 		} else if (xstrcasecmp(path, "daynaport") == 0) {
 			type = rasctl_dev_daynaport;
 		} else {
-			// Cannot determine the file type
+			// Cannot determine the file type or the basename is missing
 			fprintf(stderr,
-					"%s: unknown file extension\n", path);
+					"%s: unknown file extension or basename is missing\n", path);
 			return false;
 		}
 


### PR DESCRIPTION
With the -L/-l option the rascsi log level can now be set on startup. Note that this setting has no effect while the ProcessCmd() method is executed, because the log level is set later, after all command line options were evaluated.

This change also addresses https://github.com/akuker/RASCSI/issues/19.