### PR TITLE
Removed meaningless assertions, minor code locality cleanup

### DIFF
--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -89,10 +89,6 @@ SASIDEV::~SASIDEV()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::Reset()
 {
-	int i;
-
-	ASSERT(this);
-
 	// Work initialization
 	memset(ctrl.cmd, 0x00, sizeof(ctrl.cmd));
 	ctrl.phase = BUS::busfree;
@@ -108,7 +104,7 @@ void FASTCALL SASIDEV::Reset()
 	ctrl.length = 0;
 
 	// Unit initialization
-	for (i = 0; i < UnitMax; i++) {
+	for (int i = 0; i < UnitMax; i++) {
 		if (ctrl.unit[i]) {
 			ctrl.unit[i]->Reset();
 		}
@@ -123,13 +119,10 @@ void FASTCALL SASIDEV::Reset()
 //---------------------------------------------------------------------------
 BOOL FASTCALL SASIDEV::Save(Fileio *fio, int /*ver*/)
 {
-	DWORD sz;
-
-	ASSERT(this);
 	ASSERT(fio);
 
 	// Save size
-	sz = 2120;
+	DWORD sz = 2120;
 	if (!fio->Write(&sz, sizeof(sz))) {
 		return FALSE;
 	}
@@ -158,9 +151,6 @@ BOOL FASTCALL SASIDEV::Save(Fileio *fio, int /*ver*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SASIDEV::Load(Fileio *fio, int ver)
 {
-	DWORD sz;
-
-	ASSERT(this);
 	ASSERT(fio);
 
 	// Not saved before version 3.11
@@ -169,6 +159,7 @@ BOOL FASTCALL SASIDEV::Load(Fileio *fio, int ver)
 	}
 
 	// Load size and check if the size matches
+	DWORD sz;
 	if (!fio->Read(&sz, sizeof(sz))) {
 		return FALSE;
 	}
@@ -201,8 +192,6 @@ BOOL FASTCALL SASIDEV::Load(Fileio *fio, int ver)
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::Connect(int id, BUS *bus)
 {
-	ASSERT(this);
-
 	ctrl.m_scsi_id = id;
 	ctrl.bus = bus;
 }
@@ -214,7 +203,6 @@ void FASTCALL SASIDEV::Connect(int id, BUS *bus)
 //---------------------------------------------------------------------------
 Disk* FASTCALL SASIDEV::GetUnit(int no)
 {
-	ASSERT(this);
 	ASSERT(no < UnitMax);
 
 	return ctrl.unit[no];
@@ -227,7 +215,6 @@ Disk* FASTCALL SASIDEV::GetUnit(int no)
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::SetUnit(int no, Disk *dev)
 {
-	ASSERT(this);
 	ASSERT(no < UnitMax);
 
 	ctrl.unit[no] = dev;
@@ -240,11 +227,7 @@ void FASTCALL SASIDEV::SetUnit(int no, Disk *dev)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SASIDEV::HasUnit()
 {
-	int i;
-
-	ASSERT(this);
-
-	for (i = 0; i < UnitMax; i++) {
+	for (int i = 0; i < UnitMax; i++) {
 		if (ctrl.unit[i]) {
 			return TRUE;
 		}
@@ -260,7 +243,6 @@ BOOL FASTCALL SASIDEV::HasUnit()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::GetCTRL(ctrl_t *buffer)
 {
-	ASSERT(this);
 	ASSERT(buffer);
 
 	// reference the internal structure
@@ -274,12 +256,8 @@ void FASTCALL SASIDEV::GetCTRL(ctrl_t *buffer)
 //---------------------------------------------------------------------------
 Disk* FASTCALL SASIDEV::GetBusyUnit()
 {
-	DWORD lun;
-
-	ASSERT(this);
-
 	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
+	DWORD lun = (ctrl.cmd[1] >> 5) & 0x07;
 	return ctrl.unit[lun];
 }
 
@@ -290,8 +268,6 @@ Disk* FASTCALL SASIDEV::GetBusyUnit()
 //---------------------------------------------------------------------------
 BUS::phase_t FASTCALL SASIDEV::Process()
 {
-	ASSERT(this);
-
 	// Do nothing if not connected
 	if (ctrl.m_scsi_id < 0 || ctrl.bus == NULL) {
 		return ctrl.phase;
@@ -366,11 +342,8 @@ BUS::phase_t FASTCALL SASIDEV::Process()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::BusFree()
 {
-	ASSERT(this);
-
 	// Phase change
 	if (ctrl.phase != BUS::busfree) {
-
 		LOGINFO("Bus free phase");
 
 		// Phase Setting
@@ -402,14 +375,10 @@ void FASTCALL SASIDEV::BusFree()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::Selection()
 {
-	DWORD id;
-
-	ASSERT(this);
-
 	// Phase change
 	if (ctrl.phase != BUS::selection) {
 		// Invalid if IDs do not match
-		id = 1 << ctrl.m_scsi_id;
+		DWORD id = 1 << ctrl.m_scsi_id;
 		if ((ctrl.bus->GetDAT() & id) == 0) {
 			return;
 		}
@@ -446,8 +415,6 @@ void FASTCALL SASIDEV::Command()
 	int count;
 	int i;
 	#endif	// RASCSI
-
-	ASSERT(this);
 
 	// Phase change
 	if (ctrl.phase != BUS::command) {
@@ -534,8 +501,6 @@ void FASTCALL SASIDEV::Command()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::Execute()
 {
-	ASSERT(this);
-
 	LOGTRACE("%s Execution Phase Command %02X", __PRETTY_FUNCTION__, (WORD)ctrl.cmd[0]);
 
 	// Phase Setting
@@ -636,8 +601,6 @@ void FASTCALL SASIDEV::Status()
 	DWORD time;
 	#endif	// RASCSI
 
-	ASSERT(this);
-
 	// Phase change
 	if (ctrl.phase != BUS::status) {
 
@@ -706,8 +669,6 @@ void FASTCALL SASIDEV::Status()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::MsgIn()
 {
-	ASSERT(this);
-
 	// Phase change
 	if (ctrl.phase != BUS::msgin) {
 		LOGTRACE("%s Starting Message in phase", __PRETTY_FUNCTION__);
@@ -744,7 +705,6 @@ void FASTCALL SASIDEV::DataIn()
 	DWORD time;
 	#endif	// RASCSI
 
-	ASSERT(this);
 	ASSERT(ctrl.length >= 0);
 
 	// Phase change
@@ -801,7 +761,6 @@ void FASTCALL SASIDEV::DataOut()
 	DWORD time;
 	#endif	// RASCSI
 
-	ASSERT(this);
 	ASSERT(ctrl.length >= 0);
 
 	// Phase change
@@ -873,10 +832,6 @@ void FASTCALL SASIDEV::DataOut()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::Error()
 {
-	DWORD lun;
-
-	ASSERT(this);
-
 	// Get bus information
 	((GPIOBUS*)ctrl.bus)->Aquire();
 
@@ -901,7 +856,7 @@ void FASTCALL SASIDEV::Error()
 #endif	// DISK_LOG
 
 	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
+	DWORD lun = (ctrl.cmd[1] >> 5) & 0x07;
 
 	// Set status and message(CHECK CONDITION)
 	ctrl.status = (lun << 5) | 0x02;
@@ -917,16 +872,12 @@ void FASTCALL SASIDEV::Error()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdTestUnitReady()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE("%s TEST UNIT READY Command ", __PRETTY_FUNCTION__);
 
         DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->TestUnitReady(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->TestUnitReady(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -944,16 +895,12 @@ void FASTCALL SASIDEV::CmdTestUnitReady()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdRezero()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE( "%s REZERO UNIT Command ", __PRETTY_FUNCTION__);
 
         DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->Rezero(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->Rezero(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -971,8 +918,6 @@ void FASTCALL SASIDEV::CmdRezero()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdRequestSense()
 {
-	ASSERT(this);
-
 	LOGTRACE( "%s REQUEST SENSE Command ", __PRETTY_FUNCTION__);
 
         DWORD lun = GetLun();
@@ -994,16 +939,12 @@ void FASTCALL SASIDEV::CmdRequestSense()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdFormat()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE( "%s FORMAT UNIT Command ", __PRETTY_FUNCTION__);
 
         DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->Format(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->Format(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1021,16 +962,12 @@ void FASTCALL SASIDEV::CmdFormat()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdReassign()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE("%s REASSIGN BLOCKS Command ", __PRETTY_FUNCTION__);
 
         DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->Reassign(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->Reassign(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1053,7 +990,6 @@ void FASTCALL SASIDEV::CmdReassign()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdReserveUnit()
 {
-	ASSERT(this);
 	LOGTRACE( "%s Reserve(6) Command", __PRETTY_FUNCTION__);
 
 	// status phase
@@ -1072,7 +1008,6 @@ void FASTCALL SASIDEV::CmdReserveUnit()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdReleaseUnit()
 {
-	ASSERT(this);
 	LOGTRACE( "%s Release(6) Command", __PRETTY_FUNCTION__);
 
 	// status phase
@@ -1086,14 +1021,10 @@ void FASTCALL SASIDEV::CmdReleaseUnit()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdRead6()
 {
-	DWORD record;
-
-	ASSERT(this);
-
         DWORD lun = GetLun();
 
 	// Get record number and block number
-	record = ctrl.cmd[1] & 0x1f;
+	DWORD record = ctrl.cmd[1] & 0x1f;
 	record <<= 8;
 	record |= ctrl.cmd[2];
 	record <<= 8;
@@ -1136,10 +1067,6 @@ void FASTCALL SASIDEV::CmdRead6()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::DaynaPortWrite()
 {
-	DWORD data_format;
-
-	ASSERT(this);
-
         DWORD lun = GetLun();
 
 	// Error if not a host bridge
@@ -1156,9 +1083,7 @@ void FASTCALL SASIDEV::DaynaPortWrite()
 		ctrl.buffer = (BYTE *)malloc(ctrl.bufsize);
 	}
 
-
-	data_format = ctrl.cmd[5];
-
+	DWORD data_format = ctrl.cmd[5];
 
 	if(data_format == 0x00){
 		ctrl.length = (WORD)ctrl.cmd[4] + ((WORD)ctrl.cmd[3] << 8);
@@ -1194,10 +1119,6 @@ void FASTCALL SASIDEV::DaynaPortWrite()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdWrite6()
 {
-	DWORD record;
-
-	ASSERT(this);
-
         DWORD lun = GetLun();
 
 	// Special receive function for the DaynaPort
@@ -1207,7 +1128,7 @@ void FASTCALL SASIDEV::CmdWrite6()
 	}
 
 	// Get record number and block number
-	record = ctrl.cmd[1] & 0x1f;
+	DWORD record = ctrl.cmd[1] & 0x1f;
 	record <<= 8;
 	record |= ctrl.cmd[2];
 	record <<= 8;
@@ -1242,16 +1163,12 @@ void FASTCALL SASIDEV::CmdWrite6()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdSeek6()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE("%s SEEK(6) Command ", __PRETTY_FUNCTION__);
 
         DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->Seek(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->Seek(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1269,16 +1186,12 @@ void FASTCALL SASIDEV::CmdSeek6()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdAssign()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE("%s ASSIGN Command ", __PRETTY_FUNCTION__);
 
         DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->Assign(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->Assign(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1299,16 +1212,12 @@ void FASTCALL SASIDEV::CmdAssign()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdSpecify()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE("%s SPECIFY Command ", __PRETTY_FUNCTION__);
 
         DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->Assign(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->Assign(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1329,7 +1238,6 @@ void FASTCALL SASIDEV::CmdSpecify()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::CmdInvalid()
 {
-	ASSERT(this);
 	LOGWARN("%s Command not supported", __PRETTY_FUNCTION__);
 
 	// Failure (Error)
@@ -1354,7 +1262,6 @@ void FASTCALL SASIDEV::Send()
 	#endif	// RASCSI
 	BOOL result;
 
-	ASSERT(this);
 	ASSERT(!ctrl.bus->GetREQ());
 	ASSERT(ctrl.bus->GetIO());
 
@@ -1452,8 +1359,6 @@ void FASTCALL SASIDEV::Send()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::SendNext()
 {
-	ASSERT(this);
-
 	// Req is up
 	ASSERT(ctrl.bus->GetREQ());
 	ASSERT(ctrl.bus->GetIO());
@@ -1476,16 +1381,12 @@ void FASTCALL SASIDEV::SendNext()
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::Receive()
 {
-	DWORD data;
-
-	ASSERT(this);
-
 	// Req is up
 	ASSERT(ctrl.bus->GetREQ());
 	ASSERT(!ctrl.bus->GetIO());
 
 	// Get data
-	data = (DWORD)ctrl.bus->GetDAT();
+	DWORD data = (DWORD)ctrl.bus->GetDAT();
 
 	// Signal line operated by the target
 	ctrl.bus->SetREQ(FALSE);
@@ -1538,8 +1439,6 @@ void FASTCALL SASIDEV::ReceiveNext()
 	int len;
 	#endif	// RASCSI
 	BOOL result;
-
-	ASSERT(this);
 
 	// REQ is low
 	ASSERT(!ctrl.bus->GetREQ());
@@ -1649,14 +1548,11 @@ void FASTCALL SASIDEV::ReceiveNext()
 //---------------------------------------------------------------------------
 BOOL FASTCALL SASIDEV::XferIn(BYTE *buf)
 {
-	DWORD lun;
-
-	ASSERT(this);
 	ASSERT(ctrl.phase == BUS::datain);
 	LOGTRACE("%s ctrl.cmd[0]=%02X", __PRETTY_FUNCTION__, (unsigned int)ctrl.cmd[0]);
 
 	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
+	DWORD lun = (ctrl.cmd[1] >> 5) & 0x07;
 	if (!ctrl.unit[lun]) {
 		return FALSE;
 	}
@@ -1699,14 +1595,12 @@ BOOL FASTCALL SASIDEV::XferIn(BYTE *buf)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SASIDEV::XferOut(BOOL cont)
 {
-	DWORD lun;
 	SCSIBR *bridge;
 
-	ASSERT(this);
 	ASSERT(ctrl.phase == BUS::dataout);
 
 	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
+	DWORD lun = (ctrl.cmd[1] >> 5) & 0x07;
 	if (!ctrl.unit[lun]) {
 		return FALSE;
 	}
@@ -1800,13 +1694,10 @@ BOOL FASTCALL SASIDEV::XferOut(BOOL cont)
 //---------------------------------------------------------------------------
 void FASTCALL SASIDEV::FlushUnit()
 {
-	DWORD lun;
-
-	ASSERT(this);
 	ASSERT(ctrl.phase == BUS::dataout);
 
 	// Logical Unit
-	lun = (ctrl.cmd[1] >> 5) & 0x07;
+	DWORD lun = (ctrl.cmd[1] >> 5) & 0x07;
 	if (!ctrl.unit[lun]) {
 		return;
 	}

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -106,8 +106,6 @@ void FASTCALL SCSIDEV::SetupCommand(BYTE opcode, const char* name, void FASTCALL
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::Reset()
 {
-	ASSERT(this);
-
 	// Work initialization
 	scsi.atnmsg = FALSE;
 	scsi.msc = 0;
@@ -124,8 +122,6 @@ void FASTCALL SCSIDEV::Reset()
 //---------------------------------------------------------------------------
 BUS::phase_t FASTCALL SCSIDEV::Process()
 {
-	ASSERT(this);
-
 	// Do nothing if not connected
 	if (ctrl.m_scsi_id < 0 || ctrl.bus == NULL) {
 		return ctrl.phase;
@@ -210,8 +206,6 @@ BUS::phase_t FASTCALL SCSIDEV::Process()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::BusFree()
 {
-	ASSERT(this);
-
 	// Phase change
 	if (ctrl.phase != BUS::busfree) {
 
@@ -249,14 +243,10 @@ void FASTCALL SCSIDEV::BusFree()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::Selection()
 {
-	DWORD id;
-
-	ASSERT(this);
-
 	// Phase change
 	if (ctrl.phase != BUS::selection) {
 		// invalid if IDs do not match
-		id = 1 << ctrl.m_scsi_id;
+		DWORD id = 1 << ctrl.m_scsi_id;
 		if ((ctrl.bus->GetDAT() & id) == 0) {
 			return;
 		}
@@ -294,8 +284,6 @@ void FASTCALL SCSIDEV::Selection()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::Execute()
 {
-	ASSERT(this);
-
 	LOGTRACE( "%s Execution phase command $%02X", __PRETTY_FUNCTION__, (unsigned int)ctrl.cmd[0]);
 
 	// Phase Setting
@@ -330,7 +318,6 @@ void FASTCALL SCSIDEV::Execute()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::MsgOut()
 {
-	ASSERT(this);
 	LOGTRACE("%s ID: %d",__PRETTY_FUNCTION__, this->GetSCSIID());
 
 	// Phase change
@@ -376,8 +363,6 @@ void FASTCALL SCSIDEV::MsgOut()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::Error()
 {
-	ASSERT(this);
-
 	// Get bus information
 	((GPIOBUS*)ctrl.bus)->Aquire();
 
@@ -420,17 +405,11 @@ void FASTCALL SCSIDEV::Error()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdInquiry()
 {
-	Disk *disk;
-	int lun;
-	DWORD major;
-	DWORD minor;
-
-	ASSERT(this);
-
 	LOGTRACE("%s INQUIRY Command", __PRETTY_FUNCTION__);
 
 	// Find a valid unit
-	disk = NULL;
+	Disk *disk = NULL;
+	int lun;
 	for (lun = 0; lun < UnitMax; lun++) {
 		if (ctrl.unit[lun]) {
 			disk = ctrl.unit[lun];
@@ -440,8 +419,8 @@ void FASTCALL SCSIDEV::CmdInquiry()
 
 	// Processed on the disk side (it is originally processed by the controller)
 	if (disk) {
-		major = (DWORD)(RASCSI >> 8);
-		minor = (DWORD)(RASCSI & 0xff);
+		DWORD major = (DWORD)(RASCSI >> 8);
+		DWORD minor = (DWORD)(RASCSI & 0xff);
 		LOGTRACE("%s Buffer size is %d",__PRETTY_FUNCTION__, ctrl.bufsize);
 		ctrl.length =
 			ctrl.unit[lun]->Inquiry(ctrl.cmd, ctrl.buffer, major, minor);
@@ -471,8 +450,6 @@ void FASTCALL SCSIDEV::CmdInquiry()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdModeSelect()
 {
-	ASSERT(this);
-
 	LOGTRACE( "%s MODE SELECT Command", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
@@ -501,8 +478,6 @@ void FASTCALL SCSIDEV::CmdModeSelect()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdReserve6()
 {
-	ASSERT(this);
-	
 	LOGTRACE( "%s Reserve(6) Command", __PRETTY_FUNCTION__);
 
 	// status phase
@@ -521,7 +496,6 @@ void FASTCALL SCSIDEV::CmdReserve6()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdReserve10()
 {
-	ASSERT(this);
 	LOGTRACE( "%s Reserve(10) Command", __PRETTY_FUNCTION__);
 
 	// status phase
@@ -540,7 +514,6 @@ void FASTCALL SCSIDEV::CmdReserve10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdRelease6()
 {
-	ASSERT(this);
 	LOGTRACE( "%s Release(6) Command", __PRETTY_FUNCTION__);
 
 	// status phase
@@ -559,7 +532,6 @@ void FASTCALL SCSIDEV::CmdRelease6()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdRelease10()
 {
-	ASSERT(this);
 	LOGTRACE( "%s Release(10) Command", __PRETTY_FUNCTION__);
 
 	// status phase
@@ -573,8 +545,6 @@ void FASTCALL SCSIDEV::CmdRelease10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdModeSense()
 {
-	ASSERT(this);
-
 	LOGTRACE( "%s MODE SENSE Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
@@ -601,16 +571,12 @@ void FASTCALL SCSIDEV::CmdModeSense()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdStartStop()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE( "%s START STOP UNIT Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->StartStop(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->StartStop(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -628,16 +594,12 @@ void FASTCALL SCSIDEV::CmdStartStop()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSendDiag()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE( "%s SEND DIAGNOSTIC Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->SendDiag(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->SendDiag(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -655,16 +617,12 @@ void FASTCALL SCSIDEV::CmdSendDiag()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdRemoval()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE( "%s PREVENT/ALLOW MEDIUM REMOVAL Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->Removal(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->Removal(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -682,16 +640,12 @@ void FASTCALL SCSIDEV::CmdRemoval()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdReadCapacity()
 {
-	int length;
-
-	ASSERT(this);
-
 	LOGTRACE( "%s READ CAPACITY Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
 
 	// Command processing on drive
-	length = ctrl.unit[lun]->ReadCapacity(ctrl.cmd, ctrl.buffer);
+	int length = ctrl.unit[lun]->ReadCapacity(ctrl.cmd, ctrl.buffer);
 	ASSERT(length >= 0);
 	if (length <= 0) {
 		Error();
@@ -712,10 +666,6 @@ void FASTCALL SCSIDEV::CmdReadCapacity()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdRead10()
 {
-	DWORD record;
-
-	ASSERT(this);
-
 	DWORD lun = GetLun();
 
 	// Receive message if host bridge
@@ -725,7 +675,7 @@ void FASTCALL SCSIDEV::CmdRead10()
 	}
 
 	// Get record number and block number
-	record = ctrl.cmd[2];
+	DWORD record = ctrl.cmd[2];
 	record <<= 8;
 	record |= ctrl.cmd[3];
 	record <<= 8;
@@ -766,10 +716,6 @@ void FASTCALL SCSIDEV::CmdRead10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdWrite10()
 {
-	DWORD record;
-
-	ASSERT(this);
-
 	DWORD lun = GetLun();
 
 	// Receive message with host bridge
@@ -779,7 +725,7 @@ void FASTCALL SCSIDEV::CmdWrite10()
 	}
 
 	// Get record number and block number
-	record = ctrl.cmd[2];
+	DWORD record = ctrl.cmd[2];
 	record <<= 8;
 	record |= ctrl.cmd[3];
 	record <<= 8;
@@ -820,16 +766,12 @@ void FASTCALL SCSIDEV::CmdWrite10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSeek10()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	LOGTRACE( "%s SEEK(10) Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->Seek(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->Seek(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -848,14 +790,11 @@ void FASTCALL SCSIDEV::CmdSeek10()
 void FASTCALL SCSIDEV::CmdVerify()
 {
 	BOOL status;
-	DWORD record;
-
-	ASSERT(this);
 
 	DWORD lun = GetLun();
 
 	// Get record number and block number
-	record = ctrl.cmd[2];
+	DWORD record = ctrl.cmd[2];
 	record <<= 8;
 	record |= ctrl.cmd[3];
 	record <<= 8;
@@ -911,8 +850,6 @@ void FASTCALL SCSIDEV::CmdVerify()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSynchronizeCache()
 {
-	ASSERT(this);
-
 	GetLun();
 
 	// Make it do something (not implemented)...
@@ -928,8 +865,6 @@ void FASTCALL SCSIDEV::CmdSynchronizeCache()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdReadDefectData10()
 {
-	ASSERT(this);
-
 	LOGTRACE( "%s READ DEFECT DATA(10) Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
@@ -954,8 +889,6 @@ void FASTCALL SCSIDEV::CmdReadDefectData10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdReadToc()
 {
-	ASSERT(this);
-
 	DWORD lun = GetLun();
 
 	// Command processing on drive
@@ -977,14 +910,10 @@ void FASTCALL SCSIDEV::CmdReadToc()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdPlayAudio10()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->PlayAudio(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->PlayAudio(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1002,14 +931,10 @@ void FASTCALL SCSIDEV::CmdPlayAudio10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdPlayAudioMSF()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->PlayAudioMSF(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->PlayAudioMSF(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1027,14 +952,10 @@ void FASTCALL SCSIDEV::CmdPlayAudioMSF()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdPlayAudioTrack()
 {
-	BOOL status;
-
-	ASSERT(this);
-
 	DWORD lun = GetLun();
 
 	// Command processing on drive
-	status = ctrl.unit[lun]->PlayAudioTrack(ctrl.cmd);
+	BOOL status = ctrl.unit[lun]->PlayAudioTrack(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1052,8 +973,6 @@ void FASTCALL SCSIDEV::CmdPlayAudioTrack()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdModeSelect10()
 {
-	ASSERT(this);
-
 	LOGTRACE( "%s MODE SELECT10 Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
@@ -1077,8 +996,6 @@ void FASTCALL SCSIDEV::CmdModeSelect10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdModeSense10()
 {
-	ASSERT(this);
-
 	LOGTRACE( "%s MODE SENSE(10) Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
@@ -1106,8 +1023,6 @@ void FASTCALL SCSIDEV::CmdModeSense10()
 void FASTCALL SCSIDEV::CmdGetMessage10()
 {
 	SCSIBR *bridge;
-
-	ASSERT(this);
 
 	DWORD lun = GetLun();
 
@@ -1153,8 +1068,6 @@ void FASTCALL SCSIDEV::CmdGetMessage10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSendMessage10()
 {
-	ASSERT(this);
-
 	DWORD lun = GetLun();
 
 	// Error if not a host bridge
@@ -1199,10 +1112,6 @@ void FASTCALL SCSIDEV::CmdSendMessage10()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdRetrieveStats()
 {
-	SCSIDaynaPort *dayna_port;
-
-	ASSERT(this);
-
 	DWORD lun = GetLun();
 
 	// Error if not a DaynaPort SCSI Link
@@ -1213,7 +1122,7 @@ void FASTCALL SCSIDEV::CmdRetrieveStats()
 	}
 
 	// Process with drive
-	dayna_port = (SCSIDaynaPort*)ctrl.unit[lun];
+	SCSIDaynaPort *dayna_port = (SCSIDaynaPort*)ctrl.unit[lun];
 	ctrl.length = dayna_port->RetrieveStats(ctrl.cmd, ctrl.buffer);
 
 	if (ctrl.length <= 0) {
@@ -1237,10 +1146,6 @@ void FASTCALL SCSIDEV::CmdRetrieveStats()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSetIfaceMode()
 {
-	SCSIDaynaPort *dayna_port;
-
-	ASSERT(this);
-
 	LOGTRACE("%s",__PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
@@ -1252,7 +1157,7 @@ void FASTCALL SCSIDEV::CmdSetIfaceMode()
 		return;
 	}
 
-	dayna_port = (SCSIDaynaPort*)ctrl.unit[lun];
+	SCSIDaynaPort *dayna_port = (SCSIDaynaPort*)ctrl.unit[lun];
 
 	// Check whether this command is telling us to "Set Interface Mode" 
 	// or "Set MAC Address"
@@ -1281,8 +1186,6 @@ void FASTCALL SCSIDEV::CmdSetIfaceMode()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdSetMcastAddr()
 {
-	ASSERT(this);
-
 	LOGTRACE("%s Set Multicast Address Command ", __PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
@@ -1315,11 +1218,6 @@ void FASTCALL SCSIDEV::CmdSetMcastAddr()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::CmdEnableInterface()
 {
-	BOOL status;
-	SCSIDaynaPort *dayna_port;
-
-	ASSERT(this);
-
 	LOGTRACE("%s",__PRETTY_FUNCTION__);
 
 	DWORD lun = GetLun();
@@ -1331,10 +1229,10 @@ void FASTCALL SCSIDEV::CmdEnableInterface()
 		return;
 	}
 
-	dayna_port = (SCSIDaynaPort*)ctrl.unit[lun];
+	SCSIDaynaPort *dayna_port = (SCSIDaynaPort*)ctrl.unit[lun];
 
 	// Command processing on drive
-	status = dayna_port->EnableInterface(ctrl.cmd);
+	BOOL status = dayna_port->EnableInterface(ctrl.cmd);
 	if (!status) {
 		// Failure (Error)
 		Error();
@@ -1364,7 +1262,6 @@ void FASTCALL SCSIDEV::Send()
 	#endif	// RASCSI
 	BOOL result;
 
-	ASSERT(this);
 	ASSERT(!ctrl.bus->GetREQ());
 	ASSERT(ctrl.bus->GetIO());
 
@@ -1494,8 +1391,6 @@ void FASTCALL SCSIDEV::Send()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIDEV::SendNext()
 {
-	ASSERT(this);
-
 	// REQ is up
 	ASSERT(ctrl.bus->GetREQ());
 	ASSERT(ctrl.bus->GetIO());
@@ -1518,11 +1413,8 @@ void FASTCALL SCSIDEV::SendNext()
 void FASTCALL SCSIDEV::Receive()
 {
 	int len;
-	BOOL result;
 	int i;
 	BYTE data;
-
-	ASSERT(this);
 
 	LOGTRACE("%s",__PRETTY_FUNCTION__);
 
@@ -1552,7 +1444,7 @@ void FASTCALL SCSIDEV::Receive()
 
 	// Block subtraction, result initialization
 	ctrl.blocks--;
-	result = TRUE;
+	BOOL result = TRUE;
 
 	// Processing after receiving data (by phase)
 	LOGTRACE("%s ctrl.phase: %d (%s)",__PRETTY_FUNCTION__, (int)ctrl.phase, BUS::GetPhaseStrRaw(ctrl.phase));
@@ -1734,7 +1626,6 @@ void FASTCALL SCSIDEV::Receive()
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSIDEV::XferMsg(DWORD msg)
 {
-	ASSERT(this);
 	ASSERT(ctrl.phase == BUS::msgout);
 
 	// Save message out data

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -408,6 +408,8 @@ void FASTCALL SCSIDEV::CmdInquiry()
 	LOGTRACE("%s INQUIRY Command", __PRETTY_FUNCTION__);
 
 	// Find a valid unit
+	// TODO The code below is most likely wrong. It results in the same INQUIRY data being
+	// used for all LUNs, even though each LUN has its individual set of INQUIRY data.
 	Disk *disk = NULL;
 	int lun;
 	for (lun = 0; lun < UnitMax; lun++) {

--- a/src/raspberrypi/devices/cfilesystem.cpp
+++ b/src/raspberrypi/devices/cfilesystem.cpp
@@ -1552,6 +1552,7 @@ const CHostFilename* CHostPath::FindFilename(const BYTE* szHuman, DWORD nHumanAt
 			continue;
 		// ファイル名チェック
 		if (Compare(pFirst, pLast, pBufFirst, pBufLast) == 0)
+			// FIXME Address of local variable is returned
 			return &p->f;
 	}
 
@@ -1638,6 +1639,7 @@ const CHostFilename* CHostPath::FindFilenameWildcard(const BYTE* szHuman, DWORD 
 				memcpy(&pFind->entry, pNext->f.GetEntry(), sizeof(pFind->entry));
 			else
 				memset(&pFind->entry, 0, sizeof(pFind->entry));
+			// FIXME Address of local variable is returned
 			return &p->f;
 		}
 	}
@@ -2700,6 +2702,7 @@ CHostFiles* CHostFilesManager::Alloc(DWORD nKey)
 	// キーを設定
 	p->f.SetKey(nKey);
 
+	// FIXME Address of local variable is returned
 	return &p->f;
 }
 
@@ -2719,6 +2722,7 @@ CHostFiles* CHostFilesManager::Search(DWORD nKey)
 		if (p->f.isSameKey(nKey)) {
 			// リング先頭へ移動
 			p->r.Insert(&m_cRing);
+			// FIXME Address of local variable is returned
 			return &p->f;
 		}
 	}
@@ -3270,6 +3274,7 @@ CHostFcb* CHostFcbManager::Alloc(DWORD nKey)
 	// キーを設定
 	p->f.SetKey(nKey);
 
+	// FIXME Address of local variable is returned
 	return &p->f;
 }
 
@@ -3289,6 +3294,7 @@ CHostFcb* CHostFcbManager::Search(DWORD nKey)
 		if (p->f.isSameKey(nKey)) {
 			// リング先頭へ移動
 			p->r.Insert(&m_cRing);
+			// FIXME Address of local variable is returned
 			return &p->f;
 		}
 		p = (ring_t*)p->r.Next();

--- a/src/raspberrypi/devices/cfilesystem.cpp
+++ b/src/raspberrypi/devices/cfilesystem.cpp
@@ -896,6 +896,9 @@ BOOL CHostDrv::Find(CHostFiles* pFiles)
 //---------------------------------------------------------------------------
 CHostFilename::CHostFilename()
 {
+	m_bCorrect = FALSE;
+	m_pszHumanExt = FALSE;
+	m_pszHumanLast = FALSE;
 }
 
 //---------------------------------------------------------------------------
@@ -1294,6 +1297,8 @@ DWORD CHostPath::g_nId;				///< 識別ID生成用カウンタ
 CHostPath::CHostPath()
 {
 	m_bRefresh = TRUE;
+	m_nId = 0;
+	m_tBackup = FALSE;
 
 #ifdef _DEBUG
 	// 必ず値が更新されるので初期化不要 (デバッグ時の初期動作確認用)
@@ -3326,6 +3331,8 @@ DWORD CFileSys::g_nOption;		///< ファイル名変換フラグ
 //---------------------------------------------------------------------------
 CFileSys::CFileSys()
 {
+	m_nHostSectorCount = 0;
+
 	// コンフィグデータ初期化
 	m_nDrives = 0;
 

--- a/src/raspberrypi/devices/cfilesystem.cpp
+++ b/src/raspberrypi/devices/cfilesystem.cpp
@@ -1552,7 +1552,6 @@ const CHostFilename* CHostPath::FindFilename(const BYTE* szHuman, DWORD nHumanAt
 			continue;
 		// ファイル名チェック
 		if (Compare(pFirst, pLast, pBufFirst, pBufLast) == 0)
-			// FIXME Address of local variable is returned
 			return &p->f;
 	}
 
@@ -1639,7 +1638,6 @@ const CHostFilename* CHostPath::FindFilenameWildcard(const BYTE* szHuman, DWORD 
 				memcpy(&pFind->entry, pNext->f.GetEntry(), sizeof(pFind->entry));
 			else
 				memset(&pFind->entry, 0, sizeof(pFind->entry));
-			// FIXME Address of local variable is returned
 			return &p->f;
 		}
 	}
@@ -2702,7 +2700,6 @@ CHostFiles* CHostFilesManager::Alloc(DWORD nKey)
 	// キーを設定
 	p->f.SetKey(nKey);
 
-	// FIXME Address of local variable is returned
 	return &p->f;
 }
 
@@ -2722,7 +2719,6 @@ CHostFiles* CHostFilesManager::Search(DWORD nKey)
 		if (p->f.isSameKey(nKey)) {
 			// リング先頭へ移動
 			p->r.Insert(&m_cRing);
-			// FIXME Address of local variable is returned
 			return &p->f;
 		}
 	}
@@ -3274,7 +3270,6 @@ CHostFcb* CHostFcbManager::Alloc(DWORD nKey)
 	// キーを設定
 	p->f.SetKey(nKey);
 
-	// FIXME Address of local variable is returned
 	return &p->f;
 }
 
@@ -3294,7 +3289,6 @@ CHostFcb* CHostFcbManager::Search(DWORD nKey)
 		if (p->f.isSameKey(nKey)) {
 			// リング先頭へ移動
 			p->r.Insert(&m_cRing);
-			// FIXME Address of local variable is returned
 			return &p->f;
 		}
 		p = (ring_t*)p->r.Next();

--- a/src/raspberrypi/devices/ctapdriver.cpp
+++ b/src/raspberrypi/devices/ctapdriver.cpp
@@ -93,8 +93,6 @@ BOOL FASTCALL CTapDriver::Init()
 	struct ifreq ifr;
 	int ret;
 
-	ASSERT(this);
-
 	LOGTRACE("Opening Tap device");
 	// TAP device initilization
 	if ((m_hTAP = open("/dev/net/tun", O_RDWR)) < 0) {
@@ -209,8 +207,6 @@ BOOL FASTCALL CTapDriver::Init()
 	struct ifreq ifr;
 	struct ifaddrs *ifa, *a;
 	
-	ASSERT(this);
-
 	// TAP Device Initialization
 	if ((m_hTAP = open("/dev/tap", O_RDWR)) < 0) {
 		LOGERROR("Error: can't open tap. Errno: %d %s", errno, strerror(errno));
@@ -274,8 +270,6 @@ BOOL FASTCALL CTapDriver::OpenDump(const Filepath& path) {
 //---------------------------------------------------------------------------
 void FASTCALL CTapDriver::Cleanup()
 {
-	ASSERT(this);
-
 	int br_socket_fd = -1;
 	if ((br_socket_fd = socket(AF_LOCAL, SOCK_STREAM, 0)) < 0) {
 		LOGERROR("Error: can't open bridge socket. Errno: %d %s", errno, strerror(errno));
@@ -349,7 +343,6 @@ BOOL FASTCALL CTapDriver::Flush(){
 //---------------------------------------------------------------------------
 void FASTCALL CTapDriver::GetMacAddr(BYTE *mac)
 {
-	ASSERT(this);
 	ASSERT(mac);
 
 	memcpy(mac, m_MacAddr, sizeof(m_MacAddr));
@@ -364,7 +357,6 @@ BOOL FASTCALL CTapDriver::PendingPackets()
 {
 	struct pollfd fds;
 
-	ASSERT(this);
 	ASSERT(m_hTAP != -1);
 
 	// Check if there is data that can be received
@@ -387,10 +379,6 @@ BOOL FASTCALL CTapDriver::PendingPackets()
 //---------------------------------------------------------------------------
 int FASTCALL CTapDriver::Rx(BYTE *buf)
 {
-	DWORD dwReceived;
-	DWORD crc;
-
-	ASSERT(this);
 	ASSERT(m_hTAP != -1);
 
 	// Check if there is data that can be received
@@ -399,7 +387,7 @@ int FASTCALL CTapDriver::Rx(BYTE *buf)
 	}
 
 	// Receive
-	dwReceived = read(m_hTAP, buf, ETH_FRAME_LEN);
+	DWORD dwReceived = read(m_hTAP, buf, ETH_FRAME_LEN);
 	if (dwReceived == (DWORD)-1) {
 		LOGWARN("%s Error occured while receiving an packet", __PRETTY_FUNCTION__);
 		return 0;
@@ -412,7 +400,7 @@ int FASTCALL CTapDriver::Rx(BYTE *buf)
 		// need it.
 
 		// Initialize the CRC
-		crc = crc32(0L, Z_NULL, 0);
+		DWORD crc = crc32(0L, Z_NULL, 0);
 		// Calculate the CRC
 		crc = crc32(crc, buf, dwReceived);
 
@@ -448,7 +436,6 @@ int FASTCALL CTapDriver::Rx(BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL CTapDriver::Tx(const BYTE *buf, int len)
 {
-	ASSERT(this);
 	ASSERT(m_hTAP != -1);
 
 	if (m_pcap_dumper != NULL) {

--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -126,11 +126,7 @@ void FASTCALL DiskTrack::Init(
 BOOL FASTCALL DiskTrack::Load(const Filepath& path)
 {
 	Fileio fio;
-	off64_t offset;
 	int i;
-	int length;
-
-	ASSERT(this);
 
 	// Not needed if already loaded
 	if (dt.init) {
@@ -141,7 +137,7 @@ BOOL FASTCALL DiskTrack::Load(const Filepath& path)
 
 	// Calculate offset (previous tracks are considered to
     // hold 256 sectors)
-	offset = ((off64_t)dt.track << 8);
+	off64_t offset = ((off64_t)dt.track << 8);
 	if (dt.raw) {
 		ASSERT(dt.size == 11);
 		offset *= 0x930;
@@ -154,7 +150,7 @@ BOOL FASTCALL DiskTrack::Load(const Filepath& path)
 	offset += dt.imgoffset;
 
 	// Calculate length (data size of this track)
-	length = dt.sectors << dt.size;
+	int length = dt.sectors << dt.size;
 
 	// Allocate buffer memory
 	ASSERT((dt.size >= 8) && (dt.size <= 11));
@@ -260,14 +256,9 @@ BOOL FASTCALL DiskTrack::Load(const Filepath& path)
 //---------------------------------------------------------------------------
 BOOL FASTCALL DiskTrack::Save(const Filepath& path)
 {
-	off64_t offset;
 	int i;
 	int j;
-	Fileio fio;
-	int length;
 	int total;
-
-	ASSERT(this);
 
 	// Not needed if not initialized
 	if (!dt.init) {
@@ -289,16 +280,17 @@ BOOL FASTCALL DiskTrack::Save(const Filepath& path)
 	ASSERT(!dt.raw);
 
 	// Calculate offset (previous tracks are considered to hold 256
-	offset = ((off64_t)dt.track << 8);
+	off64_t offset = ((off64_t)dt.track << 8);
 	offset <<= dt.size;
 
 	// Add offset to real image
 	offset += dt.imgoffset;
 
 	// Calculate length per sector
-	length = 1 << dt.size;
+	int length = 1 << dt.size;
 
 	// Open file
+	Fileio fio;
 	if (!fio.Open(path, Fileio::ReadWrite)) {
 		return FALSE;
 	}
@@ -357,7 +349,6 @@ BOOL FASTCALL DiskTrack::Save(const Filepath& path)
 //---------------------------------------------------------------------------
 BOOL FASTCALL DiskTrack::Read(BYTE *buf, int sec) const
 {
-	ASSERT(this);
 	ASSERT(buf);
 	ASSERT((sec >= 0) & (sec < 0x100));
 
@@ -389,10 +380,6 @@ BOOL FASTCALL DiskTrack::Read(BYTE *buf, int sec) const
 //---------------------------------------------------------------------------
 BOOL FASTCALL DiskTrack::Write(const BYTE *buf, int sec)
 {
-	int offset;
-	int length;
-
-	ASSERT(this);
 	ASSERT(buf);
 	ASSERT((sec >= 0) & (sec < 0x100));
 	ASSERT(!dt.raw);
@@ -408,8 +395,8 @@ BOOL FASTCALL DiskTrack::Write(const BYTE *buf, int sec)
 	}
 
 	// Calculate offset and length
-	offset = sec << dt.size;
-	length = 1 << dt.size;
+	int offset = sec << dt.size;
+	int length = 1 << dt.size;
 
 	// Compare
 	ASSERT(dt.buffer);
@@ -482,7 +469,6 @@ DiskCache::~DiskCache()
 //---------------------------------------------------------------------------
 void FASTCALL DiskCache::SetRawMode(BOOL raw)
 {
-	ASSERT(this);
 	ASSERT(sec_size == 11);
 
 	// Configuration
@@ -496,12 +482,8 @@ void FASTCALL DiskCache::SetRawMode(BOOL raw)
 //---------------------------------------------------------------------------
 BOOL FASTCALL DiskCache::Save()
 {
-	int i;
-
-	ASSERT(this);
-
 	// Save track
-	for (i = 0; i < CacheMax; i++) {
+	for (int i = 0; i < CacheMax; i++) {
 		// Is it a valid track?
 		if (cache[i].disktrk) {
 			// Save
@@ -521,7 +503,6 @@ BOOL FASTCALL DiskCache::Save()
 //---------------------------------------------------------------------------
 BOOL FASTCALL DiskCache::GetCache(int index, int& track, DWORD& aserial) const
 {
-	ASSERT(this);
 	ASSERT((index >= 0) && (index < CacheMax));
 
 	// FALSE if unused
@@ -543,12 +524,8 @@ BOOL FASTCALL DiskCache::GetCache(int index, int& track, DWORD& aserial) const
 //---------------------------------------------------------------------------
 void FASTCALL DiskCache::Clear()
 {
-	int i;
-
-	ASSERT(this);
-
 	// Free the cache
-	for (i = 0; i < CacheMax; i++) {
+	for (int i = 0; i < CacheMax; i++) {
 		if (cache[i].disktrk) {
 			delete cache[i].disktrk;
 			cache[i].disktrk = NULL;
@@ -563,20 +540,16 @@ void FASTCALL DiskCache::Clear()
 //---------------------------------------------------------------------------
 BOOL FASTCALL DiskCache::Read(BYTE *buf, int block)
 {
-	int track;
-	DiskTrack *disktrk;
-
-	ASSERT(this);
 	ASSERT(sec_size != 0);
 
 	// Update first
 	Update();
 
 	// Calculate track (fixed to 256 sectors/track)
-	track = block >> 8;
+	int track = block >> 8;
 
 	// Get the track data
-	disktrk = Assign(track);
+	DiskTrack *disktrk = Assign(track);
 	if (!disktrk) {
 		return FALSE;
 	}
@@ -592,20 +565,16 @@ BOOL FASTCALL DiskCache::Read(BYTE *buf, int block)
 //---------------------------------------------------------------------------
 BOOL FASTCALL DiskCache::Write(const BYTE *buf, int block)
 {
-	int track;
-	DiskTrack *disktrk;
-
-	ASSERT(this);
 	ASSERT(sec_size != 0);
 
 	// Update first
 	Update();
 
 	// Calculate track (fixed to 256 sectors/track)
-	track = block >> 8;
+	int track = block >> 8;
 
 	// Get that track data
-	disktrk = Assign(track);
+	DiskTrack *disktrk = Assign(track);
 	if (!disktrk) {
 		return FALSE;
 	}
@@ -621,17 +590,11 @@ BOOL FASTCALL DiskCache::Write(const BYTE *buf, int block)
 //---------------------------------------------------------------------------
 DiskTrack* FASTCALL DiskCache::Assign(int track)
 {
-	int i;
-	int c;
-	DWORD s;
-	DiskTrack *disktrk;
-
-	ASSERT(this);
 	ASSERT(sec_size != 0);
 	ASSERT(track >= 0);
 
 	// First, check if it is already assigned
-	for (i = 0; i < CacheMax; i++) {
+	for (int i = 0; i < CacheMax; i++) {
 		if (cache[i].disktrk) {
 			if (cache[i].disktrk->GetTrack() == track) {
 				// Track match
@@ -642,7 +605,7 @@ DiskTrack* FASTCALL DiskCache::Assign(int track)
 	}
 
 	// Next, check for empty
-	for (i = 0; i < CacheMax; i++) {
+	for (int i = 0; i < CacheMax; i++) {
 		if (!cache[i].disktrk) {
 			// Try loading
 			if (Load(i, track)) {
@@ -659,11 +622,11 @@ DiskTrack* FASTCALL DiskCache::Assign(int track)
 	// Finally, find the youngest serial number and delete it
 
 	// Set index 0 as candidate c
-	s = cache[0].serial;
-	c = 0;
+	DWORD s = cache[0].serial;
+	int c = 0;
 
 	// Compare candidate with serial and update to smaller one
-	for (i = 0; i < CacheMax; i++) {
+	for (int i = 0; i < CacheMax; i++) {
 		ASSERT(cache[i].disktrk);
 
 		// Compare and update the existing serial
@@ -679,7 +642,7 @@ DiskTrack* FASTCALL DiskCache::Assign(int track)
 	}
 
 	// Delete this track
-	disktrk = cache[c].disktrk;
+	DiskTrack *disktrk = cache[c].disktrk;
 	cache[c].disktrk = NULL;
 
 	// Load
@@ -700,15 +663,12 @@ DiskTrack* FASTCALL DiskCache::Assign(int track)
 //---------------------------------------------------------------------------
 BOOL FASTCALL DiskCache::Load(int index, int track, DiskTrack *disktrk)
 {
-	int sectors;
-
-	ASSERT(this);
 	ASSERT((index >= 0) && (index < CacheMax));
 	ASSERT(track >= 0);
 	ASSERT(!cache[index].disktrk);
 
 	// Get the number of sectors on this track
-	sectors = sec_blocks - (track << 8);
+	int sectors = sec_blocks - (track << 8);
 	ASSERT(sectors > 0);
 	if (sectors > 0x100) {
 		sectors = 0x100;
@@ -742,10 +702,6 @@ BOOL FASTCALL DiskCache::Load(int index, int track, DiskTrack *disktrk)
 //---------------------------------------------------------------------------
 void FASTCALL DiskCache::Update()
 {
-	int i;
-
-	ASSERT(this);
-
 	// Update and do nothing except 0
 	serial++;
 	if (serial != 0) {
@@ -753,7 +709,7 @@ void FASTCALL DiskCache::Update()
 	}
 
 	// Clear serial of all caches (loop in 32bit)
-	for (i = 0; i < CacheMax; i++) {
+	for (int i = 0; i < CacheMax; i++) {
 		cache[i].serial = 0;
 	}
 }
@@ -821,8 +777,6 @@ Disk::~Disk()
 //---------------------------------------------------------------------------
 void FASTCALL Disk::Reset()
 {
-	ASSERT(this);
-
 	// no lock, no attention, reset
 	disk.lock = FALSE;
 	disk.attn = FALSE;
@@ -837,14 +791,12 @@ void FASTCALL Disk::Reset()
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Save(Fileio *fio, int ver)
 {
-	DWORD sz;
 	DWORD padding;
 
-	ASSERT(this);
 	ASSERT(fio);
 
 	// Save size
-	sz = 52;
+	DWORD sz = 52;
 	if (!fio->Write(&sz, sizeof(sz))) {
 		return FALSE;
 	}
@@ -884,7 +836,6 @@ BOOL FASTCALL Disk::Load(Fileio *fio, int ver)
 	DWORD padding;
 	Filepath path;
 
-	ASSERT(this);
 	ASSERT(fio);
 
 	// Prior to version 2.03, the disk was not saved
@@ -971,8 +922,6 @@ BOOL FASTCALL Disk::Load(Fileio *fio, int ver)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::IsNULL() const
 {
-	ASSERT(this);
-
 	if (disk.id == MAKEID('N', 'U', 'L', 'L')) {
 		return TRUE;
 	}
@@ -1027,8 +976,6 @@ void FASTCALL Disk::InvalidCmd()
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::IsSASI() const
 {
-	ASSERT(this);
-
 	if (disk.id == MAKEID('S', 'A', 'H', 'D')) {
 		return TRUE;
 	}
@@ -1042,7 +989,6 @@ BOOL FASTCALL Disk::IsSASI() const
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::IsSCSI() const
 {
-	ASSERT(this);
 	// If this isn't SASI, then it must be SCSI.
 	return (this->IsSASI()) ? FALSE : TRUE;
 }
@@ -1055,9 +1001,6 @@ BOOL FASTCALL Disk::IsSCSI() const
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Open(const Filepath& path, BOOL /*attn*/)
 {
-	Fileio fio;
-
-	ASSERT(this);
 	ASSERT((disk.size >= 8) && (disk.size <= 11));
 	ASSERT(disk.blocks > 0);
 
@@ -1070,6 +1013,7 @@ BOOL FASTCALL Disk::Open(const Filepath& path, BOOL /*attn*/)
 		new DiskCache(path, disk.size, disk.blocks, disk.imgoffset);
 
 	// Can read/write open
+	Fileio fio;
 	if (fio.Open(path, Fileio::ReadWrite)) {
 		// Write permission, not read only
 		disk.writep = FALSE;
@@ -1098,8 +1042,6 @@ BOOL FASTCALL Disk::Open(const Filepath& path, BOOL /*attn*/)
 //---------------------------------------------------------------------------
 void FASTCALL Disk::Eject(BOOL force)
 {
-	ASSERT(this);
-
 	// Can only be ejected if it is removable
 	if (!disk.removable) {
 		return;
@@ -1136,8 +1078,6 @@ void FASTCALL Disk::Eject(BOOL force)
 //---------------------------------------------------------------------------
 void FASTCALL Disk::WriteP(BOOL writep)
 {
-	ASSERT(this);
-
 	// be ready
 	if (!disk.ready) {
 		return;
@@ -1160,7 +1100,6 @@ void FASTCALL Disk::WriteP(BOOL writep)
 //---------------------------------------------------------------------------
 void FASTCALL Disk::GetDisk(disk_t *buffer) const
 {
-	ASSERT(this);
 	ASSERT(buffer);
 
 	// Assign internal buffer
@@ -1184,8 +1123,6 @@ void FASTCALL Disk::GetPath(Filepath& path) const
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Flush()
 {
-	ASSERT(this);
-
 	// Do nothing if there's nothing cached
 	if (!disk.dcache) {
 		return TRUE;
@@ -1202,8 +1139,6 @@ BOOL FASTCALL Disk::Flush()
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::CheckReady()
 {
-	ASSERT(this);
-
 	// Not ready if reset
 	if (disk.reset) {
 		disk.code = DISK_DEVRESET;
@@ -1243,8 +1178,6 @@ BOOL FASTCALL Disk::CheckReady()
 int FASTCALL Disk::Inquiry(
 	const DWORD* /*cdb*/, BYTE* /*buf*/, DWORD /*major*/, DWORD /*minor*/)
 {
-	ASSERT(this);
-
 	// default is INQUIRY failure
 	disk.code = DISK_INVALIDCMD;
 	return 0;
@@ -1258,9 +1191,6 @@ int FASTCALL Disk::Inquiry(
 //---------------------------------------------------------------------------
 int FASTCALL Disk::RequestSense(const DWORD *cdb, BYTE *buf)
 {
-	int size;
-
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 
@@ -1272,7 +1202,7 @@ int FASTCALL Disk::RequestSense(const DWORD *cdb, BYTE *buf)
 	}
 
 	// Size determination (according to allocation length)
-	size = (int)cdb[4];
+	int size = (int)cdb[4];
 	LOGTRACE("%s size of data = %d", __PRETTY_FUNCTION__, size);
 	ASSERT((size >= 0) && (size < 0x100));
 
@@ -1306,9 +1236,6 @@ int FASTCALL Disk::RequestSense(const DWORD *cdb, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::SelectCheck(const DWORD *cdb)
 {
-	int length;
-
-	ASSERT(this);
 	ASSERT(cdb);
 
 	// Error if save parameters are set instead of SCSIHD
@@ -1321,7 +1248,7 @@ int FASTCALL Disk::SelectCheck(const DWORD *cdb)
 	}
 
 	// Receive the data specified by the parameter length
-	length = (int)cdb[4];
+	int length = (int)cdb[4];
 	return length;
 }
 
@@ -1334,9 +1261,6 @@ int FASTCALL Disk::SelectCheck(const DWORD *cdb)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::SelectCheck10(const DWORD *cdb)
 {
-	DWORD length;
-
-	ASSERT(this);
 	ASSERT(cdb);
 
 	// Error if save parameters are set instead of SCSIHD
@@ -1348,7 +1272,7 @@ int FASTCALL Disk::SelectCheck10(const DWORD *cdb)
 	}
 
 	// Receive the data specified by the parameter length
-	length = cdb[7];
+	DWORD length = cdb[7];
 	length <<= 8;
 	length |= cdb[8];
 	if (length > 0x800) {
@@ -1367,7 +1291,6 @@ int FASTCALL Disk::SelectCheck10(const DWORD *cdb)
 BOOL FASTCALL Disk::ModeSelect(
 	const DWORD* /*cdb*/, const BYTE *buf, int length)
 {
-	ASSERT(this);
 	ASSERT(buf);
 	ASSERT(length >= 0);
 
@@ -1385,20 +1308,16 @@ BOOL FASTCALL Disk::ModeSelect(
 //---------------------------------------------------------------------------
 int FASTCALL Disk::ModeSense(const DWORD *cdb, BYTE *buf)
 {
-	int page;
-	int length;
-	int size;
 	BOOL valid;
 	BOOL change;
 	int ret;
 
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 	ASSERT(cdb[0] == 0x1a);
 
 	// Get length, clear buffer
-	length = (int)cdb[4];
+	int length = (int)cdb[4];
 	ASSERT((length >= 0) && (length < 0x100));
 	memset(buf, 0, length);
 
@@ -1410,7 +1329,7 @@ int FASTCALL Disk::ModeSense(const DWORD *cdb, BYTE *buf)
 	}
 
 	// Get page code (0x00 is valid from the beginning)
-	page = cdb[2] & 0x3f;
+	int page = cdb[2] & 0x3f;
 	if (page == 0x00) {
 		valid = TRUE;
 	} else {
@@ -1418,7 +1337,7 @@ int FASTCALL Disk::ModeSense(const DWORD *cdb, BYTE *buf)
 	}
 
 	// Basic information
-	size = 4;
+	int size = 4;
 
 	// MEDIUM TYPE
 	if (disk.id == MAKEID('S', 'C', 'M', 'O')) {
@@ -1530,20 +1449,16 @@ int FASTCALL Disk::ModeSense(const DWORD *cdb, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::ModeSense10(const DWORD *cdb, BYTE *buf)
 {
-	int page;
-	int length;
-	int size;
 	BOOL valid;
 	BOOL change;
 	int ret;
 
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 	ASSERT(cdb[0] == 0x5a);
 
 	// Get length, clear buffer
-	length = cdb[7];
+	int length = cdb[7];
 	length <<= 8;
 	length |= cdb[8];
 	if (length > 0x800) {
@@ -1560,7 +1475,7 @@ int FASTCALL Disk::ModeSense10(const DWORD *cdb, BYTE *buf)
 	}
 
 	// Get page code (0x00 is valid from the beginning)
-	page = cdb[2] & 0x3f;
+	int page = cdb[2] & 0x3f;
 	if (page == 0x00) {
 		valid = TRUE;
 	} else {
@@ -1568,7 +1483,7 @@ int FASTCALL Disk::ModeSense10(const DWORD *cdb, BYTE *buf)
 	}
 
 	// Basic Information
-	size = 4;
+	int size = 4;
 	if (disk.writep) {
 		buf[2] = 0x80;
 	}
@@ -1672,7 +1587,6 @@ int FASTCALL Disk::ModeSense10(const DWORD *cdb, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::AddError(BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -1697,7 +1611,6 @@ int FASTCALL Disk::AddFormat(BOOL change, BYTE *buf)
 {
 	int size;
 
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -1741,9 +1654,6 @@ int FASTCALL Disk::AddFormat(BOOL change, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::AddDrive(BOOL change, BYTE *buf)
 {
-	DWORD cylinder;
-
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -1758,7 +1668,7 @@ int FASTCALL Disk::AddDrive(BOOL change, BYTE *buf)
 	if (disk.ready) {
 		// Set the number of cylinders (total number of blocks
         // divided by 25 sectors/track and 8 heads)
-		cylinder = disk.blocks;
+		DWORD cylinder = disk.blocks;
 		cylinder >>= 3;
 		cylinder /= 25;
 		buf[0x2] = (BYTE)(cylinder >> 16);
@@ -1779,7 +1689,6 @@ int FASTCALL Disk::AddDrive(BOOL change, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::AddOpt(BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -1802,7 +1711,6 @@ int FASTCALL Disk::AddOpt(BOOL change, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::AddCache(BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -1825,7 +1733,6 @@ int FASTCALL Disk::AddCache(BOOL change, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::AddCDROM(BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -1854,7 +1761,6 @@ int FASTCALL Disk::AddCDROM(BOOL change, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::AddCDDA(BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -1878,7 +1784,6 @@ int FASTCALL Disk::AddCDDA(BOOL change, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::AddVendor(int /*page*/, BOOL /*change*/, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	return 0;
@@ -1892,15 +1797,12 @@ int FASTCALL Disk::AddVendor(int /*page*/, BOOL /*change*/, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::ReadDefectData10(const DWORD *cdb, BYTE *buf)
 {
-	DWORD length;
-
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 	ASSERT(cdb[0] == 0x37);
 
 	// Get length, clear buffer
-	length = cdb[7];
+	DWORD length = cdb[7];
 	length <<= 8;
 	length |= cdb[8];
 	if (length > 0x800) {
@@ -1941,8 +1843,6 @@ int FASTCALL Disk::ReadDefectData10(const DWORD *cdb, BYTE *buf)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::TestUnitReady(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	// Status check
 	if (!CheckReady()) {
 		return FALSE;
@@ -1959,8 +1859,6 @@ BOOL FASTCALL Disk::TestUnitReady(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Rezero(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	// Status check
 	if (!CheckReady()) {
 		return FALSE;
@@ -1978,8 +1876,6 @@ BOOL FASTCALL Disk::Rezero(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Format(const DWORD *cdb)
 {
-	ASSERT(this);
-
 	// Status check
 	if (!CheckReady()) {
 		return FALSE;
@@ -2002,8 +1898,6 @@ BOOL FASTCALL Disk::Format(const DWORD *cdb)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Reassign(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	// Status check
 	if (!CheckReady()) {
 		return FALSE;
@@ -2020,7 +1914,6 @@ BOOL FASTCALL Disk::Reassign(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::Read(const DWORD *cdb, BYTE *buf, DWORD block)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Status check
@@ -2051,8 +1944,6 @@ int FASTCALL Disk::Read(const DWORD *cdb, BYTE *buf, DWORD block)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::WriteCheck(DWORD block)
 {
-	ASSERT(this);
-
 	// Status check
 	if (!CheckReady()) {
 		return 0;
@@ -2080,7 +1971,6 @@ int FASTCALL Disk::WriteCheck(DWORD block)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Write(const DWORD *cdb, const BYTE *buf, DWORD block)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	LOGTRACE("%s", __PRETTY_FUNCTION__);
@@ -2121,8 +2011,6 @@ BOOL FASTCALL Disk::Write(const DWORD *cdb, const BYTE *buf, DWORD block)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Seek(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	// Status check
 	if (!CheckReady()) {
 		return FALSE;
@@ -2139,8 +2027,6 @@ BOOL FASTCALL Disk::Seek(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Assign(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	// Status check
 	if (!CheckReady()) {
 		return FALSE;
@@ -2157,8 +2043,6 @@ BOOL FASTCALL Disk::Assign(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Specify(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	// Status check
 	if (!CheckReady()) {
 		return FALSE;
@@ -2175,7 +2059,6 @@ BOOL FASTCALL Disk::Specify(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::StartStop(const DWORD *cdb)
 {
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x1b);
 
@@ -2203,7 +2086,6 @@ BOOL FASTCALL Disk::StartStop(const DWORD *cdb)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::SendDiag(const DWORD *cdb)
 {
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x1d);
 
@@ -2231,7 +2113,6 @@ BOOL FASTCALL Disk::SendDiag(const DWORD *cdb)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Removal(const DWORD *cdb)
 {
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x1e);
 
@@ -2261,7 +2142,6 @@ int FASTCALL Disk::ReadCapacity(const DWORD* /*cdb*/, BYTE *buf)
 	DWORD blocks;
 	DWORD length;
 
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Buffer clear
@@ -2298,22 +2178,18 @@ int FASTCALL Disk::ReadCapacity(const DWORD* /*cdb*/, BYTE *buf)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::Verify(const DWORD *cdb)
 {
-	DWORD record;
-	DWORD blocks;
-
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x2f);
 
 	// Get parameters
-	record = cdb[2];
+	DWORD record = cdb[2];
 	record <<= 8;
 	record |= cdb[3];
 	record <<= 8;
 	record |= cdb[4];
 	record <<= 8;
 	record |= cdb[5];
-	blocks = cdb[7];
+	DWORD blocks = cdb[7];
 	blocks <<= 8;
 	blocks |= cdb[8];
 
@@ -2339,7 +2215,6 @@ BOOL FASTCALL Disk::Verify(const DWORD *cdb)
 //---------------------------------------------------------------------------
 int FASTCALL Disk::ReadToc(const DWORD *cdb, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x43);
 	ASSERT(buf);
@@ -2356,7 +2231,6 @@ int FASTCALL Disk::ReadToc(const DWORD *cdb, BYTE *buf)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::PlayAudio(const DWORD *cdb)
 {
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x45);
 
@@ -2372,7 +2246,6 @@ BOOL FASTCALL Disk::PlayAudio(const DWORD *cdb)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::PlayAudioMSF(const DWORD *cdb)
 {
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x47);
 
@@ -2388,7 +2261,6 @@ BOOL FASTCALL Disk::PlayAudioMSF(const DWORD *cdb)
 //---------------------------------------------------------------------------
 BOOL FASTCALL Disk::PlayAudioTrack(const DWORD *cdb)
 {
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x48);
 

--- a/src/raspberrypi/devices/sasihd.cpp
+++ b/src/raspberrypi/devices/sasihd.cpp
@@ -58,19 +58,16 @@ void FASTCALL SASIHD::Reset()
 //---------------------------------------------------------------------------
 BOOL FASTCALL SASIHD::Open(const Filepath& path, BOOL /*attn*/)
 {
-	Fileio fio;
-	off64_t size;
-
-	ASSERT(this);
 	ASSERT(!disk.ready);
 
 	// Open as read-only
+	Fileio fio;
 	if (!fio.Open(path, Fileio::ReadOnly)) {
 		return FALSE;
 	}
 
 	// Get file size
-	size = fio.GetFileSize();
+	off64_t size = fio.GetFileSize();
 	fio.Close();
 
 	#if defined(USE_MZ1F23_1024_SUPPORT)
@@ -137,14 +134,11 @@ BOOL FASTCALL SASIHD::Open(const Filepath& path, BOOL /*attn*/)
 //---------------------------------------------------------------------------
 int FASTCALL SASIHD::RequestSense(const DWORD *cdb, BYTE *buf)
 {
-	int size;
-
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 
 	// サイズ決定
-	size = (int)cdb[4];
+	int size = (int)cdb[4];
 	ASSERT((size >= 0) && (size < 0x100));
 
 	// サイズ0のときに4バイト転送する(Shugart Associates System Interface仕様)

--- a/src/raspberrypi/devices/scsi_host_bridge.cpp
+++ b/src/raspberrypi/devices/scsi_host_bridge.cpp
@@ -89,9 +89,7 @@ int FASTCALL SCSIBR::Inquiry(
 	const DWORD *cdb, BYTE *buf, DWORD major, DWORD minor)
 {
 	char rev[32];
-	int size;
 
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 	ASSERT(cdb[0] == 0x12);
@@ -147,7 +145,7 @@ int FASTCALL SCSIBR::Inquiry(
 	buf[38] = '1';
 
 	// Size of data that can be returned
-	size = (buf[4] + 5);
+	int size = (buf[4] + 5);
 
 	// Limit if the other buffer is small
 	if (size > (int)cdb[4]) {
@@ -166,8 +164,6 @@ int FASTCALL SCSIBR::Inquiry(
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSIBR::TestUnitReady(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	// TEST UNIT READY Success
 	disk.code = DISK_NOERROR;
 	return TRUE;
@@ -180,18 +176,14 @@ BOOL FASTCALL SCSIBR::TestUnitReady(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 int FASTCALL SCSIBR::GetMessage10(const DWORD *cdb, BYTE *buf)
 {
-	int type;
-	int phase;
 	#if defined(RASCSI) && !defined(BAREMETAL)
 	int func;
 	int total_len;
 	int i;
 	#endif	// RASCSI && !BAREMETAL
 
-	ASSERT(this);
-
 	// Type
-	type = cdb[2];
+	int type = cdb[2];
 
 	#if defined(RASCSI) && !defined(BAREMETAL)
 	// Function number
@@ -199,7 +191,7 @@ int FASTCALL SCSIBR::GetMessage10(const DWORD *cdb, BYTE *buf)
 	#endif	// RASCSI && !BAREMETAL
 
 	// Phase
-	phase = cdb[9];
+	int phase = cdb[9];
 
 	switch (type) {
 		#if defined(RASCSI) && !defined(BAREMETAL)
@@ -279,26 +271,20 @@ int FASTCALL SCSIBR::GetMessage10(const DWORD *cdb, BYTE *buf)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSIBR::SendMessage10(const DWORD *cdb, BYTE *buf)
 {
-	int type;
-	int func;
-	int phase;
-	int len;
-
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 
 	// Type
-	type = cdb[2];
+	int type = cdb[2];
 
 	// Function number
-	func = cdb[3];
+	int func = cdb[3];
 
 	// Phase
-	phase = cdb[9];
+	int phase = cdb[9];
 
 	// Get the number of lights
-	len = cdb[6];
+	int len = cdb[6];
 	len <<= 8;
 	len |= cdb[7];
 	len <<= 8;
@@ -350,7 +336,6 @@ BOOL FASTCALL SCSIBR::SendMessage10(const DWORD *cdb, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL SCSIBR::GetMacAddr(BYTE *mac)
 {
-	ASSERT(this);
 	ASSERT(mac);
 
 	memcpy(mac, mac_addr, 6);
@@ -364,7 +349,6 @@ int FASTCALL SCSIBR::GetMacAddr(BYTE *mac)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::SetMacAddr(BYTE *mac)
 {
-	ASSERT(this);
 	ASSERT(mac);
 
 	memcpy(mac_addr, mac, 6);
@@ -379,7 +363,6 @@ void FASTCALL SCSIBR::ReceivePacket()
 {
 	static const BYTE bcast_addr[6] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 
-	ASSERT(this);
 	ASSERT(tap);
 
 	// previous packet has not been received
@@ -417,14 +400,11 @@ void FASTCALL SCSIBR::ReceivePacket()
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::GetPacketBuf(BYTE *buf)
 {
-	int len;
-
-	ASSERT(this);
 	ASSERT(tap);
 	ASSERT(buf);
 
 	// Size limit
-	len = packet_len;
+	int len = packet_len;
 	if (len > 2048) {
 		len = 2048;
 	}
@@ -443,7 +423,6 @@ void FASTCALL SCSIBR::GetPacketBuf(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::SendPacket(BYTE *buf, int len)
 {
-	ASSERT(this);
 	ASSERT(tap);
 	ASSERT(buf);
 
@@ -458,7 +437,6 @@ void FASTCALL SCSIBR::SendPacket(BYTE *buf, int len)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_InitDevice(BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
@@ -473,21 +451,15 @@ void FASTCALL SCSIBR::FS_InitDevice(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_CheckDir(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::namests_t *pNamests;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
 	fsresult = fs->CheckDir(nUnit, pNamests);
@@ -500,21 +472,15 @@ void FASTCALL SCSIBR::FS_CheckDir(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_MakeDir(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::namests_t *pNamests;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
 	fsresult = fs->MakeDir(nUnit, pNamests);
@@ -527,21 +493,15 @@ void FASTCALL SCSIBR::FS_MakeDir(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_RemoveDir(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::namests_t *pNamests;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
 	fsresult = fs->RemoveDir(nUnit, pNamests);
@@ -554,25 +514,18 @@ void FASTCALL SCSIBR::FS_RemoveDir(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Rename(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::namests_t *pNamests;
-	Human68k::namests_t* pNamestsNew;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
-	pNamestsNew = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamestsNew = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
 	fsresult = fs->Rename(nUnit, pNamests, pNamestsNew);
@@ -585,21 +538,15 @@ void FASTCALL SCSIBR::FS_Rename(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Delete(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::namests_t *pNamests;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
 	fsresult = fs->Delete(nUnit, pNamests);
@@ -612,26 +559,19 @@ void FASTCALL SCSIBR::FS_Delete(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Attribute(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::namests_t *pNamests;
-	DWORD nHumanAttribute;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
 	dp = (DWORD*)&buf[i];
-	nHumanAttribute = ntohl(*dp);
+	DWORD nHumanAttribute = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	fsresult = fs->Attribute(nUnit, pNamests, nHumanAttribute);
@@ -644,30 +584,22 @@ void FASTCALL SCSIBR::FS_Attribute(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Files(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD nKey;
-	Human68k::namests_t *pNamests;
-	Human68k::files_t *files;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nKey = ntohl(*dp);
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
-	files = (Human68k::files_t*)&buf[i];
+	Human68k::files_t *files = (Human68k::files_t*)&buf[i];
 	i += sizeof(Human68k::files_t);
 
 	files->sector = ntohl(files->sector);
@@ -698,26 +630,19 @@ void FASTCALL SCSIBR::FS_Files(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_NFiles(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD nKey;
-	Human68k::files_t *files;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nKey = ntohl(*dp);
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	files = (Human68k::files_t*)&buf[i];
+	Human68k::files_t *files = (Human68k::files_t*)&buf[i];
 	i += sizeof(Human68k::files_t);
 
 	files->sector = ntohl(files->sector);
@@ -748,41 +673,30 @@ void FASTCALL SCSIBR::FS_NFiles(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Create(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD nKey;
-	Human68k::namests_t *pNamests;
-	Human68k::fcb_t *pFcb;
-	DWORD nAttribute;
-	BOOL bForce;
-	DWORD *dp;
-	BOOL *bp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nKey = ntohl(*dp);
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
-	pFcb = (Human68k::fcb_t*)&buf[i];
+	Human68k::fcb_t *pFcb = (Human68k::fcb_t*)&buf[i];
 	i += sizeof(Human68k::fcb_t);
 
 	dp = (DWORD*)&buf[i];
-	nAttribute = ntohl(*dp);
+	DWORD nAttribute = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	bp = (BOOL*)&buf[i];
-	bForce = ntohl(*bp);
+	BOOL *bp = (BOOL*)&buf[i];
+	DWORD bForce = ntohl(*bp);
 	i += sizeof(BOOL);
 
 	pFcb->fileptr = ntohl(pFcb->fileptr);
@@ -813,30 +727,22 @@ void FASTCALL SCSIBR::FS_Create(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Open(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD nKey;
-	Human68k::namests_t *pNamests;
-	Human68k::fcb_t *pFcb;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nKey = ntohl(*dp);
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pNamests = (Human68k::namests_t*)&buf[i];
+	Human68k::namests_t *pNamests = (Human68k::namests_t*)&buf[i];
 	i += sizeof(Human68k::namests_t);
 
-	pFcb = (Human68k::fcb_t*)&buf[i];
+	Human68k::fcb_t *pFcb = (Human68k::fcb_t*)&buf[i];
 	i += sizeof(Human68k::fcb_t);
 
 	pFcb->fileptr = ntohl(pFcb->fileptr);
@@ -867,26 +773,19 @@ void FASTCALL SCSIBR::FS_Open(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Close(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD nKey;
-	Human68k::fcb_t *pFcb;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nKey = ntohl(*dp);
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pFcb = (Human68k::fcb_t*)&buf[i];
+	Human68k::fcb_t *pFcb = (Human68k::fcb_t*)&buf[i];
 	i += sizeof(Human68k::fcb_t);
 
 	pFcb->fileptr = ntohl(pFcb->fileptr);
@@ -917,26 +816,19 @@ void FASTCALL SCSIBR::FS_Close(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Read(BYTE *buf)
 {
-	DWORD nKey;
-	Human68k::fcb_t *pFcb;
-	DWORD nSize;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nKey = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pFcb = (Human68k::fcb_t*)&buf[i];
+	Human68k::fcb_t *pFcb = (Human68k::fcb_t*)&buf[i];
 	i += sizeof(Human68k::fcb_t);
 
 	dp = (DWORD*)&buf[i];
-	nSize = ntohl(*dp);
+	DWORD nSize = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	pFcb->fileptr = ntohl(pFcb->fileptr);
@@ -969,26 +861,19 @@ void FASTCALL SCSIBR::FS_Read(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Write(BYTE *buf)
 {
-	DWORD nKey;
-	Human68k::fcb_t *pFcb;
-	DWORD nSize;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nKey = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pFcb = (Human68k::fcb_t*)&buf[i];
+	Human68k::fcb_t *pFcb = (Human68k::fcb_t*)&buf[i];
 	i += sizeof(Human68k::fcb_t);
 
 	dp = (DWORD*)&buf[i];
-	nSize = ntohl(*dp);
+	DWORD nSize = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	pFcb->fileptr = ntohl(pFcb->fileptr);
@@ -1019,32 +904,23 @@ void FASTCALL SCSIBR::FS_Write(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Seek(BYTE *buf)
 {
-	DWORD nKey;
-	Human68k::fcb_t *pFcb;
-	DWORD nMode;
-	int nOffset;
-	DWORD *dp;
-	int *ip;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nKey = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pFcb = (Human68k::fcb_t*)&buf[i];
+	Human68k::fcb_t *pFcb = (Human68k::fcb_t*)&buf[i];
 	i += sizeof(Human68k::fcb_t);
 
 	dp = (DWORD*)&buf[i];
-	nMode = ntohl(*dp);
+	DWORD nMode = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	ip = (int*)&buf[i];
-	nOffset = ntohl(*ip);
+	int *ip = (int*)&buf[i];
+	int nOffset = ntohl(*ip);
 	i += sizeof(int);
 
 	pFcb->fileptr = ntohl(pFcb->fileptr);
@@ -1075,31 +951,23 @@ void FASTCALL SCSIBR::FS_Seek(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_TimeStamp(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD nKey;
-	Human68k::fcb_t *pFcb;
-	DWORD nHumanTime;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nKey = ntohl(*dp);
+	DWORD nKey = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pFcb = (Human68k::fcb_t*)&buf[i];
+	Human68k::fcb_t *pFcb = (Human68k::fcb_t*)&buf[i];
 	i += sizeof(Human68k::fcb_t);
 
 	dp = (DWORD*)&buf[i];
-	nHumanTime = ntohl(*dp);
+	DWORD nHumanTime = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	pFcb->fileptr = ntohl(pFcb->fileptr);
@@ -1130,20 +998,15 @@ void FASTCALL SCSIBR::FS_TimeStamp(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_GetCapacity(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::capacity_t cap;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
+	Human68k::capacity_t cap;
 	fsresult = fs->GetCapacity(nUnit, &cap);
 
 	cap.freearea = htons(cap.freearea);
@@ -1162,21 +1025,15 @@ void FASTCALL SCSIBR::FS_GetCapacity(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_CtrlDrive(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::ctrldrive_t *pCtrlDrive;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pCtrlDrive = (Human68k::ctrldrive_t*)&buf[i];
+	Human68k::ctrldrive_t *pCtrlDrive = (Human68k::ctrldrive_t*)&buf[i];
 	i += sizeof(Human68k::ctrldrive_t);
 
 	fsresult = fs->CtrlDrive(nUnit, pCtrlDrive);
@@ -1192,20 +1049,15 @@ void FASTCALL SCSIBR::FS_CtrlDrive(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_GetDPB(BYTE *buf)
 {
-	DWORD nUnit;
-	Human68k::dpb_t dpb;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
+	Human68k::dpb_t dpb;
 	fsresult = fs->GetDPB(nUnit, &dpb);
 
 	dpb.sector_size = htons(dpb.sector_size);
@@ -1226,27 +1078,20 @@ void FASTCALL SCSIBR::FS_GetDPB(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_DiskRead(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD nSector;
-	DWORD nSize;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nSector = ntohl(*dp);
+	DWORD nSector = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nSize = ntohl(*dp);
+	DWORD nSize = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	fsresult = fs->DiskRead(nUnit, fsout, nSector, nSize);
@@ -1260,17 +1105,12 @@ void FASTCALL SCSIBR::FS_DiskRead(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_DiskWrite(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	fsresult = fs->DiskWrite(nUnit);
@@ -1283,26 +1123,19 @@ void FASTCALL SCSIBR::FS_DiskWrite(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Ioctrl(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD nFunction;
-	Human68k::ioctrl_t *pIoctrl;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	dp = (DWORD*)&buf[i];
-	nFunction = ntohl(*dp);
+	DWORD nFunction = ntohl(*dp);
 	i += sizeof(DWORD);
 
-	pIoctrl = (Human68k::ioctrl_t*)&buf[i];
+	Human68k::ioctrl_t *pIoctrl = (Human68k::ioctrl_t*)&buf[i];
 	i += sizeof(Human68k::ioctrl_t);
 
 	switch (nFunction) {
@@ -1337,17 +1170,12 @@ void FASTCALL SCSIBR::FS_Ioctrl(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Flush(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	fsresult = fs->Flush(nUnit);
@@ -1360,17 +1188,12 @@ void FASTCALL SCSIBR::FS_Flush(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_CheckMedia(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	fsresult = fs->CheckMedia(nUnit);
@@ -1383,17 +1206,12 @@ void FASTCALL SCSIBR::FS_CheckMedia(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::FS_Lock(BYTE *buf)
 {
-	DWORD nUnit;
-	DWORD *dp;
-	int i;
-
-	ASSERT(this);
 	ASSERT(fs);
 	ASSERT(buf);
 
-	i = 0;
-	dp = (DWORD*)buf;
-	nUnit = ntohl(*dp);
+	int i = 0;
+	DWORD *dp = (DWORD*)buf;
+	DWORD nUnit = ntohl(*dp);
 	i += sizeof(DWORD);
 
 	fsresult = fs->Lock(nUnit);
@@ -1406,12 +1224,9 @@ void FASTCALL SCSIBR::FS_Lock(BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL SCSIBR::ReadFsResult(BYTE *buf)
 {
-	DWORD *dp;
-
-	ASSERT(this);
 	ASSERT(buf);
 
-	dp = (DWORD*)buf;
+	DWORD *dp = (DWORD*)buf;
 	*dp = htonl(fsresult);
 	return sizeof(DWORD);
 }
@@ -1423,7 +1238,6 @@ int FASTCALL SCSIBR::ReadFsResult(BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL SCSIBR::ReadFsOut(BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	memcpy(buf, fsout, fsoutlen);
@@ -1437,7 +1251,6 @@ int FASTCALL SCSIBR::ReadFsOut(BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL SCSIBR::ReadFsOpt(BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	memcpy(buf, fsopt, fsoptlen);
@@ -1451,7 +1264,6 @@ int FASTCALL SCSIBR::ReadFsOpt(BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::WriteFs(int func, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	fsresult = FS_FATAL_INVALIDCOMMAND;
@@ -1496,7 +1308,5 @@ void FASTCALL SCSIBR::WriteFs(int func, BYTE *buf)
 //---------------------------------------------------------------------------
 void FASTCALL SCSIBR::WriteFsOpt(BYTE *buf, int num)
 {
-	ASSERT(this);
-
 	memcpy(fsopt, buf, num);
 }

--- a/src/raspberrypi/devices/scsi_host_bridge.cpp
+++ b/src/raspberrypi/devices/scsi_host_bridge.cpp
@@ -34,6 +34,11 @@
 //---------------------------------------------------------------------------
 SCSIBR::SCSIBR() : Disk()
 {
+	fsoptlen = 0;
+	fsoutlen = 0;
+	fsresult = 0;
+	packet_len = 0;
+
 	// Host Bridge
 	disk.id = MAKEID('S', 'C', 'B', 'R');
 

--- a/src/raspberrypi/devices/scsicd.cpp
+++ b/src/raspberrypi/devices/scsicd.cpp
@@ -63,7 +63,6 @@ CDTrack::~CDTrack()
 //---------------------------------------------------------------------------
 BOOL FASTCALL CDTrack::Init(int track, DWORD first, DWORD last)
 {
-	ASSERT(this);
 	ASSERT(!valid);
 	ASSERT(track >= 1);
 	ASSERT(first < last);
@@ -86,7 +85,6 @@ BOOL FASTCALL CDTrack::Init(int track, DWORD first, DWORD last)
 //---------------------------------------------------------------------------
 void FASTCALL CDTrack::SetPath(BOOL cdda, const Filepath& path)
 {
-	ASSERT(this);
 	ASSERT(valid);
 
 	// CD-DA or data
@@ -103,7 +101,6 @@ void FASTCALL CDTrack::SetPath(BOOL cdda, const Filepath& path)
 //---------------------------------------------------------------------------
 void FASTCALL CDTrack::GetPath(Filepath& path) const
 {
-	ASSERT(this);
 	ASSERT(valid);
 
 	// Return the path (by reference)
@@ -117,7 +114,6 @@ void FASTCALL CDTrack::GetPath(Filepath& path) const
 //---------------------------------------------------------------------------
 void FASTCALL CDTrack::AddIndex(int index, DWORD lba)
 {
-	ASSERT(this);
 	ASSERT(valid);
 	ASSERT(index > 0);
 	ASSERT(first_lba <= lba);
@@ -134,7 +130,6 @@ void FASTCALL CDTrack::AddIndex(int index, DWORD lba)
 //---------------------------------------------------------------------------
 DWORD FASTCALL CDTrack::GetFirst() const
 {
-	ASSERT(this);
 	ASSERT(valid);
 	ASSERT(first_lba < last_lba);
 
@@ -148,7 +143,6 @@ DWORD FASTCALL CDTrack::GetFirst() const
 //---------------------------------------------------------------------------
 DWORD FASTCALL CDTrack::GetLast() const
 {
-	ASSERT(this);
 	ASSERT(valid);
 	ASSERT(first_lba < last_lba);
 
@@ -162,7 +156,6 @@ DWORD FASTCALL CDTrack::GetLast() const
 //---------------------------------------------------------------------------
 DWORD FASTCALL CDTrack::GetBlocks() const
 {
-	ASSERT(this);
 	ASSERT(valid);
 	ASSERT(first_lba < last_lba);
 
@@ -177,7 +170,6 @@ DWORD FASTCALL CDTrack::GetBlocks() const
 //---------------------------------------------------------------------------
 int FASTCALL CDTrack::GetTrackNo() const
 {
-	ASSERT(this);
 	ASSERT(valid);
 	ASSERT(track_no >= 1);
 
@@ -191,8 +183,6 @@ int FASTCALL CDTrack::GetTrackNo() const
 //---------------------------------------------------------------------------
 BOOL FASTCALL CDTrack::IsValid(DWORD lba) const
 {
-	ASSERT(this);
-
 	// FALSE if the track itself is invalid
 	if (!valid) {
 		return FALSE;
@@ -219,7 +209,6 @@ BOOL FASTCALL CDTrack::IsValid(DWORD lba) const
 //---------------------------------------------------------------------------
 BOOL FASTCALL CDTrack::IsAudio() const
 {
-	ASSERT(this);
 	ASSERT(valid);
 
 	return audio;
@@ -310,7 +299,6 @@ BOOL FASTCALL SCSICD::Load(Fileio *fio, int ver)
 	DWORD padding;
 	Filepath path;
 
-	ASSERT(this);
 	ASSERT(fio);
 	ASSERT(ver >= 0x0200);
 
@@ -406,7 +394,6 @@ BOOL FASTCALL SCSICD::Open(const Filepath& path, BOOL attn)
 	off64_t size;
 	TCHAR file[5];
 
-	ASSERT(this);
 	ASSERT(!disk.ready);
 
 	// Initialization, track clear
@@ -484,8 +471,6 @@ BOOL FASTCALL SCSICD::Open(const Filepath& path, BOOL attn)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSICD::OpenCue(const Filepath& /*path*/)
 {
-	ASSERT(this);
-
 	// Always fail
 	return FALSE;
 }
@@ -497,20 +482,17 @@ BOOL FASTCALL SCSICD::OpenCue(const Filepath& /*path*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSICD::OpenIso(const Filepath& path)
 {
-	Fileio fio;
-	off64_t size;
 	BYTE header[12];
 	BYTE sync[12];
 
-	ASSERT(this);
-
 	// Open as read-only
+	Fileio fio;
 	if (!fio.Open(path, Fileio::ReadOnly)) {
 		return FALSE;
 	}
 
 	// Get file size
-	size = fio.GetFileSize();
+	off64_t size = fio.GetFileSize();
 	if (size < 0x800) {
 		fio.Close();
 		return FALSE;
@@ -589,18 +571,14 @@ BOOL FASTCALL SCSICD::OpenIso(const Filepath& path)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSICD::OpenPhysical(const Filepath& path)
 {
-	Fileio fio;
-	off64_t size;
-
-	ASSERT(this);
-
 	// Open as read-only
+	Fileio fio;
 	if (!fio.Open(path, Fileio::ReadOnly)) {
 		return FALSE;
 	}
 
 	// Get size
-	size = fio.GetFileSize();
+	off64_t size = fio.GetFileSize();
 	if (size < 0x800) {
 		fio.Close();
 		return FALSE;
@@ -641,9 +619,7 @@ int FASTCALL SCSICD::Inquiry(
 	const DWORD *cdb, BYTE *buf, DWORD major, DWORD minor)
 {
 	char rev[32];
-	int size;
 
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 	ASSERT(cdb[0] == 0x12);
@@ -710,7 +686,7 @@ int FASTCALL SCSICD::Inquiry(
 //	memcpy(&buf[37],"1999/01/01",10);
 
 	// Size of data that can be returned
-	size = (buf[4] + 5);
+	int size = (buf[4] + 5);
 
 	// Limit if the other buffer is small
 	if (size > (int)cdb[4]) {
@@ -729,10 +705,8 @@ int FASTCALL SCSICD::Inquiry(
 //---------------------------------------------------------------------------
 int FASTCALL SCSICD::Read(const DWORD *cdb, BYTE *buf, DWORD block)
 {
-	int index;
 	Filepath path;
 
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Status check
@@ -741,7 +715,7 @@ int FASTCALL SCSICD::Read(const DWORD *cdb, BYTE *buf, DWORD block)
 	}
 
 	// Search for the track
-	index = SearchTrack(block);
+	int index = SearchTrack(block);
 
 	// if invalid, out of range
 	if (index < 0) {
@@ -781,15 +755,11 @@ int FASTCALL SCSICD::Read(const DWORD *cdb, BYTE *buf, DWORD block)
 //---------------------------------------------------------------------------
 int FASTCALL SCSICD::ReadToc(const DWORD *cdb, BYTE *buf)
 {
-	int last;
-	int index;
-	int length;
 	int loop;
 	int i;
 	BOOL msf;
 	DWORD lba;
 
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(cdb[0] == 0x43);
 	ASSERT(buf);
@@ -804,7 +774,7 @@ int FASTCALL SCSICD::ReadToc(const DWORD *cdb, BYTE *buf)
 	ASSERT(track[0]);
 
 	// Get allocation length, clear buffer
-	length = cdb[7] << 8;
+	int length = cdb[7] << 8;
 	length |= cdb[8];
 	memset(buf, 0, length);
 
@@ -816,7 +786,7 @@ int FASTCALL SCSICD::ReadToc(const DWORD *cdb, BYTE *buf)
 	}
 
 	// Get and check the last track number
-	last = track[tracks - 1]->GetTrackNo();
+	int last = track[tracks - 1]->GetTrackNo();
 	if ((int)cdb[6] > last) {
 		// Except for AA
 		if (cdb[6] != 0xaa) {
@@ -826,7 +796,7 @@ int FASTCALL SCSICD::ReadToc(const DWORD *cdb, BYTE *buf)
 	}
 
 	// Check start index
-	index = 0;
+	int index = 0;
 	if (cdb[6] != 0x00) {
 		// Advance the track until the track numbers match
 		while (track[index]) {
@@ -910,8 +880,6 @@ int FASTCALL SCSICD::ReadToc(const DWORD *cdb, BYTE *buf)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSICD::PlayAudio(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	disk.code = DISK_INVALIDCDB;
 	return FALSE;
 }
@@ -923,8 +891,6 @@ BOOL FASTCALL SCSICD::PlayAudio(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSICD::PlayAudioMSF(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	disk.code = DISK_INVALIDCDB;
 	return FALSE;
 }
@@ -936,8 +902,6 @@ BOOL FASTCALL SCSICD::PlayAudioMSF(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSICD::PlayAudioTrack(const DWORD* /*cdb*/)
 {
-	ASSERT(this);
-
 	disk.code = DISK_INVALIDCDB;
 	return FALSE;
 }
@@ -949,16 +913,10 @@ BOOL FASTCALL SCSICD::PlayAudioTrack(const DWORD* /*cdb*/)
 //---------------------------------------------------------------------------
 void FASTCALL SCSICD::LBAtoMSF(DWORD lba, BYTE *msf) const
 {
-	DWORD m;
-	DWORD s;
-	DWORD f;
-
-	ASSERT(this);
-
 	// 75 and 75*60 get the remainder
-	m = lba / (75 * 60);
-	s = lba % (75 * 60);
-	f = s % 75;
+	DWORD m = lba / (75 * 60);
+	DWORD s = lba % (75 * 60);
+	DWORD f = s % 75;
 	s /= 75;
 
 	// The base point is M=0, S=2, F=0
@@ -985,14 +943,11 @@ void FASTCALL SCSICD::LBAtoMSF(DWORD lba, BYTE *msf) const
 //---------------------------------------------------------------------------
 DWORD FASTCALL SCSICD::MSFtoLBA(const BYTE *msf) const
 {
-	DWORD lba;
-
-	ASSERT(this);
 	ASSERT(msf[2] < 60);
 	ASSERT(msf[3] < 75);
 
 	// 1, 75, add up in multiples of 75*60
-	lba = msf[1];
+	DWORD lba = msf[1];
 	lba *= 60;
 	lba += msf[2];
 	lba *= 75;
@@ -1011,12 +966,8 @@ DWORD FASTCALL SCSICD::MSFtoLBA(const BYTE *msf) const
 //---------------------------------------------------------------------------
 void FASTCALL SCSICD::ClearTrack()
 {
-	int i;
-
-	ASSERT(this);
-
 	// delete the track object
-	for (i = 0; i < TrackMax; i++) {
+	for (int i = 0; i < TrackMax; i++) {
 		if (track[i]) {
 			delete track[i];
 			track[i] = NULL;
@@ -1039,12 +990,8 @@ void FASTCALL SCSICD::ClearTrack()
 //---------------------------------------------------------------------------
 int FASTCALL SCSICD::SearchTrack(DWORD lba) const
 {
-	int i;
-
-	ASSERT(this);
-
 	// Track loop
-	for (i = 0; i < tracks; i++) {
+	for (int i = 0; i < tracks; i++) {
 		// Listen to the track
 		ASSERT(track[i]);
 		if (track[i]->IsValid(lba)) {
@@ -1063,7 +1010,6 @@ int FASTCALL SCSICD::SearchTrack(DWORD lba) const
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSICD::NextFrame()
 {
-	ASSERT(this);
 	ASSERT((frame >= 0) && (frame < 75));
 
 	// set the frame in the range 0-74
@@ -1085,5 +1031,5 @@ BOOL FASTCALL SCSICD::NextFrame()
 void FASTCALL SCSICD::GetBuf(
 	DWORD* /*buffer*/, int /*samples*/, DWORD /*rate*/)
 {
-	ASSERT(this);
+	// TODO Missing implementation?
 }

--- a/src/raspberrypi/devices/scsihd.cpp
+++ b/src/raspberrypi/devices/scsihd.cpp
@@ -57,19 +57,16 @@ void FASTCALL SCSIHD::Reset()
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSIHD::Open(const Filepath& path, BOOL /*attn*/)
 {
-	Fileio fio;
-	off64_t size;
-
-	ASSERT(this);
 	ASSERT(!disk.ready);
 
 	// read open required
+	Fileio fio;
 	if (!fio.Open(path, Fileio::ReadOnly)) {
 		return FALSE;
 	}
 
 	// Get file size
-	size = fio.GetFileSize();
+	off64_t size = fio.GetFileSize();
 	fio.Close();
 
 	// Must be 512 bytes
@@ -106,9 +103,7 @@ int FASTCALL SCSIHD:: Inquiry(
 	char vendor[32];
 	char product[32];
 	char rev[32];
-	int size;
 
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 	ASSERT(cdb[0] == 0x12);
@@ -146,7 +141,7 @@ int FASTCALL SCSIHD:: Inquiry(
 
 	// Determine vendor name/product name
 	sprintf(vendor, BENDER_SIGNATURE);
-	size = disk.blocks >> 11;
+	int size = disk.blocks >> 11;
 	if (size < 300)
 		sprintf(product, "PRODRIVE LPS%dS", size);
 	else if (size < 600)
@@ -195,7 +190,6 @@ BOOL FASTCALL SCSIHD::ModeSelect(const DWORD *cdb, const BYTE *buf, int length)
 	BYTE page;
 	int size;
 
-	ASSERT(this);
 	ASSERT(buf);
 	ASSERT(length >= 0);
 

--- a/src/raspberrypi/devices/scsihd_apple.cpp
+++ b/src/raspberrypi/devices/scsihd_apple.cpp
@@ -39,12 +39,11 @@ SCSIHD_APPLE::SCSIHD_APPLE() : SCSIHD()
 int FASTCALL SCSIHD_APPLE::Inquiry(
 	const DWORD *cdb, BYTE *buf, DWORD major, DWORD minor)
 {
-	int size;
 	char vendor[32];
 	char product[32];
 
 	// Call the base class
-	size = SCSIHD::Inquiry(cdb, buf, major, minor);
+	int size = SCSIHD::Inquiry(cdb, buf, major, minor);
 
 	// End if there is an error in the base class
 	if (size == 0) {
@@ -69,7 +68,6 @@ int FASTCALL SCSIHD_APPLE::Inquiry(
 //---------------------------------------------------------------------------
 int FASTCALL SCSIHD_APPLE::AddVendor(int page, BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Page code 48

--- a/src/raspberrypi/devices/scsihd_nec.cpp
+++ b/src/raspberrypi/devices/scsihd_nec.cpp
@@ -72,7 +72,6 @@ BOOL FASTCALL SCSIHD_NEC::Open(const Filepath& path, BOOL /*attn*/)
 	BYTE hdr[512];
 	LPCTSTR ext;
 
-	ASSERT(this);
 	ASSERT(!disk.ready);
 
 	// Open as read-only
@@ -200,7 +199,6 @@ int FASTCALL SCSIHD_NEC::Inquiry(
 //---------------------------------------------------------------------------
 int FASTCALL SCSIHD_NEC::AddError(BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -223,9 +221,6 @@ int FASTCALL SCSIHD_NEC::AddError(BOOL change, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL SCSIHD_NEC::AddFormat(BOOL change, BYTE *buf)
 {
-	int size;
-
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length
@@ -249,7 +244,7 @@ int FASTCALL SCSIHD_NEC::AddFormat(BOOL change, BYTE *buf)
 		buf[0xb] = (BYTE)sectors;
 
 		// 物理セクタのバイト数を設定
-		size = 1 << disk.size;
+		int size = 1 << disk.size;
 		buf[0xc] = (BYTE)(size >> 8);
 		buf[0xd] = (BYTE)size;
 	}
@@ -269,7 +264,6 @@ int FASTCALL SCSIHD_NEC::AddFormat(BOOL change, BYTE *buf)
 //---------------------------------------------------------------------------
 int FASTCALL SCSIHD_NEC::AddDrive(BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Set the message length

--- a/src/raspberrypi/devices/scsimo.cpp
+++ b/src/raspberrypi/devices/scsimo.cpp
@@ -45,19 +45,16 @@ SCSIMO::SCSIMO() : Disk()
 //---------------------------------------------------------------------------
 BOOL FASTCALL SCSIMO::Open(const Filepath& path, BOOL attn)
 {
-	Fileio fio;
-	off64_t size;
-
-	ASSERT(this);
 	ASSERT(!disk.ready);
 
 	// Open as read-only
+	Fileio fio;
 	if (!fio.Open(path, Fileio::ReadOnly)) {
 		return FALSE;
 	}
 
 	// Get file size
-	size = fio.GetFileSize();
+	off64_t size = fio.GetFileSize();
 	fio.Close();
 
 	switch (size) {
@@ -114,7 +111,6 @@ BOOL FASTCALL SCSIMO::Load(Fileio *fio, int ver)
 	DWORD padding;
 	Filepath path;
 
-	ASSERT(this);
 	ASSERT(fio);
 	ASSERT(ver >= 0x0200);
 
@@ -192,7 +188,6 @@ int FASTCALL SCSIMO::Inquiry(
 	int size;
 	char rev[32];
 
-	ASSERT(this);
 	ASSERT(cdb);
 	ASSERT(buf);
 	ASSERT(cdb[0] == 0x12);
@@ -260,7 +255,6 @@ BOOL FASTCALL SCSIMO::ModeSelect(const DWORD *cdb, const BYTE *buf, int length)
 	int page;
 	int size;
 
-	ASSERT(this);
 	ASSERT(buf);
 	ASSERT(length >= 0);
 
@@ -327,7 +321,6 @@ BOOL FASTCALL SCSIMO::ModeSelect(const DWORD *cdb, const BYTE *buf, int length)
 //---------------------------------------------------------------------------
 int FASTCALL SCSIMO::AddVendor(int page, BOOL change, BYTE *buf)
 {
-	ASSERT(this);
 	ASSERT(buf);
 
 	// Page code 20h

--- a/src/raspberrypi/scsi.cpp
+++ b/src/raspberrypi/scsi.cpp
@@ -20,10 +20,6 @@
 //---------------------------------------------------------------------------
 BUS::phase_t FASTCALL BUS::GetPhase()
 {
-	DWORD mci;
-
-	ASSERT(this);
-
 	// Selection Phase
 	if (GetSEL()) {
 		return selection;
@@ -35,7 +31,7 @@ BUS::phase_t FASTCALL BUS::GetPhase()
 	}
 
 	// Get target phase from bus signal line
-	mci = GetMSG() ? 0x04 : 0x00;
+	DWORD mci = GetMSG() ? 0x04 : 0x00;
 	mci |= GetCD() ? 0x02 : 0x00;
 	mci |= GetIO() ? 0x01 : 0x00;
 	return GetPhase(mci);


### PR DESCRIPTION
@akuker Correct me if I am missing something, but IMO 'ASSERT(this)' does not serve any purpose, because in general member functions cannot be called anyway on NULL object (this) pointers.

I also improved code locality a bit.