### PR TITLE
Cplusplus level update to c++-17

### DIFF
--- a/src/raspberrypi/Makefile
+++ b/src/raspberrypi/Makefile
@@ -31,7 +31,7 @@ else
 	BUILD_TYPE = Release
 endif
 CFLAGS += -iquote . -MD -MP
-CXXFLAGS += -std=c++14 -iquote . -MD -MP
+CXXFLAGS += -std=c++20 -iquote . -MD -MP
 
 ## EXTRA_FLAGS : Can be used to pass special purpose flags
 CFLAGS += $(EXTRA_FLAGS)

--- a/src/raspberrypi/Makefile
+++ b/src/raspberrypi/Makefile
@@ -31,7 +31,7 @@ else
 	BUILD_TYPE = Release
 endif
 CFLAGS += -iquote . -MD -MP
-CXXFLAGS += -std=c++20 -iquote . -MD -MP
+CXXFLAGS += -std=c++17 -iquote . -MD -MP
 
 ## EXTRA_FLAGS : Can be used to pass special purpose flags
 CFLAGS += $(EXTRA_FLAGS)


### PR DESCRIPTION
Updated C++ level to c++-17. The standard compiler of Raspberry OS does not yet support c++-20, but only c++-17.