### PR TITLE
Removed image size check. There is no such limit for SCSI drives.

### DIFF
--- a/src/raspberrypi/devices/scsihd.cpp
+++ b/src/raspberrypi/devices/scsihd.cpp
@@ -74,10 +74,6 @@ BOOL FASTCALL SCSIHD::Open(const Filepath& path, BOOL /*attn*/)
 		return FALSE;
 	}
 
-	// 10MB or more
-	if (size < 0x9f5400) {
-		return FALSE;
-	}
     // 2TB according to xm6i
     // There is a similar one in wxw/wxw_cfg.cpp
 	if (size > 2LL * 1024 * 1024 * 1024 * 1024) {


### PR DESCRIPTION
This change fixes issues with small drive image files. Besides the fact that there is no minimum size for SCSI drives it is not unusual that image files are rather small. They do not need to be bigger than the software they contain.