### PR TITLE
fix bridge-utils missing from dev

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -41,7 +41,7 @@ function initialChecks() {
 }
 
 function installPackages() {
-    sudo apt-get update && sudo apt install git libspdlog-dev libpcap-dev genisoimage python3 python3-venv nginx libpcap-dev protobuf-compiler -y
+    sudo apt-get update && sudo apt install git libspdlog-dev libpcap-dev genisoimage python3 python3-venv nginx libpcap-dev protobuf-compiler bridge-utils -y
 }
 
 # install all dependency packages for RaSCSI Service


### PR DESCRIPTION
For some reason this is in master but not develop. May cause merge conflict but needed.