### PR TITLE
Speed up web uploads and various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ core
 __pycache__
 src/web/current
 src/oled_monitor/current
+src/raspberrypi/hfdisk/

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -105,10 +105,20 @@ function installRaScsiWebInterface() {
 function updateRaScsiGit() {
     echo "Updating checked out branch $GIT_REMOTE/$GIT_BRANCH"
     cd ~/RASCSI
+    stashed=0
+    if [[ $(git diff --stat) != '' ]]; then
+        echo 'There are local changes, we will stash and reapply them.'
+        git stash
+        stashed=1
+    fi
+
     git fetch $GIT_REMOTE
-    git stash
     git rebase $GIT_REMOTE/$GIT_BRANCH
-    git stash apply
+
+    if [ $stashed -eq 1 ]; then
+        echo "Reapplying local changes..."
+        git stash apply
+    fi
 }
 
 function updateRaScsi() {

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -296,7 +296,7 @@ function readChoice() {
        read -r choice
    done
 
-   runChoice choice
+   runChoice "$choice"
 }
 
 function showMenu() {

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -41,7 +41,7 @@ function initialChecks() {
 }
 
 function installPackages() {
-    sudo apt-get update && sudo apt install git libspdlog-dev libpcap-dev genisoimage python3 python3-venv nginx libpcap-dev protobuf-compiler bridge-utils -y
+    sudo apt-get update && sudo apt install git libspdlog-dev libpcap-dev genisoimage python3 python3-venv nginx libpcap-dev protobuf-compiler bridge-utils python3-dev libev-dev libevdev2 -y
 }
 
 # install all dependency packages for RaSCSI Service

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -279,10 +279,24 @@ function runChoice() {
               createDriveCustom
               echo "Creating a custom drive - Complete!"
           ;;
+          -h|--help|h|help)
+              showMenu
+          ;;
           *)
               echo "${1} is not a valid option, exiting..."
               exit 1
       esac
+}
+
+function readChoice() {
+   choice=-1
+
+   until [ $choice -ge "0" ] && [ $choice -le "7" ]; do
+       echo -n "Enter your choice (0-7) or CTRL-C to exit: "
+       read -r choice
+   done
+
+   runChoice choice
 }
 
 function showMenu() {
@@ -299,16 +313,6 @@ function showMenu() {
     echo "CREATE EMPTY DRIVE"
     echo "  6) 600MB drive (recommended)"
     echo "  7) custom drive size (up to 4000MB)"
-
-
-    choice=-1
-
-    until [ $choice -ge "0" ] && [ $choice -le "7" ]; do
-        echo -n "Enter your choice (0-7) or CTRL-C to exit: "
-        read -r choice
-    done
-
-    runChoice choice
 }
 
 
@@ -316,6 +320,7 @@ showRaSCSILogo
 initialChecks
 if [ -z "${1}" ]; then # $1 is unset, show menu
     showMenu
+    readChoice
 else
     runChoice "$1"
 fi

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -25,6 +25,7 @@ HFS_FORMAT=/usr/bin/hformat
 HFDISK_BIN=/usr/bin/hfdisk
 LIDO_DRIVER=~/RASCSI/lido-driver.img
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_REMOTE=${GIT_REMOTE:-origin}
 
 function initialChecks() {
     currentUser=$(whoami)
@@ -102,11 +103,11 @@ function installRaScsiWebInterface() {
 }
 
 function updateRaScsiGit() {
-    echo "Updating checked out branch $GIT_BRANCH"
+    echo "Updating checked out branch $GIT_REMOTE/$GIT_BRANCH"
     cd ~/RASCSI
-    git fetch origin
+    git fetch $GIT_REMOTE
     git stash
-    git rebase origin/$GIT_BRANCH
+    git rebase $GIT_REMOTE/$GIT_BRANCH
     git stash apply
 }
 

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -238,38 +238,46 @@ function runChoice() {
               installRaScsiWebInterface
               createDrive600MB
               showRaScsiStatus
+              echo "Installing RaSCSI Service + Web interface - Complete!"
           ;;
           1)
               echo "Installing RaSCSI Service"
               installRaScsi
               showRaScsiStatus
+              echo "Installing RaSCSI Service - Complete!"
           ;;
           2)
               echo "Installing RaSCSI Web interface"
               installRaScsiWebInterface
+              echo "Installing RaSCSI Web interface - Complete!"
           ;;
           3)
               echo "Updating RaSCSI Service + Web interface"
               updateRaScsi
               updateRaScsiWebInterface
               showRaScsiStatus
+              echo "Updating RaSCSI Service + Web interface - Complete!"
           ;;
           4)
               echo "Updating RaSCSI Service"
               updateRaScsi
               showRaScsiStatus
+              echo "Updating RaSCSI Service - Complete!"
           ;;
           5)
               echo "Updating RaSCSI Web interface"
               updateRaScsiWebInterface
+              echo "Updating RaSCSI Web interface - Complete!"
           ;;
           6)
               echo "Creating a 600MB drive"
               createDrive600MB
+              echo "Creating a 600MB drive - Complete!"
           ;;
           7)
               echo "Creating a custom drive"
               createDriveCustom
+              echo "Creating a custom drive - Complete!"
           ;;
           *)
               echo "${1} is not a valid option, exiting..."

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -139,6 +139,7 @@ function updateRaScsiWebInterface() {
     updateRaScsiGit
     sudo cp -f ~/RASCSI/src/web/service-infra/nginx-default.conf /etc/nginx/sites-available/default
     sudo cp -f ~/RASCSI/src/web/service-infra/502.html /var/www/html/502.html
+    echo "Restarting rascsi-web services..."
     sudo systemctl restart rascsi-web
     sudo systemctl restart nginx
 }

--- a/src/web/file_cmds.py
+++ b/src/web/file_cmds.py
@@ -6,7 +6,7 @@ import time
 from ractl_cmds import attach_image
 from settings import *
 
-valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.mos", "*.iso", "*.cdr", "*.zip"]
+valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.iso", "*.cdr", "*.zip"]
 valid_file_types = r"|".join([fnmatch.translate(x) for x in valid_file_suffix])
 
 

--- a/src/web/file_cmds.py
+++ b/src/web/file_cmds.py
@@ -6,8 +6,8 @@ import time
 from ractl_cmds import attach_image
 from settings import *
 
-valid_file_types = ["*.hda", "*.iso", "*.cdr"]
-valid_file_types = r"|".join([fnmatch.translate(x) for x in valid_file_types])
+valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.mos", "*.iso", "*.cdr", "*.zip"]
+valid_file_types = r"|".join([fnmatch.translate(x) for x in valid_file_suffix])
 
 
 def create_new_image(file_name, type, size):

--- a/src/web/ractl_cmds.py
+++ b/src/web/ractl_cmds.py
@@ -1,12 +1,12 @@
 import fnmatch
-import os
 import subprocess
 import re
 
 from settings import *
 
-valid_file_types = ["*.hda", "*.iso", "*.cdr", "*.zip"]
-valid_file_types = r"|".join([fnmatch.translate(x) for x in valid_file_types])
+
+valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.mos", "*.iso", "*.cdr", "*.zip"]
+valid_file_types = r"|".join([fnmatch.translate(x) for x in valid_file_suffix])
 # List of SCSI ID's you'd like to exclude - eg if you are on a Mac, the System is usually 7
 EXCLUDE_SCSI_IDS = [7]
 

--- a/src/web/ractl_cmds.py
+++ b/src/web/ractl_cmds.py
@@ -5,7 +5,7 @@ import re
 from settings import *
 
 
-valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.mos", "*.iso", "*.cdr", "*.zip"]
+valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.iso", "*.cdr", "*.zip"]
 valid_file_types = r"|".join([fnmatch.translate(x) for x in valid_file_suffix])
 # List of SCSI ID's you'd like to exclude - eg if you are on a Mac, the System is usually 7
 EXCLUDE_SCSI_IDS = [7]

--- a/src/web/requirements.txt
+++ b/src/web/requirements.txt
@@ -1,5 +1,6 @@
+bjoern==3.1.0
 click==7.1.2
-Flask==2.0.0
+Flask==2.0.1
 itsdangerous==2.0.0
 Jinja2==3.0.0
 machfs==1.2.4
@@ -7,6 +8,5 @@ macresources==1.2
 MarkupSafe==2.0.0
 rsrcfork==1.8.0
 waitress==1.4.4
-Werkzeug==2.0.0
 zope.event==4.5.0
 zope.interface==5.1.2

--- a/src/web/start.sh
+++ b/src/web/start.sh
@@ -37,6 +37,7 @@ if ! test -e venv; then
   echo "Activating venv"
   source venv/bin/activate
   echo "Installing requirements.txt"
+  pip install wheel
   pip install -r requirements.txt
   git rev-parse HEAD > current
 fi

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -222,7 +222,6 @@
                         <option value="nhd">SCSI Hard Disk image (T98Next HD image)</option>
                         <option value="hdf">SASI Hard Disk image (XM6 SASI HD image - typically only used with X68000)</option>
                         <option value="hds">SCSI Hard Disk image (XM6 SCSI HD image - typically only  used with X68000)</option>
-                        <option value="mos">SCSI Magneto-optical image (XM6 SCSI MO image - typically only used with X68000)</option>
                     </select>
                     <label for="size">Size(MB):</label>
                     <input type="number" placeholder="Size(MB)" name="size"/>

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -153,7 +153,7 @@
     <table style="border: none">
             <tr style="border: none">
                 <td style="border: none; vertical-align:top;">
-                <form action="/files/upload" method="post">
+                <form action="/files/upload" method="post" enctype="multipart/form-data">
                     <label for="file">File:</label>
                     <input type="file" name="file"/>
                     <input type="submit" value="Upload" />

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -153,7 +153,7 @@
     <table style="border: none">
             <tr style="border: none">
                 <td style="border: none; vertical-align:top;">
-                <form action="/files/upload" method="post" enctype="multipart/form-data">
+                <form id="uploadForm" action="/files/upload/" onchange="fileSelect(event)" method="post" enctype="multipart/form-data">
                     <label for="file">File:</label>
                     <input type="file" name="file"/>
                     <input type="submit" value="Upload" />
@@ -161,6 +161,12 @@
             </td>
         </tr>
     </table>
+<script>
+    function fileSelect(e) {
+        document.getElementById("uploadForm").setAttribute('action', "/files/upload/" + e.target.files[0].name)
+        console.log(e.target.files[0].name);
+    }
+</script>
 
     <hr/>
 

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -153,7 +153,7 @@
     <table style="border: none">
             <tr style="border: none">
                 <td style="border: none; vertical-align:top;">
-                <form action="/files/upload" method="post" enctype="multipart/form-data">
+                <form action="/files/upload" method="post">
                     <label for="file">File:</label>
                     <input type="file" name="file"/>
                     <input type="submit" value="Upload" />

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -229,19 +229,20 @@ def download_img():
 
 @app.route("/files/upload", methods=["POST"])
 def upload_file():
-    if "file" not in request.files:
-        flash("No file part", "error")
-        return redirect(url_for("index"))
-    filename = request.form["filename"]
+    # if "file" not in request.files:
+    #     flash("No file part", "error")
+    #     return redirect(url_for("index"))
 
-    with open(os.path.join(app.config["UPLOAD_FOLDER"], filename, "bw")) as f:
+    # filename = request.form["file"]# Content-Disposition
+
+    with open(os.path.join(app.config["UPLOAD_FOLDER"], "test.iso"), "bw") as f:
         chunk_size = 4096
         while True:
             chunk = request.stream.read(chunk_size)
             if len(chunk) == 0:
                 break
             f.write(chunk)
-    return redirect(url_for("index", filename=filename))
+    return redirect(url_for("index", filename="filename"))
 
 
 @app.route("/files/create", methods=["POST"])

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -1,3 +1,5 @@
+import re
+
 from flask import Flask, render_template, request, flash, url_for, redirect, send_file
 
 from file_cmds import (
@@ -21,6 +23,8 @@ from ractl_cmds import (
     daynaport_setup_bridge,
     list_config_files,
     detach_all,
+    valid_file_suffix,
+    valid_file_types
 )
 from settings import *
 
@@ -128,12 +132,17 @@ def attach():
     scsi_id = request.form.get("scsi_id")
 
     # Validate image type by suffix
-    if file_name.lower().endswith(".iso") or file_name.lower().endswith("iso"):
-        image_type = "cd"
-    elif file_name.lower().endswith(".hda"):
-        image_type = "hd"
+    print("file_name", file_name)
+    print("valid_file_types: ", valid_file_types)
+    if re.match(valid_file_types, file_name):
+        if file_name.lower().endswith("iso"):
+            image_type = "cd"
+        elif file_name.lower().endswith("mos"):
+            image_type = "mo"
+        else:
+            image_type = "hd"
     else:
-        flash("Unknown file type. Valid files are .iso, .hda, .cdr", "error")
+        flash(f"Unknown file type. Valid files are: {', '.join(valid_file_suffix)}", "error")
         return redirect(url_for("index"))
 
     process = attach_image(scsi_id, file_name, image_type)

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -227,22 +227,20 @@ def download_img():
     return redirect(url_for("index"))
 
 
-@app.route("/files/upload", methods=["POST"])
-def upload_file():
+@app.route("/files/upload/<filename>", methods=["POST"])
+def upload_file(filename):
     # if "file" not in request.files:
     #     flash("No file part", "error")
     #     return redirect(url_for("index"))
 
-    # filename = request.form["file"]# Content-Disposition
-
-    with open(os.path.join(app.config["UPLOAD_FOLDER"], "test.iso"), "bw") as f:
+    with open(os.path.join(app.config["UPLOAD_FOLDER"], filename), "bw") as f:
         chunk_size = 4096
         while True:
             chunk = request.stream.read(chunk_size)
             if len(chunk) == 0:
                 break
             f.write(chunk)
-    return redirect(url_for("index", filename="filename"))
+    return redirect(url_for("index", filename=filename))
 
 
 @app.route("/files/create", methods=["POST"])

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -1,5 +1,4 @@
 from flask import Flask, render_template, request, flash, url_for, redirect, send_file
-from werkzeug.utils import secure_filename
 
 from file_cmds import (
     create_new_image,
@@ -235,7 +234,7 @@ def upload_file():
         return redirect(url_for("index"))
     file = request.files["file"]
     if file:
-        filename = secure_filename(file.filename)
+        filename = file.filename
         file.save(os.path.join(app.config["UPLOAD_FOLDER"], filename))
         return redirect(url_for("index", filename=filename))
 
@@ -244,9 +243,9 @@ def upload_file():
 def create_file():
     file_name = request.form.get("file_name")
     size = request.form.get("size")
-    type = request.form.get("type")
+    file_type = request.form.get("type")
 
-    process = create_new_image(file_name, type, size)
+    process = create_new_image(file_name, file_type, size)
     if process.returncode == 0:
         flash("Drive created")
         return redirect(url_for("index"))
@@ -293,6 +292,6 @@ if __name__ == "__main__":
     os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
     app.config["MAX_CONTENT_LENGTH"] = MAX_FILE_SIZE
 
-    from waitress import serve
+    import bjoern
+    bjoern.run(app, "0.0.0.0", 8080)
 
-    serve(app, host="0.0.0.0", port=8080)

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -229,9 +229,9 @@ def download_img():
 
 @app.route("/files/upload/<filename>", methods=["POST"])
 def upload_file(filename):
-    # if "file" not in request.files:
-    #     flash("No file part", "error")
-    #     return redirect(url_for("index"))
+    if not filename:
+        flash("No file provided.", "error")
+        return redirect(url_for("index"))
 
     with open(os.path.join(app.config["UPLOAD_FOLDER"], filename), "bw") as f:
         chunk_size = 4096

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -1,3 +1,4 @@
+import io
 import re
 
 from flask import Flask, render_template, request, flash, url_for, redirect, send_file
@@ -240,8 +241,14 @@ def upload_file(filename):
         flash("No file provided.", "error")
         return redirect(url_for("index"))
 
-    with open(os.path.join(app.config["UPLOAD_FOLDER"], filename), "bw") as f:
-        chunk_size = 4096
+    file_path = os.path.join(app.config["UPLOAD_FOLDER"], filename)
+    if os.path.isfile(file_path):
+        flash(f"{filename} already exists.", "error")
+        return redirect(url_for("index"))
+
+    binary_new_file = "bx"
+    with open(file_path, binary_new_file, buffering=io.DEFAULT_BUFFER_SIZE) as f:
+        chunk_size = io.DEFAULT_BUFFER_SIZE
         while True:
             chunk = request.stream.read(chunk_size)
             if len(chunk) == 0:
@@ -304,5 +311,6 @@ if __name__ == "__main__":
     app.config["MAX_CONTENT_LENGTH"] = MAX_FILE_SIZE
 
     import bjoern
+    print("Serving rascsi-web...")
     bjoern.run(app, "0.0.0.0", 8080)
 

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -232,11 +232,16 @@ def upload_file():
     if "file" not in request.files:
         flash("No file part", "error")
         return redirect(url_for("index"))
-    file = request.files["file"]
-    if file:
-        filename = file.filename
-        file.save(os.path.join(app.config["UPLOAD_FOLDER"], filename))
-        return redirect(url_for("index", filename=filename))
+    filename = request.form["filename"]
+
+    with open(os.path.join(app.config["UPLOAD_FOLDER"], filename, "bw")) as f:
+        chunk_size = 4096
+        while True:
+            chunk = request.stream.read(chunk_size)
+            if len(chunk) == 0:
+                break
+            f.write(chunk)
+    return redirect(url_for("index", filename=filename))
 
 
 @app.route("/files/create", methods=["POST"])

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -137,8 +137,6 @@ def attach():
     if re.match(valid_file_types, file_name):
         if file_name.lower().endswith("iso"):
             image_type = "cd"
-        elif file_name.lower().endswith("mos"):
-            image_type = "mo"
         else:
             image_type = "hd"
     else:


### PR DESCRIPTION
* 1gb file now uploads in 1m 20 seconds - still slower than sftp, but does not time out and seems acceptable (well better then timing out)
* Added `GIT_REMOTE` option to `easyinstall.sh` to use different remotes than origin - handy for testing
* `easyinstall.sh` now can be by passing in options - eg `./easyinstall.sh 0` and run option 0.
Allow web to show/attach all supported types

