### PR TITLE
Extended protobuf interface with server information

### DIFF
--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -491,7 +491,7 @@ bool ProcessCmd(int fd, const PbCommand &command)
 	string params = command.params().c_str();
 
 	ostringstream s;
-	s << "Processing: cmd=" << cmd << ", id=" << id << ", un=" << un << ", type=" << type << ", params=" << params << endl;
+	s << "Processing: cmd=" << PbOperation_Name(cmd) << ", id=" << id << ", un=" << un << ", type=" << PbDeviceType_Name(type) << ", params=" << params << endl;
 	LOGINFO("%s", s.str().c_str());
 
 	// Copy the Unit List
@@ -558,7 +558,7 @@ bool ProcessCmd(int fd, const PbCommand &command)
 				break;
 			default:
 				ostringstream error;
-				error << "rasctl sent a command for an invalid drive type: " << type;
+				error << "rasctl sent a command for an invalid drive type: " << PbDeviceType_Name(type);
 				return ReturnStatus(fd, false, error.str());
 		}
 
@@ -663,7 +663,7 @@ bool ProcessCmd(int fd, const PbCommand &command)
 
 		default:
 			ostringstream error;
-			error << "Received unknown command from rasctl: " << cmd;
+			error << "Received unknown command from rasctl: " << PbOperation_Name(cmd);
 			LOGWARN("%s", error.str().c_str());
 			return ReturnStatus(fd, false, error.str());
 	}

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -458,6 +458,35 @@ void SetLogLevel(const string& log_level) {
 	}
 }
 
+const char *GetLogLevel() {
+	switch (get_level()) {
+		case level::trace:
+			return "trace";
+
+		case level::debug:
+			return "debug";
+
+		case level::info:
+			return "info";
+
+		case level::warn:
+			return "warn";
+
+		case level::err:
+			return "err";
+
+		case level::critical:
+			return "critical";
+
+		case level::off:
+			return "off";
+
+		default:
+			assert(false);
+			return "";
+	}
+}
+
 void LogDeviceList(const string& device_list)
 {
 	stringstream ss(device_list);
@@ -852,6 +881,12 @@ static void *MonThread(void *param)
 			}
 			else if (command.cmd() == LOG_LEVEL) {
 				SetLogLevel(command.params());
+			}
+			else if (command.cmd() == SERVER_INFO) {
+				PbServerInfo serverInfo;
+				serverInfo.set_rascsi_version(rascsi_get_version_string());
+				serverInfo.set_log_level(GetLogLevel());
+				SerializeMessage(fd, serverInfo);
 			}
 			else {
 				// Wait until we become idle

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -431,9 +431,7 @@ bool ReturnStatus(int fd, bool status = true, const string msg = "") {
 	return status;
 }
 
-void SetLogLevel(const string& log_level) {
-	spdlog_log_level = log_level;
-
+bool SetLogLevel(const string& log_level) {
 	if (log_level == "trace") {
 		set_level(level::trace);
 	}
@@ -456,10 +454,12 @@ void SetLogLevel(const string& log_level) {
 		set_level(level::off);
 	}
 	else {
-		LOGWARN("Invalid log level '%s', falling back to 'trace'", log_level.c_str());
-		spdlog_log_level = "trace";
-		set_level(level::trace);
+		return false;
 	}
+
+	spdlog_log_level = log_level;
+
+	return true;
 }
 
 void LogDeviceList(const string& device_list)
@@ -776,7 +776,9 @@ bool ParseArgument(int argc, char* argv[], int& port)
 		id = -1;
 	}
 
-	SetLogLevel(log_level);
+	if (!SetLogLevel(log_level)) {
+		LOGWARN("Invalid log level '%s'", log_level.c_str());
+	}
 
 	// Display and log the device list
 	const PbDevices devices = GetDevices();
@@ -856,6 +858,15 @@ static void *MonThread(void *param)
 			}
 			else if (command.cmd() == LOG_LEVEL) {
 				SetLogLevel(command.params());
+				bool status = SetLogLevel(command.params());
+				if (!status) {
+					ostringstream error;
+					error << "Invalid log level: " << command.params();
+					ReturnStatus(fd, false, error.str());
+				}
+				else {
+					ReturnStatus(fd);
+				}
 			}
 			else if (command.cmd() == SERVER_INFO) {
 				PbServerInfo serverInfo;
@@ -908,6 +919,7 @@ int main(int argc, char* argv[])
 	struct sched_param schparam;
 
 	SetLogLevel("trace");
+
 	// Create a thread-safe stdout logger to process the log messages
 	auto logger = stdout_color_mt("rascsi stdout logger");
 

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -59,4 +59,6 @@ message PbDevices {
 message PbServerInfo {
     string rascsi_version = 1;
     string log_level = 2;
+    // Not used yet
+    string default_image_folder = 3;
 }

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -17,13 +17,14 @@ enum PbDeviceType {
 // rascsi remote operations
 enum PbOperation {
     NONE = 0;
-    LIST = 1;
-    ATTACH = 2;
-    DETACH = 3;
-    INSERT = 4;
-    EJECT = 5;
-    PROTECT = 6;
-    LOG_LEVEL = 7;
+    SERVER_INFO = 1;
+    LIST = 2;
+    ATTACH = 3;
+    DETACH = 4;
+    INSERT = 5;
+    EJECT = 6;
+    PROTECT = 7;
+    LOG_LEVEL = 8;
 }
 
 // Commands rascsi can execute
@@ -52,4 +53,10 @@ message PbDevice {
 
 message PbDevices {
     repeated PbDevice devices = 1;
+}
+
+// The rascsi server information
+message PbServerInfo {
+    string rascsi_version = 1;
+    string log_level = 2;
 }


### PR DESCRIPTION
rasctl can query the server information with the new '-s' option:

```
>rasctl -s
rascsi version: 21.99 --DEVELOPMENT BUILD--
rascsi log level: trace
```