### PR TITLE
Reject duplicate image files

### DIFF
--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -63,7 +63,7 @@ int monsocket;						// Monitor Socket
 pthread_t monthread;				// Monitor Thread
 pthread_mutex_t ctrl_mutex;					// Semaphore for the ctrl array
 static void *MonThread(void *param);
-set<string> files;
+set<string> files_in_use;
 
 //---------------------------------------------------------------------------
 //
@@ -564,12 +564,12 @@ bool ProcessCmd(int fd, const PbCommand &command)
 			// Strip the image file extension from device file names, so that device files can be used as drive images
 			string file = params.find("/dev/") ? params : params.substr(0, params.length() - 4);
 
-			if (files.find(file) != files.end()) {
+			if (files_in_use.find(file) != files_in_use.end()) {
 				ostringstream error;
 				error << "Image file '" << file << "' is already in use";
 				return ReturnStatus(fd, false, error.str());
 			}
-			files.insert(file);
+			files_in_use.insert(file);
 
 			// Set the Path
 			filepath.SetPath(file.c_str());
@@ -629,7 +629,7 @@ bool ProcessCmd(int fd, const PbCommand &command)
 			Filepath filepath;
 			pUnit->GetPath(filepath);
 
-			files.erase(filepath.GetPath());
+			files_in_use.erase(filepath.GetPath());
 		}
 
 		return ReturnStatus(fd, status, status ? "" : "Error : SASI and SCSI can't be mixed\n");

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -63,6 +63,7 @@ int monsocket;						// Monitor Socket
 pthread_t monthread;				// Monitor Thread
 pthread_mutex_t ctrl_mutex;					// Semaphore for the ctrl array
 static void *MonThread(void *param);
+set<string> files;
 
 //---------------------------------------------------------------------------
 //
@@ -563,6 +564,13 @@ bool ProcessCmd(int fd, const PbCommand &command)
 			// Strip the image file extension from device file names, so that device files can be used as drive images
 			string file = params.find("/dev/") ? params : params.substr(0, params.length() - 4);
 
+			if (files.find(file) != files.end()) {
+				ostringstream error;
+				error << "Image file '" << file << "' is already in use";
+				return ReturnStatus(fd, false, error.str());
+			}
+			files.insert(file);
+
 			// Set the Path
 			filepath.SetPath(file.c_str());
 
@@ -617,6 +625,13 @@ bool ProcessCmd(int fd, const PbCommand &command)
 
 		// Re-map the controller
 		bool status = MapController(map);
+		if (status) {
+			Filepath filepath;
+			pUnit->GetPath(filepath);
+
+			files.erase(filepath.GetPath());
+		}
+
 		return ReturnStatus(fd, status, status ? "" : "Error : SASI and SCSI can't be mixed\n");
 	}
 


### PR DESCRIPTION
Test results:

'''''
>./bin/fullspec/rasctl -l
No images currently attached.
>./bin/fullspec/rasctl -i 4 -t hd -c ATTACH -f /home/us/hatari/test.hds
>./bin/fullspec/rasctl -l

+----+----+------+-------------------------------------
| ID | UN | TYPE | DEVICE STATUS
+----+----+------+-------------------------------------
|  4 |  0 | SCHD | /home/us/hatari/test.hds
+----+----+------+-------------------------------------

>./bin/fullspec/rasctl -i 2 -t hd -c ATTACH -f /home/us/hatari/test.hds
Image file '/home/us/hatari/test.hds' is already in use

>./bin/fullspec/rasctl -i 4 -c DETACH

>./bin/fullspec/rasctl -l
No images currently attached.

>./bin/fullspec/rasctl -i 2 -t hd -c ATTACH -f /home/us/hatari/test.hds

>./bin/fullspec/rasctl -l

+----+----+------+-------------------------------------
| ID | UN | TYPE | DEVICE STATUS
+----+----+------+-------------------------------------
|  2 |  0 | SCHD | /home/us/hatari/test.hds
+----+----+------+-------------------------------------

>./bin/fullspec/rasctl -i 5 -t hd -c ATTACH -f /home/us/hatari/test.hds
Image file '/home/us/hatari/test.hds' is already in use

>./bin/fullspec/rasctl -l

+----+----+------+-------------------------------------
| ID | UN | TYPE | DEVICE STATUS
+----+----+------+-------------------------------------
|  2 |  0 | SCHD | /home/us/hatari/test.hds
+----+----+------+-------------------------------------

>./bin/fullspec/rasctl -i 5 -t hd -c ATTACH -f /home/us/hatari/scsi.hds

>./bin/fullspec/rasctl -l

+----+----+------+-------------------------------------
| ID | UN | TYPE | DEVICE STATUS
+----+----+------+-------------------------------------
|  2 |  0 | SCHD | /home/us/hatari/test.hds
|  5 |  0 | SCHD | /home/us/hatari/scsi.hds
+----+----+------+-------------------------------------
```