### PR TITLE
Feature testing improvement for X86 platforms

### DIFF
--- a/src/raspberrypi/xm6.h
+++ b/src/raspberrypi/xm6.h
@@ -25,7 +25,6 @@
 //	Various Operation Settings
 //
 //---------------------------------------------------------------------------
-#undef USE_SEL_EVENT_ENABLE
 #define USE_SEL_EVENT_ENABLE			// Check SEL signal by event
 #define REMOVE_FIXED_SASIHD_SIZE		// remove the size limitation of SASIHD
 #define USE_MZ1F23_1024_SUPPORT			// MZ-1F23 (SASI 20M/sector size 1024)

--- a/src/raspberrypi/xm6.h
+++ b/src/raspberrypi/xm6.h
@@ -25,9 +25,15 @@
 //	Various Operation Settings
 //
 //---------------------------------------------------------------------------
+#undef USE_SEL_EVENT_ENABLE
 #define USE_SEL_EVENT_ENABLE			// Check SEL signal by event
 #define REMOVE_FIXED_SASIHD_SIZE		// remove the size limitation of SASIHD
 #define USE_MZ1F23_1024_SUPPORT			// MZ-1F23 (SASI 20M/sector size 1024)
+// This avoids an indefinite loop with warnings if there is no RaSCSI hardware
+// and thus helps with running certain tests on X86 hardware.
+#if defined(__x86_64__) || defined(__X86__)
+#undef USE_SEL_EVENT_ENABLE
+#endif
 
 //---------------------------------------------------------------------------
 //


### PR DESCRIPTION
This minor change prevents polling for RaSCSI events on X86 hardware, which effectively suppress constant epoll failed warnings. This is useful for testing certain feature on X86 hardware, e.g. parsing of command line options, the protobuf interface etc.