### PR TITLE
Feature explicit device type (rascsi)

### DIFF
--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -57,7 +57,7 @@ Display the rascsi version.
 .BR \-ID\fIn " " \fIFILE[:TYPE]
 n is the SCSI ID number (0-7)
 .IP
-FILE is the name of the image file to attach to that ID. If FILE starts with '/dev/' the extension, which encodes the device type, is stripped, so that device files can conveniently be used as image files. An optional explicit device type (SASI_HD, SCSI_HD, CD, MO, BR, NUVOLINK, DAYNAPORT) can be provided after a colon.
+FILE is the name of the image file to attach to that ID. An optional explicit device type (SASI_HD, SCSI_HD, CD, MO, BR, NUVOLINK, DAYNAPORT) can be provided after a colon.
 .TP 
 .BR \-HD\fIn " " \fIFILE
 n is the SASI ID number (0-15)
@@ -73,8 +73,8 @@ Launch RaSCSI with no emulated drives attached:
 Launch RaSCSI with an Apple hard drive image as ID 0 and a CD-ROM as ID 2
    rascsi -ID0 /path/to/harddrive.hda -ID2 /path/to/cdimage.iso
 
-Launch RaSCSI with a SCSI hard drive image as ID 0 and the raw device file /dev/hdb (e.g. a USB stick) as an image file:
-   rascsi -ID0 /dev/hdb.hds
+Launch RaSCSI with a SCSI hard drive image as ID 0 and the raw device file /dev/hdb (e.g. a USB stick) as a SCSI hard disk image file:
+   rascsi -ID0 /dev/hdb:SCSI_HD
 
 To create an empty, 100MB HD image, use the following command:
    dd if=/dev/zero of=/path/to/newimage.hda bs=512 count=204800

--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -54,10 +54,10 @@ The rascsi server port, default is 6868.
 .BR \-v\fI " " \fI
 Display the rascsi version.
 .TP
-.BR \-ID\fIn " " \fIFILE
+.BR \-ID\fIn " " \fIFILE[:TYPE]
 n is the SCSI ID number (0-7)
 .IP
-FILE is the name of the image file to attach to that ID. If FILE starts with '/dev/' the extension, which encodes the device type, is stripped, so that device files can conveniently be used as image files.
+FILE is the name of the image file to attach to that ID. If FILE starts with '/dev/' the extension, which encodes the device type, is stripped, so that device files can conveniently be used as image files. An optional explicit device type (SASI_HD, SCSI_HD, CD, MO, BR, NUVOLINK, DAYNAPORT) can be provided after a colon.
 .TP 
 .BR \-HD\fIn " " \fIFILE
 n is the SASI ID number (0-15)

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -63,13 +63,15 @@ OPTIONS
 
        -v     Display the rascsi version.
 
-       -IDn FILE
+       -IDn FILE[:TYPE]
               n is the SCSI ID number (0-7)
 
               FILE is the name of the image file to attach to that ID. If FILE
               starts  with  '/dev/'  the  extension,  which encodes the device
               type, is stripped, so that device files can conveniently be used
-              as image files.
+              as  image  files.  An  optional  explicit  device type (SASI_HD,
+              SCSI_HD, CD, MO, BR, NUVOLINK, DAYNAPORT) can be provided  after
+              a colon.
 
        -HDn FILE
               n is the SASI ID number (0-15)

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -638,9 +638,6 @@ bool ProcessCmd(int fd, const PbCommand &command)
 
 		// drive checks files
 		if (type != BR && type != DAYNAPORT && !command.params().empty()) {
-			// Strip the image file extension from device file names, so that device files can be used as drive images
-			file = file.find("/dev/") ? file : file.substr(0, file.length() - 4);
-
 			// Set the Path
 			filepath.SetPath(file.c_str());
 

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -567,7 +567,11 @@ bool ProcessCmd(int fd, const PbCommand &command)
 		if (separatorPos != string::npos) {
 			string t = file.substr(separatorPos + 1);
 			transform(t.begin(), t.end(), t.begin(), ::toupper);
-			PbDeviceType_Parse(t, &type);
+
+			if (!PbDeviceType_Parse(t, &type)) {
+				error << "Invalid device type " << t;
+				return ReturnStatus(fd, false, error);
+			}
 
 			file = file.substr(0, separatorPos);
 		}


### PR DESCRIPTION
This change allows to explicitly specify an optional device type, which overrides the type derived from the filename. It's possible to create any device this way, also a daynaport device.

```
>rascsi -f /home/us/images -ID0 :DAYNAPORT -ID3 test.hds:cd
```

The type is case-insensitive.

Result:

```
+----+----+------+-------------------------------------
| ID | UN | TYPE | DEVICE STATUS
+----+----+------+-------------------------------------
|  0 |  0 | SCDP | DaynaPort SCSI/Link
|  3 |  0 | SCCD | /home/us/images/test.hds (WRITEPROTECT)
+----+----+------+-------------------------------------
```

I removed the device file work-around I added some time ago, because an explicit device type can be used instead.