### PR TITLE
Feature controller/device cleanup

### DIFF
--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -136,7 +136,7 @@ public:
 		// Transfer
 		BYTE *buffer;					// Transfer data buffer
 		int bufsize;					// Transfer data buffer size
-		DWORD blocks;					// Number of transfer block
+		uint32_t blocks;				// Number of transfer block
 		DWORD next;						// Next record
 		DWORD offset;					// Transfer offset
 		DWORD length;					// Transfer remaining length

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -177,6 +177,9 @@ public:
 	virtual BOOL IsSCSI() const {return FALSE;}			// SCSI check
 	Disk* GetBusyUnit();								// Get the busy unit
 
+public:
+	void DataIn();							// Data in phase
+
 protected:
 	// Phase processing
 	virtual void BusFree();					// Bus free phase
@@ -185,7 +188,6 @@ protected:
 	virtual void Execute();					// Execution phase
 	void Status();							// Status phase
 	void MsgIn();							// Message in phase
-	void DataIn();							// Data in phase
 	void DataOut();						// Data out phase
 	virtual void Error(ERROR_CODES::sense_key sense_key = ERROR_CODES::sense_key::NO_SENSE,
 			ERROR_CODES::asc = ERROR_CODES::asc::NO_ADDITIONAL_SENSE_INFORMATION);	// Common error handling

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -143,6 +143,8 @@ public:
 
 		// Logical unit
 		Disk *unit[UnitMax];
+
+		Disk *device;
 	} ctrl_t;
 
 public:
@@ -158,7 +160,7 @@ public:
 	void Connect(int id, BUS *sbus);				// Controller connection
 	Disk* GetUnit(int no);							// Get logical unit
 	void SetUnit(int no, Disk *dev);				// Logical unit setting
-	BOOL HasUnit();						// Has a valid logical unit
+	bool HasUnit();						// Has a valid logical unit
 
 	// Other
 	BUS::phase_t GetPhase() {return ctrl.phase;}			// Get the phase

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -669,17 +669,7 @@ void SCSIDEV::CmdReadCapacity16()
 	LOGTRACE( "%s READ CAPACITY(16) Command ", __PRETTY_FUNCTION__);
 
 	// Command processing on drive
-	int length = ctrl.device->ReadCapacity16(ctrl.cmd, ctrl.buffer);
-	if (length <= 0) {
-		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::MEDIUM_NOT_PRESENT);
-		return;
-	}
-
-	// Length setting
-	ctrl.length = length;
-
-	// Data-in Phase
-	DataIn();
+	ctrl.device->ReadCapacity16(this, &ctrl);
 }
 
 //---------------------------------------------------------------------------

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -697,35 +697,12 @@ void SCSIDEV::CmdRead10()
 	}
 
 	// Get record number and block number
-	DWORD record = ctrl.cmd[2];
-	record <<= 8;
-	record |= ctrl.cmd[3];
-	record <<= 8;
-	record |= ctrl.cmd[4];
-	record <<= 8;
-	record |= ctrl.cmd[5];
-	ctrl.blocks = ctrl.cmd[7];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[8];
-
-	// Check capacity
-	DWORD capacity = ctrl.device->GetBlockCount();
-	if (record > capacity || record + ctrl.blocks > capacity) {
-		ostringstream s;
-		s << "Media capacity of " << capacity << " blocks exceeded: "
-				<< "Trying to read block " << record << ", block count " << ctrl.blocks;
-		LOGWARN("%s", s.str().c_str());
-		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
+	uint64_t record;
+	if (!GetStartAndCount(record, ctrl.blocks, false)) {
 		return;
 	}
 
 	LOGTRACE("%s READ(10) command record=%d blocks=%d", __PRETTY_FUNCTION__, (unsigned int)record, (int)ctrl.blocks);
-
-	// Do not process 0 blocks
-	if (ctrl.blocks == 0) {
-		Status();
-		return;
-	}
 
 	// Command processing on drive
 	ctrl.length = ctrl.device->Read(ctrl.cmd, ctrl.buffer, record);
@@ -756,47 +733,13 @@ void SCSIDEV::CmdRead16()
 		return;
 	}
 
-	// Report an error as long as big drives are not supported
-	if (ctrl.cmd[2] || ctrl.cmd[3] || ctrl.cmd[4] || ctrl.cmd[5]) {
-		LOGWARN("Can't execute READ(16) with 64 bit sector number");
-		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
-		return;
-	}
-
 	// Get record number and block number
-	DWORD record = ctrl.cmd[6];
-	record <<= 8;
-	record |= ctrl.cmd[7];
-	record <<= 8;
-	record |= ctrl.cmd[8];
-	record <<= 8;
-	record |= ctrl.cmd[9];
-	ctrl.blocks = ctrl.cmd[10];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[11];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[12];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[13];
-
-	// Check capacity
-	DWORD capacity = ctrl.device->GetBlockCount();
-	if (record > capacity || record + ctrl.blocks > capacity) {
-		ostringstream s;
-		s << "Media capacity of " << capacity << " blocks exceeded: "
-				<< "Trying to read block " << record << ", block count " << ctrl.blocks;
-		LOGWARN("%s", s.str().c_str());
-		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
+	uint64_t record;
+	if (!GetStartAndCount(record, ctrl.blocks, true)) {
 		return;
 	}
 
 	LOGTRACE("%s READ(16) command record=%d blocks=%d", __PRETTY_FUNCTION__, (unsigned int)record, (int)ctrl.blocks);
-
-	// Do not process 0 blocks
-	if (ctrl.blocks == 0) {
-		Status();
-		return;
-	}
 
 	// Command processing on drive
 	ctrl.length = ctrl.device->Read(ctrl.cmd, ctrl.buffer, record);
@@ -828,35 +771,12 @@ void SCSIDEV::CmdWrite10()
 	}
 
 	// Get record number and block number
-	DWORD record = ctrl.cmd[2];
-	record <<= 8;
-	record |= ctrl.cmd[3];
-	record <<= 8;
-	record |= ctrl.cmd[4];
-	record <<= 8;
-	record |= ctrl.cmd[5];
-	ctrl.blocks = ctrl.cmd[7];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[8];
-
-	// Check capacity
-	DWORD capacity = ctrl.device->GetBlockCount();
-	if (record > capacity || record + ctrl.blocks > capacity) {
-		ostringstream s;
-		s << "Media capacity of " << capacity << " blocks exceeded: "
-				<< "Trying to read block " << record << ", block count " << ctrl.blocks;
-		LOGWARN("%s", s.str().c_str());
-		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
+	uint64_t record;
+	if (!GetStartAndCount(record, ctrl.blocks, false)) {
 		return;
 	}
 
 	LOGTRACE("%s WRITE(10) command record=%d blocks=%d",__PRETTY_FUNCTION__, (unsigned int)record, (unsigned int)ctrl.blocks);
-
-	// Do not process 0 blocks
-	if (ctrl.blocks == 0) {
-		Status();
-		return;
-	}
 
 	// Command processing on drive
 	ctrl.length = ctrl.device->WriteCheck(record);
@@ -887,47 +807,13 @@ void SCSIDEV::CmdWrite16()
 		return;
 	}
 
-	// Report an error as long as big drives are not supported
-	if (ctrl.cmd[2] || ctrl.cmd[3] || ctrl.cmd[4] || ctrl.cmd[5]) {
-		LOGWARN("Can't execute WRITE(16) with 64 bit sector number");
-		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
-		return;
-	}
-
 	// Get record number and block number
-	DWORD record = ctrl.cmd[6];
-	record <<= 8;
-	record |= ctrl.cmd[7];
-	record <<= 8;
-	record |= ctrl.cmd[8];
-	record <<= 8;
-	record |= ctrl.cmd[9];
-	ctrl.blocks = ctrl.cmd[10];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[11];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[12];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[13];
-
-	// Check capacity
-	DWORD capacity = ctrl.device->GetBlockCount();
-	if (record > capacity || record + ctrl.blocks > capacity) {
-		ostringstream s;
-		s << "Media capacity of " << capacity << " blocks exceeded: "
-				<< "Trying to read block " << record << ", block count " << ctrl.blocks;
-		LOGWARN("%s", s.str().c_str());
-		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
+	uint64_t record;
+	if (!GetStartAndCount(record, ctrl.blocks, true)) {
 		return;
 	}
 
 	LOGTRACE("%s WRITE(16) command record=%d blocks=%d",__PRETTY_FUNCTION__, (unsigned int)record, (unsigned int)ctrl.blocks);
-
-	// Do not process 0 blocks
-	if (ctrl.blocks == 0) {
-		Status();
-		return;
-	}
 
 	// Command processing on drive
 	ctrl.length = ctrl.device->WriteCheck(record);
@@ -972,32 +858,16 @@ void SCSIDEV::CmdSeek10()
 //---------------------------------------------------------------------------
 void SCSIDEV::CmdVerify()
 {
-	bool status;
-
 	// Get record number and block number
-	DWORD record = ctrl.cmd[2];
-	record <<= 8;
-	record |= ctrl.cmd[3];
-	record <<= 8;
-	record |= ctrl.cmd[4];
-	record <<= 8;
-	record |= ctrl.cmd[5];
-	ctrl.blocks = ctrl.cmd[7];
-	ctrl.blocks <<= 8;
-	ctrl.blocks |= ctrl.cmd[8];
+	uint64_t record;
+	GetStartAndCount(record, ctrl.blocks, false);
 
 	LOGTRACE("%s VERIFY command record=%08X blocks=%d",__PRETTY_FUNCTION__, (unsigned int)record, (int)ctrl.blocks);
-
-	// Do not process 0 blocks
-	if (ctrl.blocks == 0) {
-		Status();
-		return;
-	}
 
 	// if BytChk=0
 	if ((ctrl.cmd[1] & 0x02) == 0) {
 		// Command processing on drive
-		status = ctrl.device->Seek(ctrl.cmd);
+		bool status = ctrl.device->Seek(ctrl.cmd);
 		if (!status) {
 			// Failure (Error)
 			Error();
@@ -1776,4 +1646,65 @@ BOOL SCSIDEV::XferMsg(DWORD msg)
 	}
 
 	return TRUE;
+}
+
+//---------------------------------------------------------------------------
+//
+//	Get start sector and sector count for a READ/WRITE(10/16) operation
+//
+//---------------------------------------------------------------------------
+bool SCSIDEV::GetStartAndCount(uint64_t& start, uint32_t& count, bool rw64)
+{
+	start = ctrl.cmd[2];
+	start <<= 8;
+	start |= ctrl.cmd[3];
+	start <<= 8;
+	start |= ctrl.cmd[4];
+	start <<= 8;
+	start |= ctrl.cmd[5];
+	if (rw64) {
+		start <<= 8;
+		start |= ctrl.cmd[6];
+		start <<= 8;
+		start |= ctrl.cmd[7];
+		start <<= 8;
+		start |= ctrl.cmd[8];
+		start <<= 8;
+		start |= ctrl.cmd[9];
+	}
+
+	if (rw64) {
+		count = ctrl.cmd[10];
+		count <<= 8;
+		count |= ctrl.cmd[11];
+		count <<= 8;
+		count |= ctrl.cmd[12];
+		count <<= 8;
+		count |= ctrl.cmd[13];
+	}
+	else {
+		count = ctrl.cmd[7];
+		count <<= 8;
+		count |= ctrl.cmd[8];
+	}
+
+	// Check capacity
+	uint64_t capacity = ctrl.device->GetBlockCount();
+	if (start > capacity || start + count > capacity) {
+		ostringstream s;
+		s << "Media capacity of " << capacity << " blocks exceeded: "
+				<< "Trying to read block " << start << ", block count " << ctrl.blocks;
+		LOGWARN("%s", s.str().c_str());
+		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
+		return false;
+	}
+
+	// Do not process 0 blocks
+	if (!count) {
+		LOGTRACE("NOT processing 0 blocks");
+		Status();
+		return false;
+	}
+
+	return true;
 }

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -651,17 +651,7 @@ void SCSIDEV::CmdReadCapacity10()
 	LOGTRACE( "%s READ CAPACITY(10) Command ", __PRETTY_FUNCTION__);
 
 	// Command processing on drive
-	int length = ctrl.device->ReadCapacity10(ctrl.cmd, ctrl.buffer);
-	if (length <= 0) {
-		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::MEDIUM_NOT_PRESENT);
-		return;
-	}
-
-	// Length setting
-	ctrl.length = length;
-
-	// Data-in Phase
-	DataIn();
+	ctrl.device->ReadCapacity10(this, &ctrl);
 }
 
 void SCSIDEV::CmdReadCapacity16()

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -42,64 +42,73 @@ SCSIDEV::SCSIDEV() : SASIDEV()
 	scsi.msc = 0;
 	memset(scsi.msb, 0x00, sizeof(scsi.msb));
 
-	SetUpCommand(eCmdTestUnitReady, "CmdTestUnitReady", &SCSIDEV::CmdTestUnitReady);
-	SetUpCommand(eCmdRezero, "CmdRezero", &SCSIDEV::CmdRezero);
-	SetUpCommand(eCmdRequestSense, "CmdRequestSense", &SCSIDEV::CmdRequestSense);
-	SetUpCommand(eCmdFormat, "CmdFormat", &SCSIDEV::CmdFormat);
-	SetUpCommand(eCmdReassign, "CmdReassign", &SCSIDEV::CmdReassign);
-	SetUpCommand(eCmdRead6, "CmdRead6", &SCSIDEV::CmdRead6);
-	SetUpCommand(eCmdWrite6, "CmdWrite6", &SCSIDEV::CmdWrite6);
-	SetUpCommand(eCmdSeek6, "CmdSeek6", &SCSIDEV::CmdSeek6);
-	SetUpCommand(eCmdInquiry, "CmdInquiry", &SCSIDEV::CmdInquiry);
-	SetUpCommand(eCmdModeSelect, "CmdModeSelect", &SCSIDEV::CmdModeSelect);
-	SetUpCommand(eCmdReserve6, "CmdReserve6", &SCSIDEV::CmdReserve6);
-	SetUpCommand(eCmdRelease6, "CmdRelease6", &SCSIDEV::CmdRelease6);
-	SetUpCommand(eCmdModeSense, "CmdModeSense", &SCSIDEV::CmdModeSense);
-	SetUpCommand(eCmdStartStop, "CmdStartStop", &SCSIDEV::CmdStartStop);
-	SetUpCommand(eCmdSendDiag, "CmdSendDiag", &SCSIDEV::CmdSendDiag);
-	SetUpCommand(eCmdRemoval, "CmdRemoval", &SCSIDEV::CmdRemoval);
-	SetUpCommand(eCmdReadCapacity10, "CmdReadCapacity10", &SCSIDEV::CmdReadCapacity10);
-	SetUpCommand(eCmdRead10, "CmdRead10", &SCSIDEV::CmdRead10);
-	SetUpCommand(eCmdWrite10, "CmdWrite10", &SCSIDEV::CmdWrite10);
-	SetUpCommand(eCmdVerify10, "CmdVerify10", &SCSIDEV::CmdWrite10);
-	SetUpCommand(eCmdSeek10, "CmdSeek10", &SCSIDEV::CmdSeek10);
-	SetUpCommand(eCmdVerify, "CmdVerify", &SCSIDEV::CmdVerify);
-	SetUpCommand(eCmdSynchronizeCache, "CmdSynchronizeCache", &SCSIDEV::CmdSynchronizeCache);
-	SetUpCommand(eCmdReadDefectData10, "CmdReadDefectData10", &SCSIDEV::CmdReadDefectData10);
-	SetUpCommand(eCmdModeSelect10, "CmdModeSelect10", &SCSIDEV::CmdModeSelect10);
-	SetUpCommand(eCmdReserve10, "CmdReserve10", &SCSIDEV::CmdReserve10);
-	SetUpCommand(eCmdRelease10, "CmdRelease10", &SCSIDEV::CmdRelease10);
-	SetUpCommand(eCmdModeSense10, "CmdModeSense10", &SCSIDEV::CmdModeSense10);
-	SetUpCommand(eCmdRead16, "CmdRead16", &SCSIDEV::CmdRead16);
-	SetUpCommand(eCmdWrite16, "CmdWrite16", &SCSIDEV::CmdWrite16);
-	SetUpCommand(eCmdVerify16, "CmdVerify16", &SCSIDEV::CmdWrite16);
-	SetUpCommand(eCmdReadCapacity16, "CmdReadCapacity16", &SCSIDEV::CmdReadCapacity16);
-	SetUpCommand(eCmdReportLuns, "CmdReportLuns", &SCSIDEV::CmdReportLuns);
+	SetUpControllerCommand(eCmdTestUnitReady, "CmdTestUnitReady", &SCSIDEV::CmdTestUnitReady);
+	SetUpControllerCommand(eCmdRezero, "CmdRezero", &SCSIDEV::CmdRezero);
+	SetUpControllerCommand(eCmdRequestSense, "CmdRequestSense", &SCSIDEV::CmdRequestSense);
+	SetUpControllerCommand(eCmdFormat, "CmdFormat", &SCSIDEV::CmdFormat);
+	SetUpControllerCommand(eCmdReassign, "CmdReassign", &SCSIDEV::CmdReassign);
+	SetUpControllerCommand(eCmdRead6, "CmdRead6", &SCSIDEV::CmdRead6);
+	SetUpControllerCommand(eCmdWrite6, "CmdWrite6", &SCSIDEV::CmdWrite6);
+	SetUpControllerCommand(eCmdSeek6, "CmdSeek6", &SCSIDEV::CmdSeek6);
+	SetUpControllerCommand(eCmdInquiry, "CmdInquiry", &SCSIDEV::CmdInquiry);
+	SetUpControllerCommand(eCmdModeSelect, "CmdModeSelect", &SCSIDEV::CmdModeSelect);
+	SetUpControllerCommand(eCmdReserve6, "CmdReserve6", &SCSIDEV::CmdReserve6);
+	SetUpControllerCommand(eCmdRelease6, "CmdRelease6", &SCSIDEV::CmdRelease6);
+	SetUpControllerCommand(eCmdModeSense, "CmdModeSense", &SCSIDEV::CmdModeSense);
+	SetUpControllerCommand(eCmdStartStop, "CmdStartStop", &SCSIDEV::CmdStartStop);
+	SetUpControllerCommand(eCmdSendDiag, "CmdSendDiag", &SCSIDEV::CmdSendDiag);
+	SetUpControllerCommand(eCmdRemoval, "CmdRemoval", &SCSIDEV::CmdRemoval);
+	SetUpDeviceCommand(eCmdReadCapacity10, "CmdReadCapacity10", &Disk::ReadCapacity10);
+	SetUpControllerCommand(eCmdRead10, "CmdRead10", &SCSIDEV::CmdRead10);
+	SetUpControllerCommand(eCmdWrite10, "CmdWrite10", &SCSIDEV::CmdWrite10);
+	SetUpControllerCommand(eCmdVerify10, "CmdVerify10", &SCSIDEV::CmdWrite10);
+	SetUpControllerCommand(eCmdSeek10, "CmdSeek10", &SCSIDEV::CmdSeek10);
+	SetUpControllerCommand(eCmdVerify, "CmdVerify", &SCSIDEV::CmdVerify);
+	SetUpControllerCommand(eCmdSynchronizeCache, "CmdSynchronizeCache", &SCSIDEV::CmdSynchronizeCache);
+	SetUpControllerCommand(eCmdReadDefectData10, "CmdReadDefectData10", &SCSIDEV::CmdReadDefectData10);
+	SetUpControllerCommand(eCmdModeSelect10, "CmdModeSelect10", &SCSIDEV::CmdModeSelect10);
+	SetUpControllerCommand(eCmdReserve10, "CmdReserve10", &SCSIDEV::CmdReserve10);
+	SetUpControllerCommand(eCmdRelease10, "CmdRelease10", &SCSIDEV::CmdRelease10);
+	SetUpControllerCommand(eCmdModeSense10, "CmdModeSense10", &SCSIDEV::CmdModeSense10);
+	SetUpControllerCommand(eCmdRead16, "CmdRead16", &SCSIDEV::CmdRead16);
+	SetUpControllerCommand(eCmdWrite16, "CmdWrite16", &SCSIDEV::CmdWrite16);
+	SetUpControllerCommand(eCmdVerify16, "CmdVerify16", &SCSIDEV::CmdWrite16);
+	SetUpDeviceCommand(eCmdReadCapacity16, "CmdReadCapacity16", &Disk::ReadCapacity16);
+	SetUpControllerCommand(eCmdReportLuns, "CmdReportLuns", &SCSIDEV::CmdReportLuns);
 
 	// MMC specific. TODO Move to separate class
-	SetUpCommand(eCmdReadToc, "CmdReadToc", &SCSIDEV::CmdReadToc);
-	SetUpCommand(eCmdPlayAudio10, "CmdPlayAudio10", &SCSIDEV::CmdPlayAudio10);
-	SetUpCommand(eCmdPlayAudioMSF, "CmdPlayAudioMSF", &SCSIDEV::CmdPlayAudioMSF);
-	SetUpCommand(eCmdPlayAudioTrack, "CmdPlayAudioTrack", &SCSIDEV::CmdPlayAudioTrack);
-	SetUpCommand(eCmdGetEventStatusNotification, "CmdGetEventStatusNotification", &SCSIDEV::CmdGetEventStatusNotification);
+	SetUpControllerCommand(eCmdReadToc, "CmdReadToc", &SCSIDEV::CmdReadToc);
+	SetUpControllerCommand(eCmdPlayAudio10, "CmdPlayAudio10", &SCSIDEV::CmdPlayAudio10);
+	SetUpControllerCommand(eCmdPlayAudioMSF, "CmdPlayAudioMSF", &SCSIDEV::CmdPlayAudioMSF);
+	SetUpControllerCommand(eCmdPlayAudioTrack, "CmdPlayAudioTrack", &SCSIDEV::CmdPlayAudioTrack);
+	SetUpControllerCommand(eCmdGetEventStatusNotification, "CmdGetEventStatusNotification", &SCSIDEV::CmdGetEventStatusNotification);
 
 	// DaynaPort specific. TODO Move to separate class
-	SetUpCommand(eCmdRetrieveStats, "CmdRetrieveStats", &SCSIDEV::CmdRetrieveStats);
-	SetUpCommand(eCmdSetIfaceMode, "CmdSetIfaceMode", &SCSIDEV::CmdSetIfaceMode);
-	SetUpCommand(eCmdSetMcastAddr, "CmdSetMcastAddr", &SCSIDEV::CmdSetMcastAddr);
-	SetUpCommand(eCmdEnableInterface, "CmdEnableInterface", &SCSIDEV::CmdEnableInterface);
+	SetUpControllerCommand(eCmdRetrieveStats, "CmdRetrieveStats", &SCSIDEV::CmdRetrieveStats);
+	SetUpControllerCommand(eCmdSetIfaceMode, "CmdSetIfaceMode", &SCSIDEV::CmdSetIfaceMode);
+	SetUpControllerCommand(eCmdSetMcastAddr, "CmdSetMcastAddr", &SCSIDEV::CmdSetMcastAddr);
+	SetUpControllerCommand(eCmdEnableInterface, "CmdEnableInterface", &SCSIDEV::CmdEnableInterface);
 }
 
 SCSIDEV::~SCSIDEV()
 {
-	for (auto const& command : scsi_commands) {
+	for (auto const& command : controller_commands) {
+		free(command.second);
+	}
+
+	for (auto const& command : device_commands) {
 		free(command.second);
 	}
 }
 
-void SCSIDEV::SetUpCommand(scsi_command opcode, const char* name, void (SCSIDEV::*execute)(void))
+void SCSIDEV::SetUpControllerCommand(scsi_command opcode, const char* name, void (SCSIDEV::*execute)(void))
 {
-	scsi_commands[opcode] = new command_t(name, execute);
+	controller_commands[opcode] = new controller_command_t(name, execute);
+}
+
+void SCSIDEV::SetUpDeviceCommand(scsi_command opcode, const char* name, void (Disk::*execute)(SCSIDEV *, SASIDEV::ctrl_t *))
+{
+	device_commands[opcode] = new device_command_t(name, execute);
 }
 
 //---------------------------------------------------------------------------
@@ -296,12 +305,6 @@ void SCSIDEV::Execute()
 	ctrl.blocks = 1;
 	ctrl.execstart = SysTimer::GetTimerLow();
 
-	// If the command is valid it must be contained in the command map
-	if (!scsi_commands.count(static_cast<scsi_command>(ctrl.cmd[0]))) {
-		CmdInvalid();
-		return;
-	}
-
 	ctrl.device = NULL;
 
 	// INQUIRY requires a special LUN handling
@@ -309,7 +312,23 @@ void SCSIDEV::Execute()
 		ctrl.device = ctrl.unit[GetLun()];
 	}
 
-	command_t* command = scsi_commands[static_cast<scsi_command>(ctrl.cmd[0])];
+	if (device_commands.count(static_cast<scsi_command>(ctrl.cmd[0]))) {
+		device_command_t *command = device_commands[static_cast<scsi_command>(ctrl.cmd[0])];
+
+		LOGDEBUG("++++ CMD ++++ %s ID %d received %s ($%02X)", __PRETTY_FUNCTION__, GetSCSIID(), command->name, (unsigned int)ctrl.cmd[0]);
+
+		(ctrl.device->*command->execute)(this, &ctrl);
+
+		return;
+	}
+
+	// If the command is valid it must be contained in the command map
+	if (!controller_commands.count(static_cast<scsi_command>(ctrl.cmd[0]))) {
+		CmdInvalid();
+		return;
+	}
+
+	controller_command_t* command = controller_commands[static_cast<scsi_command>(ctrl.cmd[0])];
 
 	LOGDEBUG("++++ CMD ++++ %s ID %d received %s ($%02X)", __PRETTY_FUNCTION__, GetSCSIID(), command->name, (unsigned int)ctrl.cmd[0]);
 
@@ -639,27 +658,6 @@ void SCSIDEV::CmdRemoval()
 
 	// status phase
 	Status();
-}
-
-//---------------------------------------------------------------------------
-//
-//	READ CAPACITY
-//
-//---------------------------------------------------------------------------
-void SCSIDEV::CmdReadCapacity10()
-{
-	LOGTRACE( "%s READ CAPACITY(10) Command ", __PRETTY_FUNCTION__);
-
-	// Command processing on drive
-	ctrl.device->ReadCapacity10(this, &ctrl);
-}
-
-void SCSIDEV::CmdReadCapacity16()
-{
-	LOGTRACE( "%s READ CAPACITY(16) Command ", __PRETTY_FUNCTION__);
-
-	// Command processing on drive
-	ctrl.device->ReadCapacity16(this, &ctrl);
 }
 
 //---------------------------------------------------------------------------

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -712,7 +712,7 @@ void SCSIDEV::CmdRead10()
 	DWORD capacity = ctrl.device->GetBlockCount();
 	if (record > capacity || record + ctrl.blocks > capacity) {
 		ostringstream s;
-		s << "ID " << GetSCSIID() << ": Media capacity of " << capacity << " blocks exceeded: "
+		s << "Media capacity of " << capacity << " blocks exceeded: "
 				<< "Trying to read block " << record << ", block count " << ctrl.blocks;
 		LOGWARN("%s", s.str().c_str());
 		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
@@ -783,7 +783,7 @@ void SCSIDEV::CmdRead16()
 	DWORD capacity = ctrl.device->GetBlockCount();
 	if (record > capacity || record + ctrl.blocks > capacity) {
 		ostringstream s;
-		s << "ID " << GetSCSIID() << ": Media capacity of " << capacity << " blocks exceeded: "
+		s << "Media capacity of " << capacity << " blocks exceeded: "
 				<< "Trying to read block " << record << ", block count " << ctrl.blocks;
 		LOGWARN("%s", s.str().c_str());
 		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
@@ -843,7 +843,7 @@ void SCSIDEV::CmdWrite10()
 	DWORD capacity = ctrl.device->GetBlockCount();
 	if (record > capacity || record + ctrl.blocks > capacity) {
 		ostringstream s;
-		s << "ID " << GetSCSIID() << ": Media capacity of " << capacity << " blocks exceeded: "
+		s << "Media capacity of " << capacity << " blocks exceeded: "
 				<< "Trying to read block " << record << ", block count " << ctrl.blocks;
 		LOGWARN("%s", s.str().c_str());
 		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);
@@ -914,7 +914,7 @@ void SCSIDEV::CmdWrite16()
 	DWORD capacity = ctrl.device->GetBlockCount();
 	if (record > capacity || record + ctrl.blocks > capacity) {
 		ostringstream s;
-		s << "ID " << GetSCSIID() << ": Media capacity of " << capacity << " blocks exceeded: "
+		s << "Media capacity of " << capacity << " blocks exceeded: "
 				<< "Trying to read block " << record << ", block count " << ctrl.blocks;
 		LOGWARN("%s", s.str().c_str());
 		Error(ERROR_CODES::sense_key::ILLEGAL_REQUEST, ERROR_CODES::asc::LBA_OUT_OF_RANGE);

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -66,6 +66,9 @@ public:
 	BOOL IsSASI() const {return FALSE;}				// SASI Check
 	BOOL IsSCSI() const {return TRUE;}				// SCSI check
 
+	void Error(ERROR_CODES::sense_key sense_key = ERROR_CODES::sense_key::NO_SENSE,
+			ERROR_CODES::asc asc = ERROR_CODES::asc::NO_ADDITIONAL_SENSE_INFORMATION);	// Common erorr handling
+
 private:
 	void SetUpCommand(scsi_command, const char*, void (SCSIDEV::*)(void));
 
@@ -74,8 +77,6 @@ private:
 	void Selection();						// Selection phase
 	void Execute();						// Execution phase
 	void MsgOut();							// Message out phase
-	void Error(ERROR_CODES::sense_key sense_key = ERROR_CODES::sense_key::NO_SENSE,
-			ERROR_CODES::asc asc = ERROR_CODES::asc::NO_ADDITIONAL_SENSE_INFORMATION);	// Common erorr handling
 
 	// commands
 	void CmdInquiry();						// INQUIRY command

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -40,15 +40,21 @@ public:
 	} scsi_t;
 
 	// SCSI command name and pointer to implementation
-	typedef struct _command_t {
+	typedef struct _controller_command_t {
 		const char* name;
 		void (SCSIDEV::*execute)(void);
 
-		_command_t(const char* _name, void (SCSIDEV::*_execute)(void)) : name(_name), execute(_execute) { };
-	} command_t;
+		_controller_command_t(const char* _name, void (SCSIDEV::*_execute)(void)) : name(_name), execute(_execute) { };
+	} controller_command_t;
+	std::map<scsi_command, controller_command_t*> controller_commands;
 
-	// Mapping of SCSI opcodes to command implementations
-	std::map<scsi_command, command_t*> scsi_commands;
+	typedef struct _device_command_t {
+		const char* name;
+		void (Disk::*execute)(SCSIDEV *, SASIDEV::ctrl_t *);
+
+		_device_command_t(const char* _name, void (Disk::*_execute)(SCSIDEV *, SASIDEV::ctrl_t *)) : name(_name), execute(_execute) { };
+	} device_command_t;
+	std::map<scsi_command, device_command_t*> device_commands;
 
 public:
 	// Basic Functions
@@ -70,7 +76,8 @@ public:
 			ERROR_CODES::asc asc = ERROR_CODES::asc::NO_ADDITIONAL_SENSE_INFORMATION);	// Common erorr handling
 
 private:
-	void SetUpCommand(scsi_command, const char*, void (SCSIDEV::*)(void));
+	void SetUpControllerCommand(scsi_command, const char*, void (SCSIDEV::*)(void));
+	void SetUpDeviceCommand(scsi_command, const char*, void (Disk::*)(SCSIDEV *, SASIDEV::ctrl_t *));
 
 	// Phase
 	void BusFree();						// Bus free phase
@@ -89,7 +96,6 @@ private:
 	void CmdStartStop();						// START STOP UNIT command
 	void CmdSendDiag();						// SEND DIAGNOSTIC command
 	void CmdRemoval();						// PREVENT/ALLOW MEDIUM REMOVAL command
-	void CmdReadCapacity10();					// READ CAPACITY(10) command
 	void CmdRead10();						// READ(10) command
 	void CmdWrite10();						// WRITE(10) command
 	void CmdSeek10();						// SEEK(10) command
@@ -103,7 +109,6 @@ private:
 	void CmdGetEventStatusNotification();
 	void CmdModeSelect10();					// MODE SELECT(10) command
 	void CmdModeSense10();						// MODE SENSE(10) command
-	void CmdReadCapacity16();					// READ CAPACITY(16) command
 	void CmdRead16();						// READ(16) command
 	void CmdWrite16();						// WRITE(16) command
 	void CmdReportLuns();					// REPORT LUNS command

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -117,6 +117,8 @@ private:
 	void Receive();						// Receive data
 	BOOL XferMsg(DWORD msg);					// Data transfer message
 
+	bool GetStartAndCount(uint64_t&, uint32_t&, bool);
+
 	scsi_t scsi;								// Internal data
 };
 

--- a/src/raspberrypi/devices/block_device.h
+++ b/src/raspberrypi/devices/block_device.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "controllers/sasidev_ctrl.h"
+#include "controllers/scsidev_ctrl.h"
 #include "primary_device.h"
 
 class BlockDevice : public PrimaryDevice
@@ -30,7 +32,7 @@ public:
 	// WRITE(6), WRITE(10)
 	virtual bool Write(const DWORD *cdb, const BYTE *buf, DWORD block) = 0;
 	virtual int ReadCapacity10(const DWORD *cdb, BYTE *buf) = 0;
-	virtual int ReadCapacity16(const DWORD *cdb, BYTE *buf) = 0;
+	virtual void ReadCapacity16(SCSIDEV *, SASIDEV::ctrl_t *) = 0;
 	// TODO Uncomment as soon as there is a clean separation between controllers and devices
 	//virtual int Read16(const DWORD *cdb, BYTE *buf, DWORD block) = 0;
 	//virtual int Write16(const DWORD *cdb, BYTE *buf, DWORD block) = 0;

--- a/src/raspberrypi/devices/block_device.h
+++ b/src/raspberrypi/devices/block_device.h
@@ -31,7 +31,7 @@ public:
 	virtual int Read(const DWORD *cdb, BYTE *buf, DWORD block) = 0;
 	// WRITE(6), WRITE(10)
 	virtual bool Write(const DWORD *cdb, const BYTE *buf, DWORD block) = 0;
-	virtual int ReadCapacity10(const DWORD *cdb, BYTE *buf) = 0;
+	virtual void ReadCapacity10(SCSIDEV *, SASIDEV::ctrl_t *) = 0;
 	virtual void ReadCapacity16(SCSIDEV *, SASIDEV::ctrl_t *) = 0;
 	// TODO Uncomment as soon as there is a clean separation between controllers and devices
 	//virtual int Read16(const DWORD *cdb, BYTE *buf, DWORD block) = 0;

--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -1740,6 +1740,8 @@ bool Disk::Removal(const DWORD *cdb)
 //---------------------------------------------------------------------------
 void Disk::ReadCapacity10(SCSIDEV *controller, SASIDEV::ctrl_t *ctrl)
 {
+	LOGTRACE( "%s READ CAPACITY(10) Command ", __PRETTY_FUNCTION__);
+
 	BYTE *buf = ctrl->buffer;
 
 	ASSERT(buf);
@@ -1784,6 +1786,8 @@ void Disk::ReadCapacity10(SCSIDEV *controller, SASIDEV::ctrl_t *ctrl)
 
 void Disk::ReadCapacity16(SCSIDEV *controller, SASIDEV::ctrl_t *ctrl)
 {
+	LOGTRACE( "%s READ CAPACITY(16) Command ", __PRETTY_FUNCTION__);
+
 	BYTE *buf = ctrl->buffer;
 
 	ASSERT(buf);

--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -1555,12 +1555,6 @@ int Disk::Read(const DWORD *cdb, BYTE *buf, DWORD block)
 		return 0;
 	}
 
-	// Error if the total number of blocks is exceeded
-	if (block >= disk.blocks) {
-		SetStatusCode(STATUS_INVALIDLBA);
-		return 0;
-	}
-
 	// leave it to the cache
 	if (!disk.dcache->Read(buf, block)) {
 		SetStatusCode(STATUS_READFAULT);
@@ -1581,12 +1575,6 @@ int Disk::WriteCheck(DWORD block)
 	// Status check
 	if (!CheckReady()) {
 		LOGDEBUG("WriteCheck failed (not ready)");
-		return 0;
-	}
-
-	// Error if the total number of blocks is exceeded
-	if (block >= disk.blocks) {
-		LOGDEBUG("WriteCheck failed (capacity exceeded)");
 		return 0;
 	}
 
@@ -1615,12 +1603,6 @@ bool Disk::Write(const DWORD *cdb, const BYTE *buf, DWORD block)
 	// Error if not ready
 	if (!IsReady()) {
 		SetStatusCode(STATUS_NOTREADY);
-		return false;
-	}
-
-	// Error if the total number of blocks is exceeded
-	if (block >= disk.blocks) {
-		SetStatusCode(STATUS_INVALIDLBA);
 		return false;
 	}
 

--- a/src/raspberrypi/devices/disk.h
+++ b/src/raspberrypi/devices/disk.h
@@ -168,7 +168,7 @@ public:
 	bool StartStop(const DWORD *cdb);				// START STOP UNIT command
 	bool SendDiag(const DWORD *cdb);				// SEND DIAGNOSTIC command
 	bool Removal(const DWORD *cdb);				// PREVENT/ALLOW MEDIUM REMOVAL command
-	int ReadCapacity10(const DWORD *cdb, BYTE *buf) override;			// READ CAPACITY(10) command
+	void ReadCapacity10(SCSIDEV *, SASIDEV::ctrl_t *) override;			// READ CAPACITY(10) command
 	void ReadCapacity16(SCSIDEV *, SASIDEV::ctrl_t *) override;			// READ CAPACITY(16) command
 	int ReportLuns(const DWORD *cdb, BYTE *buf);				// REPORT LUNS command
 	int GetSectorSize() const;

--- a/src/raspberrypi/devices/disk.h
+++ b/src/raspberrypi/devices/disk.h
@@ -20,6 +20,8 @@
 #include "xm6.h"
 #include "log.h"
 #include "scsi.h"
+#include "controllers/sasidev_ctrl.h"
+#include "controllers/scsidev_ctrl.h"
 #include "block_device.h"
 #include "file_support.h"
 #include "filepath.h"
@@ -167,7 +169,7 @@ public:
 	bool SendDiag(const DWORD *cdb);				// SEND DIAGNOSTIC command
 	bool Removal(const DWORD *cdb);				// PREVENT/ALLOW MEDIUM REMOVAL command
 	int ReadCapacity10(const DWORD *cdb, BYTE *buf) override;			// READ CAPACITY(10) command
-	int ReadCapacity16(const DWORD *cdb, BYTE *buf) override;			// READ CAPACITY(16) command
+	void ReadCapacity16(SCSIDEV *, SASIDEV::ctrl_t *) override;			// READ CAPACITY(16) command
 	int ReportLuns(const DWORD *cdb, BYTE *buf);				// REPORT LUNS command
 	int GetSectorSize() const;
 	void SetSectorSize(int);


### PR DESCRIPTION
ReadCapacity10/16 provide examples on the impact of moving the device functionality out of the controller to the actual device, which will also help with decoupling SCBR/SCDP from the Disk class.
The controller should just dispatch commands to the devices, instead of doing something, then delegating something to the device, and then again doing something. The device should be responsible for requesting the required bus phases from the controller, just like the ReadCapacity10/16 do it at the end.