### PR TITLE
Fix for issue#197

### DIFF
--- a/src/web/file_cmds.py
+++ b/src/web/file_cmds.py
@@ -6,9 +6,6 @@ import time
 from ractl_cmds import attach_image
 from settings import *
 
-valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.hdr", "*.iso", "*.cdr", "*.zip"]
-valid_file_types = r"|".join([fnmatch.translate(x) for x in valid_file_suffix])
-
 
 def create_new_image(file_name, type, size):
     if file_name == "":

--- a/src/web/ractl_cmds.py
+++ b/src/web/ractl_cmds.py
@@ -5,7 +5,7 @@ import re
 from settings import *
 
 
-valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.hdr", "*.iso", "*.cdr", "*.zip"]
+valid_file_suffix = ["*.hda", "*.hdn", "*.hdi", "*.nhd", "*.hdf", "*.hds", "*.hdr", "*.iso", "*.cdr", "*.toast", "*.img", "*.zip"]
 valid_file_types = r"|".join([fnmatch.translate(x) for x in valid_file_suffix])
 # List of SCSI ID's you'd like to exclude - eg if you are on a Mac, the System is usually 7
 EXCLUDE_SCSI_IDS = [7]

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -136,7 +136,7 @@ def attach():
     print("file_name", file_name)
     print("valid_file_types: ", valid_file_types)
     if re.match(valid_file_types, file_name):
-        if file_name.lower().endswith("iso"):
+        if file_name.lower().endswith((".iso", ".cdr", ".toast", ".img")):
             image_type = "cd"
         else:
             image_type = "hd"


### PR DESCRIPTION
Allowing for additional CD image file endings to be attached through the webui. Tested working with each file ending. Also removed the valid file extensions list from web/file_cmds.py since it wasn't used.