### PR TITLE
Added INFO_IMAGE_FILES and INFO_NETWORK_INTERFACES

### DIFF
--- a/doc/rasctl.1
+++ b/doc/rasctl.1
@@ -3,6 +3,7 @@
 rasctl \- Sends management commands to the rascsi process
 .SH SYNOPSIS
 .B rasctl
+\fB\-e\fR |
 \fB\-l\fR |
 \fB\-s\fR |
 [\fB\-d\fR \fIIMAGE_FOLDER\fR]
@@ -40,6 +41,9 @@ Set the rascsi log level (trace, debug, info, warn, err, critical, off).
 .TP
 .BR \-h\fI " " \fIHOST
 The rascsi host to connect to, default is 'localhost'.
+.TP
+.BR \-i\fI
+List all images files in the default image folder.
 .TP
 .BR \-l\fI
 List all of the devices that are currently being emulated by RaSCSI, as well as their current status.

--- a/doc/rasctl.1
+++ b/doc/rasctl.1
@@ -4,6 +4,7 @@ rasctl \- Sends management commands to the rascsi process
 .SH SYNOPSIS
 .B rasctl
 \fB\-e\fR |
+\fB\-k\fR |
 \fB\-l\fR |
 \fB\-s\fR |
 [\fB\-d\fR \fIIMAGE_FOLDER\fR]
@@ -33,7 +34,7 @@ Note: The command and type arguments are case insensitive. Only the first letter
 .BR \-a\fI " "\fIFILENAME:FILESIZE
 Create an image file in the default image folder with the specified name and size in bytes.
 .TP
-.BR \-g\fI " "\fIIMAGE_FOLDER
+.BR \-d\fI " "\fIIMAGE_FOLDER
 Set the default image folder.
 .TP
 .BR \-g\fI " "\fILOG_LEVEL
@@ -42,8 +43,11 @@ Set the rascsi log level (trace, debug, info, warn, err, critical, off).
 .BR \-h\fI " " \fIHOST
 The rascsi host to connect to, default is 'localhost'.
 .TP
-.BR \-i\fI
+.BR \-e\fI
 List all images files in the default image folder.
+.TP
+.BR \-k\fI
+Lists all available network interfaces provided that they are up.
 .TP
 .BR \-l\fI
 List all of the devices that are currently being emulated by RaSCSI, as well as their current status.

--- a/doc/rasctl_man_page.txt
+++ b/doc/rasctl_man_page.txt
@@ -6,9 +6,9 @@ NAME
        rasctl - Sends management commands to the rascsi process
 
 SYNOPSIS
-       rasctl  -l  | -s | [-d IMAGE_FOLDER] [-g LOG_LEVEL] [-h HOST] [-p PORT]
-       [-r RESERVED_IDS] [-v] -i ID [-c CMD] [-f  FILE|PARAM]  [-n  NAME]  [-t
-       TYPE] [-u UNIT]
+       rasctl  -e  |  -l | -s | [-d IMAGE_FOLDER] [-g LOG_LEVEL] [-h HOST] [-p
+       PORT] [-r RESERVED_IDS] [-v] -i ID [-c CMD] [-f FILE|PARAM]  [-n  NAME]
+       [-t TYPE] [-u UNIT]
 
 DESCRIPTION
        rasctl  Sends  commands to the rascsi process to make configuration ad‐
@@ -35,6 +35,8 @@ OPTIONS
 
        -h HOST
               The rascsi host to connect to, default is 'localhost'.
+
+       -i     List all images files in the default image folder.
 
        -l     List  all  of  the  devices that are currently being emulated by
               RaSCSI, as well as their current status.

--- a/doc/rasctl_man_page.txt
+++ b/doc/rasctl_man_page.txt
@@ -6,9 +6,9 @@ NAME
        rasctl - Sends management commands to the rascsi process
 
 SYNOPSIS
-       rasctl  -e  |  -l | -s | [-d IMAGE_FOLDER] [-g LOG_LEVEL] [-h HOST] [-p
-       PORT] [-r RESERVED_IDS] [-v] -i ID [-c CMD] [-f FILE|PARAM]  [-n  NAME]
-       [-t TYPE] [-u UNIT]
+       rasctl  -e  | -k | -l | -s | [-d IMAGE_FOLDER] [-g LOG_LEVEL] [-h HOST]
+       [-p PORT] [-r RESERVED_IDS] [-v] -i ID [-c  CMD]  [-f  FILE|PARAM]  [-n
+       NAME] [-t TYPE] [-u UNIT]
 
 DESCRIPTION
        rasctl  Sends  commands to the rascsi process to make configuration ad‐
@@ -26,7 +26,7 @@ OPTIONS
               Create an image file in the default image folder with the speci‐
               fied name and size in bytes.
 
-       -g IMAGE_FOLDER
+       -d IMAGE_FOLDER
               Set the default image folder.
 
        -g LOG_LEVEL
@@ -36,9 +36,12 @@ OPTIONS
        -h HOST
               The rascsi host to connect to, default is 'localhost'.
 
-       -i     List all images files in the default image folder.
+       -e     List all images files in the default image folder.
 
-       -l     List  all  of  the  devices that are currently being emulated by
+       -k     Lists  all  available  network interfaces provided that they are
+              up.
+
+       -l     List all of the devices that are  currently  being  emulated  by
               RaSCSI, as well as their current status.
 
        -m CURRENT_NAME:NEW_NAME
@@ -50,7 +53,7 @@ OPTIONS
        -r RESERVED_IDS
               Comma-separated list of IDs to reserve.
 
-       -s     Display server-side settings like available images or  supported
+       -s     Display  server-side settings like available images or supported
               device types.
 
        -v     Display the rascsi version.
@@ -68,7 +71,7 @@ OPTIONS
                  d(etach): Detach disk
                  i(nsert): Insert media (removable media devices only)
                  e(ject): Eject media (removable media devices only)
-                 p(rotect):  Write  protect the medium (not for CD-ROMs, which
+                 p(rotect): Write protect the medium (not for  CD-ROMs,  which
               are always read-only)
                  u(nprotect): Remove write protection from the medium (not for
               CD-ROMs, which are always read-only)
@@ -78,18 +81,18 @@ OPTIONS
 
        -b BLOCK_SIZE
               The optional block size. For SCSI drives 512, 1024, 2048 or 4096
-              bytes, default size is 512 bytes. For SASI drives  256  or  1024
+              bytes,  default  size  is 512 bytes. For SASI drives 256 or 1024
               bytes, default is 256 bytes.
 
        -f FILE|PARAM
               Device-specific: Either a path to a disk image file, or a param‐
-              eter for a non-disk device. See the rascsi(1) man page for  per‐
+              eter  for a non-disk device. See the rascsi(1) man page for per‐
               mitted file types.
 
        -t TYPE
-              Specifies  the device type. This type overrides the type derived
+              Specifies the device type. This type overrides the type  derived
               from  the  file  extension  of  the  specified  image.  See  the
-              rascsi(1)  man  page  for  the  available device types. For some
+              rascsi(1) man page for the  available  device  types.  For  some
               types there are shortcuts (only the first letter is required):
                  hd: SCSI hard disk drive
                  rm: SCSI removable media drive
@@ -99,16 +102,16 @@ OPTIONS
                  daynaport: DaynaPORT network adapter
 
        -n VENDOR:PRODUCT:REVISION
-              The vendor, product and revision for the device, to be  returned
+              The  vendor, product and revision for the device, to be returned
               with the INQUIRY data. A complete set of name components must be
               provided. VENDOR may have up to 8, PRODUCT up to 16, REVISION up
               to 4 characters. Padding with blanks to the maxium length is au‐
-              tomatically applied. Once set the name of  a  device  cannot  be
+              tomatically  applied.  Once  set  the name of a device cannot be
               changed.
 
        -u UNIT
-              Unit  number  (0  or  1). This will default to 0. This option is
-              only used when there are multiple SCSI devices on a shared  SCSI
+              Unit number (0 or 1). This will default to  0.  This  option  is
+              only  used when there are multiple SCSI devices on a shared SCSI
               controller. (This is not common)
 
 EXAMPLES

--- a/src/raspberrypi/devices/device_factory.h
+++ b/src/raspberrypi/devices/device_factory.h
@@ -33,12 +33,13 @@ public:
 
 	static DeviceFactory& instance();
 
+	Device *CreateDevice(PbDeviceType type, const string& filename, const string& ext);
+
 	const set<uint32_t>& GetSectorSizes(PbDeviceType type) { return sector_sizes[type]; }
 	const set<uint32_t>& GetSectorSizes(const string&);
 	const set<uint64_t> GetCapacities(PbDeviceType);
 	const map<string, string>& GetDefaultParams(PbDeviceType type) { return default_params[type]; }
-
-	Device *CreateDevice(PbDeviceType type, const string& filename, const string& ext);
+	const list<string> GetNetworkInterfaces() const;
 
 private:
 

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -563,7 +563,7 @@ void GetNetworkInterfacesInfo(PbNetworkInterfacesInfo& network_interfaces_info)
 	struct ifaddrs *tmp = addrs;
 
 	while (tmp) {
-	    if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_PACKET) {
+	    if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_PACKET && strcmp("lo", tmp->ifa_name)) {
 	        int fd = socket(PF_INET6, SOCK_DGRAM, IPPROTO_IP);
 
 	        struct ifreq ifr;

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -563,7 +563,8 @@ void GetNetworkInterfacesInfo(PbNetworkInterfacesInfo& network_interfaces_info)
 	struct ifaddrs *tmp = addrs;
 
 	while (tmp) {
-	    if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_PACKET && strcmp("lo", tmp->ifa_name)) {
+	    if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_PACKET &&
+	    		strcmp(tmp->ifa_name, "lo") && strcmp(tmp->ifa_name, "rascsi_bridge")) {
 	        int fd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
 
 	        struct ifreq ifr;

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -531,6 +531,8 @@ void GetAvailableImages(PbServerInfo& server_info)
 	PbImageFilesInfo *image_files_info = new PbImageFilesInfo();
 	server_info.set_allocated_image_files_info(image_files_info);
 
+	image_files_info->set_default_image_folder(default_image_folder);
+
 	if (!access(default_image_folder.c_str(), F_OK)) {
 		for (const auto& entry : filesystem::directory_iterator(default_image_folder, filesystem::directory_options::skip_permission_denied)) {
 			if (entry.is_regular_file() && entry.file_size() && !(entry.file_size() & 0x1ff)) {
@@ -1776,7 +1778,6 @@ static void *MonThread(void *param)
 					LOGTRACE(string("Received " + PbOperation_Name(command.operation()) + " command").c_str());
 
 					PbImageFilesInfo *image_files_info = new PbImageFilesInfo();
-					image_files_info->set_default_image_folder(default_image_folder);
 					GetAvailableImages(*image_files_info);
 					PbResult result;
 					result.set_status(true);

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -544,6 +544,8 @@ void GetAvailableImages(PbServerInfo& server_info)
 
 void GetAvailableImages(PbImageFilesInfo& image_files_info)
 {
+	image_files_info.set_default_image_folder(default_image_folder);
+
 	if (!access(default_image_folder.c_str(), F_OK)) {
 		for (const auto& entry : filesystem::directory_iterator(default_image_folder, filesystem::directory_options::skip_permission_denied)) {
 			if (entry.is_regular_file() && entry.file_size() && !(entry.file_size() & 0x1ff)) {

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1773,6 +1773,7 @@ static void *MonThread(void *param)
 					LOGTRACE(string("Received " + PbOperation_Name(GET_IMAGE_FILES) + " command").c_str());
 
 					PbImageFiles *image_files = new PbImageFiles();
+					image_files->set_default_image_folder(default_image_folder);
 					GetAvailableImages(*image_files);
 					PbResult result;
 					result.set_status(true);

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -564,7 +564,7 @@ void GetNetworkInterfacesInfo(PbNetworkInterfacesInfo& network_interfaces_info)
 
 	while (tmp) {
 	    if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_PACKET && strcmp("lo", tmp->ifa_name)) {
-	        int fd = socket(PF_INET6, SOCK_DGRAM, IPPROTO_IP);
+	        int fd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
 
 	        struct ifreq ifr;
 	        memset(&ifr, 0, sizeof(ifr));

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -688,6 +688,9 @@ void GetServerInfo(PbResult& result)
 	server_info->set_current_log_level(current_log_level);
 	GetAllDeviceTypeProperties(*server_info);
 	GetAvailableImages(*server_info);
+	PbNetworkInterfacesInfo * network_interfaces_info = new PbNetworkInterfacesInfo();
+	server_info->set_allocated_network_interfaces_info(network_interfaces_info);
+	GetNetworkInterfacesInfo(*network_interfaces_info);
 	GetDevices(*server_info);
 	for (int id : reserved_ids) {
 		server_info->add_reserved_ids(id);

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -71,57 +71,60 @@ enum PbOperation {
 
     // Gets information on available image files. A lightweight alternative to getting the complete server info.
     IMAGE_FILES_INFO = 12;
+    
+    // Gets the names of the available network interfaces. Only lists interfaces that are up.
+    NETWORK_INTERFACES_INFO = 13;
 
     // Set the default folder for image files.
     // Parameters:
     //   "folder": The default folder name.
-    DEFAULT_FOLDER = 13;
+    DEFAULT_FOLDER = 14;
 
     // Set server log level.
     // Parameters:
     //   "level": The new log level
-    LOG_LEVEL = 14;
+    LOG_LEVEL = 15;
 
     // Block IDs from being used, usually the IDs of the initiators (computers) in the SCSI chain.
     // Parameters:
     //   "ids": A comma-separated list of IDs to reserve, or an empty string in order not to reserve any ID.
-    RESERVE = 15;
+    RESERVE = 16;
     
     // Create an image file. The image file must not yet exist.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
     //   "size": The file size in bytes, must be a multiple of 512
     //   "read_only": "true" (case-insensitive) in order to create a read-only file, otherwise "false"
-    CREATE_IMAGE = 16;
+    CREATE_IMAGE = 17;
 
     // Delete an image file.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    DELETE_IMAGE = 17;
+    DELETE_IMAGE = 18;
 
     // Rename an image file.
     // Parameters:
     //   "from": The old filename, relative to the default image folder. It must not contain a slash.
     //   "to": The new filename, relative to the default image folder. It must not contain a slash.
     // The new filename must not yet exist.
-    RENAME_IMAGE = 18;
+    RENAME_IMAGE = 19;
 
     // Copy an image file.
     // Parameters:
     //   "from": The source filename, relative to the default image folder. It must not contain a slash.
     //   "to": The destination filename, relative to the default image folder. It must not contain a slash.
     // The destination filename must not yet exist.
-    COPY_IMAGE = 19;
+    COPY_IMAGE = 20;
     
     // Write-protect an image file.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    PROTECT_IMAGE = 20;
+    PROTECT_IMAGE = 21;
 
     // Make an image file writable.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    UNPROTECT_IMAGE = 21;
+    UNPROTECT_IMAGE = 22;
 }
 
 // The properties supported by a device
@@ -179,6 +182,11 @@ message PbImageFile {
 message PbImageFilesInfo {
     string default_image_folder = 1;
     repeated PbImageFile image_files = 2;
+}
+
+// The network interfaces information
+message PbNetworkInterfacesInfo {
+    repeated string name = 1;
 }
 
 // The device definition, sent from the client to the server
@@ -245,6 +253,8 @@ message PbResult {
         PbDevices device_info = 4;
         // The result of an IMAGE_FILES_INFO command
         PbImageFilesInfo image_files_info = 5;
+        // The result of a NETWORK_INTERFACES_INFO command
+        PbNetworkInterfacesInfo network_interfaces_info = 6;
     }
 }
 
@@ -261,8 +271,9 @@ message PbServerInfo {
     // Supported device types and their properties
     repeated PbDeviceTypeProperties types_properties = 6;
     PbImageFilesInfo image_files_info = 7;
+    PbNetworkInterfacesInfo network_interfaces_info = 8;
     // The attached devices
-    repeated PbDevice devices = 8;
+    repeated PbDevice devices = 9;
     // The unsorted list of reserved IDs
-    repeated uint32 reserved_ids = 9;
+    repeated uint32 reserved_ids = 10;
 }

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -83,42 +83,45 @@ enum PbOperation {
     // Parameters:
     //   "ids": A comma-separated list of IDs to reserve, or an empty string in order not to reserve any ID.
     RESERVE = 14;
+    
+    // Get list of available image files. A lightweight alternative to getting the complete server info.
+    GET_IMAGE_FILES = 15;
 
     // Create an image file. The image file must not yet exist.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
     //   "size": The file size in bytes, must be a multiple of 512
     //   "read_only": "true" (case-insensitive) in order to create a read-only file, otherwise "false"
-    CREATE_IMAGE = 15;
+    CREATE_IMAGE = 16;
 
     // Delete an image file.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    DELETE_IMAGE = 16;
+    DELETE_IMAGE = 17;
 
     // Rename an image file.
     // Parameters:
     //   "from": The old filename, relative to the default image folder. It must not contain a slash.
     //   "to": The new filename, relative to the default image folder. It must not contain a slash.
     // The new filename must not yet exist.
-    RENAME_IMAGE = 17;
+    RENAME_IMAGE = 18;
 
     // Copy an image file.
     // Parameters:
     //   "from": The source filename, relative to the default image folder. It must not contain a slash.
     //   "to": The destination filename, relative to the default image folder. It must not contain a slash.
     // The destination filename must not yet exist.
-    COPY_IMAGE = 18;
+    COPY_IMAGE = 19;
     
     // Write-protect an image file.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    PROTECT_IMAGE = 19;
+    PROTECT_IMAGE = 20;
 
     // Make an image file writable.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    UNPROTECT_IMAGE = 20;
+    UNPROTECT_IMAGE = 21;
 }
 
 // The properties supported by a device
@@ -170,6 +173,10 @@ message PbImageFile {
     string name = 1;
     bool read_only = 2;
     int64 size = 3;
+}
+
+message PbImageFiles {
+    repeated PbImageFile image_files = 1;
 }
 
 // The device definition, sent from the client to the server
@@ -234,6 +241,8 @@ message PbResult {
         PbServerInfo server_info = 3;
         // The result of a DEVICE_INFO command
         PbDevices device_info = 4;
+        // The result of an GET_IMAGE_FILES command
+        PbImageFiles image_files = 5;
     }
 }
 

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -176,7 +176,8 @@ message PbImageFile {
 }
 
 message PbImageFiles {
-    repeated PbImageFile image_files = 1;
+    string default_image_folder = 1;
+    repeated PbImageFile image_files = 2;
 }
 
 // The device definition, sent from the client to the server

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -66,27 +66,27 @@ enum PbOperation {
     // Gets the server information
     SERVER_INFO = 10;
 
-    // Gets information for a list of attached devices. Returns data for all attached devices if empty.
+    // Gets information on attached devices. Returns data for all attached devices if empty.
     DEVICE_INFO = 11;
+
+    // Gets information on available image files. A lightweight alternative to getting the complete server info.
+    IMAGE_FILES_INFO = 12;
 
     // Set the default folder for image files.
     // Parameters:
     //   "folder": The default folder name.
-    DEFAULT_FOLDER = 12;
+    DEFAULT_FOLDER = 13;
 
     // Set server log level.
     // Parameters:
     //   "level": The new log level
-    LOG_LEVEL = 13;
+    LOG_LEVEL = 14;
 
     // Block IDs from being used, usually the IDs of the initiators (computers) in the SCSI chain.
     // Parameters:
     //   "ids": A comma-separated list of IDs to reserve, or an empty string in order not to reserve any ID.
-    RESERVE = 14;
+    RESERVE = 15;
     
-    // Get list of available image files. A lightweight alternative to getting the complete server info.
-    GET_IMAGE_FILES = 15;
-
     // Create an image file. The image file must not yet exist.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
@@ -175,7 +175,8 @@ message PbImageFile {
     int64 size = 3;
 }
 
-message PbImageFiles {
+// The default image folder and the image files it contains
+message PbImageFilesInfo {
     string default_image_folder = 1;
     repeated PbImageFile image_files = 2;
 }
@@ -242,8 +243,8 @@ message PbResult {
         PbServerInfo server_info = 3;
         // The result of a DEVICE_INFO command
         PbDevices device_info = 4;
-        // The result of an GET_IMAGE_FILES command
-        PbImageFiles image_files = 5;
+        // The result of an IMAGE_FILES_INFO command
+        PbImageFilesInfo image_files_info = 5;
     }
 }
 
@@ -257,13 +258,11 @@ message PbServerInfo {
     // List of available log levels, ordered by increasing by severity
     repeated string log_levels = 4;
     string current_log_level = 5;
-    string default_image_folder = 6;
     // Supported device types and their properties
-    repeated PbDeviceTypeProperties types_properties = 7;
-    // Unordered list of files in the default image folder
-    repeated PbImageFile image_files = 8;
+    repeated PbDeviceTypeProperties types_properties = 6;
+    PbImageFilesInfo image_files_info = 7;
     // The attached devices
-    repeated PbDevice devices = 9;
+    repeated PbDevice devices = 8;
     // The unsorted list of reserved IDs
-    repeated uint32 reserved_ids = 10;
+    repeated uint32 reserved_ids = 9;
 }

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -176,6 +176,22 @@ void DisplayImageFiles(const list<PbImageFile> image_files, const string& defaul
 	}
 }
 
+void DisplayNetworkInterfaces(list<string> interfaces)
+{
+	interfaces.sort([](const auto& a, const auto& b) { return a < b; });
+
+	cout << "Available (up) network interfaces:" << endl;
+	bool isFirst = true;
+	for (const auto& interface : interfaces) {
+		if (!isFirst) {
+			cout << ", ";
+		}
+		isFirst = false;
+		cout << interface;
+	}
+	cout << endl;
+}
+
 //---------------------------------------------------------------------------
 //
 //	Command implementations
@@ -326,6 +342,10 @@ void CommandServerInfo(PbCommand& command, const string& hostname, int port)
 		{ server_info.image_files_info().image_files().begin(), server_info.image_files_info().image_files().end() };
 	DisplayImageFiles(image_files, server_info.image_files_info().default_image_folder());
 
+	const list<string> network_interfaces =
+		{ server_info.network_interfaces_info().name().begin(), server_info.network_interfaces_info().name().end() };
+	DisplayNetworkInterfaces(network_interfaces);
+
 	cout << "Supported device types and their properties:" << endl;
 	for (auto it = server_info.types_properties().begin(); it != server_info.types_properties().end(); ++it) {
 		cout << "  " << PbDeviceType_Name(it->type());
@@ -459,20 +479,9 @@ void CommandNetworkInterfacesInfo(const PbCommand& command, const string&hostnam
 	PbResult result;
 	SendCommand(hostname.c_str(), port, command, result);
 
-	list<string> interfaces =
+	list<string> network_interfaces =
 		{ result.network_interfaces_info().name().begin(), result.network_interfaces_info().name().end() };
-	interfaces.sort([](const auto& a, const auto& b) { return a < b; });
-
-	cout << "Available (up) network interfaces:" << endl;
-	bool isFirst = true;
-	for (const auto& interface : interfaces) {
-		if (!isFirst) {
-			cout << ", ";
-		}
-		isFirst = false;
-		cout << interface;
-	}
-	cout << endl;
+	DisplayNetworkInterfaces(network_interfaces);
 }
 
 PbOperation ParseOperation(const char *optarg)

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -322,8 +322,9 @@ void CommandServerInfo(PbCommand& command, const string& hostname, int port)
 		cout << "Current rascsi log level: " << server_info.current_log_level() << endl;
 	}
 
-	const list<PbImageFile> image_files = { server_info.image_files().begin(), server_info.image_files().end() };
-	DisplayImageFiles(image_files, server_info.default_image_folder());
+	const list<PbImageFile> image_files =
+		{ server_info.image_files_info().image_files().begin(), server_info.image_files_info().image_files().end() };
+	DisplayImageFiles(image_files, server_info.image_files_info().default_image_folder());
 
 	cout << "Supported device types and their properties:" << endl;
 	for (auto it = server_info.types_properties().begin(); it != server_info.types_properties().end(); ++it) {
@@ -443,14 +444,14 @@ void CommandServerInfo(PbCommand& command, const string& hostname, int port)
 	}
 }
 
-void CommandGetImageFiles(PbCommand& command, const string& hostname, int port)
+void CommandImageFilesInfo(PbCommand& command, const string& hostname, int port)
 {
 	PbResult result;
 	SendCommand(hostname.c_str(), port, command, result);
 
 	const list<PbImageFile> image_files =
-		{ result.image_files().image_files().begin(),result.image_files().image_files().end() };
-	DisplayImageFiles(image_files, result.image_files().default_image_folder());
+		{ result.image_files_info().image_files().begin(),result.image_files_info().image_files().end() };
+	DisplayImageFiles(image_files, result.image_files_info().default_image_folder());
 }
 
 PbOperation ParseOperation(const char *optarg)
@@ -607,7 +608,7 @@ int main(int argc, char* argv[])
 				break;
 
 			case'e':
-				command.set_operation(GET_IMAGE_FILES);
+				command.set_operation(IMAGE_FILES_INFO);
 				break;
 
 			case 'f':
@@ -743,8 +744,8 @@ int main(int argc, char* argv[])
 			CommandServerInfo(command, hostname, port);
 			exit(EXIT_SUCCESS);
 
-		case GET_IMAGE_FILES:
-			CommandGetImageFiles(command, hostname, port);
+		case IMAGE_FILES_INFO:
+			CommandImageFilesInfo(command, hostname, port);
 			exit(EXIT_SUCCESS);
 
 		default:


### PR DESCRIPTION
This change makes the protobuf interface more granular by introducing an IMAGE_FILES_INFO command. Clients that are only interested in file-related information do not have to get the complete SERVER_INFO anymore.

@rdmark Note that this results in a minor change in PbServerInfo.