### PR TITLE
SCSIMON immediately dies and doesn't collect any data

### DIFF
--- a/src/raspberrypi/scsimon.cpp
+++ b/src/raspberrypi/scsimon.cpp
@@ -481,7 +481,7 @@ int main(int argc, char* argv[])
     s << "Elapsed time: " << elapsed_us << " microseconds (" << elapsed_us / 1000000 << " seconds)";
     LOGINFO("%s", s.str().c_str());
     s.str("");
-    s << "Collected %lu changes" << data_idx;
+    s << "Collected " << data_idx << " changes";
     LOGINFO("%s", s.str().c_str());
 
     // Note: ns_per_loop is a global variable that is used by Cleanup() to printout the timestamps.    

--- a/src/raspberrypi/scsimon.cpp
+++ b/src/raspberrypi/scsimon.cpp
@@ -412,7 +412,7 @@ int main(int argc, char* argv[])
 	sched_setscheduler(0, SCHED_FIFO, &schparam);
 
 	// Start execution
-	running = false;
+	running = true;
 	bus->SetACT(FALSE);
 
     (void)gettimeofday(&start_time, NULL);


### PR DESCRIPTION
During one of the updates on develop, an error was introduced where `running` was set to `false` during initialization. This caused scsimon to immediately exit. This PR changes it back to `true`