### PR TITLE
Issue 278: fix ModeSense(6) and ModeSense(10)

### DIFF
--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -845,20 +845,20 @@ int Disk::ModeSense10(const DWORD *cdb, BYTE *buf)
 			// Check LLBAA for short or long block descriptor
 			if ((cdb[1] & 0x10) == 0 || disk_blocks <= 0xFFFFFFFF) {
 				// Mode parameter header, block descriptor length
-				buf[3] = 0x08;
+				buf[7] = 0x08;
 
 				// Short LBA mode parameter block descriptor (number of blocks and block length)
 
-				buf[4] = disk_blocks >> 24;
-				buf[5] = disk_blocks >> 16;
-				buf[6] = disk_blocks >> 8;
-				buf[7] = disk_blocks;
+				buf[8] = disk_blocks >> 24;
+				buf[9] = disk_blocks >> 16;
+				buf[10] = disk_blocks >> 8;
+				buf[11] = disk_blocks;
 
-				buf[9] = disk_size >> 16;
-				buf[10] = disk_size >> 8;
-				buf[11] = disk_size;
+				buf[13] = disk_size >> 16;
+				buf[14] = disk_size >> 8;
+				buf[15] = disk_size;
 
-				size = 12;
+				size = 16;
 			}
 			else {
 				// Mode parameter header, LONGLBA
@@ -869,21 +869,21 @@ int Disk::ModeSense10(const DWORD *cdb, BYTE *buf)
 
 				// Long LBA mode parameter block descriptor (number of blocks and block length)
 
-				buf[4] = disk_blocks >> 56;
-				buf[5] = disk_blocks >> 48;
-				buf[6] = disk_blocks >> 40;
-				buf[7] = disk_blocks >> 32;
-				buf[8] = disk_blocks >> 24;
-				buf[9] = disk_blocks >> 16;
-				buf[10] = disk_blocks >> 8;
-				buf[11] = disk_blocks;
+				buf[8] = disk_blocks >> 56;
+				buf[9] = disk_blocks >> 48;
+				buf[10] = disk_blocks >> 40;
+				buf[11] = disk_blocks >> 32;
+				buf[12] = disk_blocks >> 24;
+				buf[13] = disk_blocks >> 16;
+				buf[14] = disk_blocks >> 8;
+				buf[15] = disk_blocks;
 
-				buf[16] = disk_size >> 24;
-				buf[17] = disk_size >> 16;
-				buf[18] = disk_size >> 8;
-				buf[19] = disk_size;
+				buf[20] = disk_size >> 24;
+				buf[21] = disk_size >> 16;
+				buf[22] = disk_size >> 8;
+				buf[23] = disk_size;
 
-				size = 20;
+				size = 24;
 			}
 		}
 	}

--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -784,6 +784,13 @@ int Disk::ModeSense6(const DWORD *cdb, BYTE *buf)
 		SetStatusCode(STATUS_INVALIDCDB);
 		return 0;
 	}
+	//check if size of data is more than size requested.
+	if (size > length) {
+		SetStatusCode(STATUS_INVALIDCDB);
+		return 0;
+	}
+	//Set length returned to actual size of data
+	length = size;
 
 	return length;
 }
@@ -945,6 +952,13 @@ int Disk::ModeSense10(const DWORD *cdb, BYTE *buf)
 		SetStatusCode(STATUS_INVALIDCDB);
 		return 0;
 	}
+	//check if size of data is more than size requested.
+	if (size > length) {
+		SetStatusCode(STATUS_INVALIDCDB);
+		return 0;
+	}
+	//Set length returned to actual size of data
+	length = size;
 
 	return length;
 }


### PR DESCRIPTION
ModeSense(6) and ModeSense(10) were returning too much data and crashing OpenVMS in this case.  
Both ModeSense(6) and ModeSense(10) were returning the max length of data allowed by the host instead of the real size of data. They both will now return the length of the data unless the data is larger than the length requested by the host. This is described in section 4.2.5.6 Allocation length in Working Draft SCSI Primary Commands - 6 (SPC-6)

ModeSense(10) was not returning a proper Mode Parameter Header as described in the SCSI spec. The header being returned was 4 bytes instead of 8 bytes as defined in Table 449 of Working Draft SCSI Primary Commands - 6 (SPC-6)