### PR TITLE
Set SASI product name to SASI HD

### DIFF
--- a/src/raspberrypi/devices/device_factory.cpp
+++ b/src/raspberrypi/devices/device_factory.cpp
@@ -127,6 +127,7 @@ Device *DeviceFactory::CreateDevice(PbDeviceType type, const string& filename)
 			case SAHD:
 				device = new SASIHD();
 				device->SetSupportedLuns(2);
+				device->SetProduct("SASI HD");
 				((Disk *)device)->SetSectorSizes(sector_sizes[SAHD]);
 			break;
 


### PR DESCRIPTION
```
Attached devices:
  0:0  SAHD  RaSCSI:SASI HD:2199  256 bytes per sector  127398912 bytes capacity  /home/us/hatari/test.hds  read-only
```