### PR TITLE
Feature interface granularity

### DIFF
--- a/doc/rasctl.1
+++ b/doc/rasctl.1
@@ -4,6 +4,7 @@ rasctl \- Sends management commands to the rascsi process
 .SH SYNOPSIS
 .B rasctl
 \fB\-L\fR |
+\fB\-O\fR |
 \fB\-e\fR |
 \fB\-l\fR |
 \fB\-m\fR |
@@ -58,6 +59,9 @@ List all images files in the default image folder.
 .TP
 .BR \-N\fI
 Lists all available network interfaces provided that they are up.
+.TP
+.BR \-O\fI
+Display the available rascsi server log levels and the current log level.
 .TP
 .BR \-l\fI
 List all of the devices that are currently being emulated by RaSCSI, as well as their current status.

--- a/doc/rasctl.1
+++ b/doc/rasctl.1
@@ -9,6 +9,7 @@ rasctl \- Sends management commands to the rascsi process
 \fB\-m\fR |
 \fB\-s\fR |
 \fB\-T\fR |
+\fB\-V\fR |
 [\fB\-E\fR \fIFILENAME\fR]
 [\fB\-F\fR \fIIMAGE_FOLDER\fR]
 [\fB\-C\fR \fIFILENAME:FILESIZE\fR]
@@ -80,7 +81,10 @@ Display server-side settings like available images or supported device types.
 Display all device types and their properties.
 .TP
 .BR \-v\fI " " \fI
-Display the rascsi version.
+Display the rascsi server version.
+.TP
+.BR \-V\fI " " \fI
+Display the rasctl version.
 .TP
 .BR \-D\fI " "\fIFILENAME
 Delete an image file in the default image folder.

--- a/doc/rasctl.1
+++ b/doc/rasctl.1
@@ -3,12 +3,14 @@
 rasctl \- Sends management commands to the rascsi process
 .SH SYNOPSIS
 .B rasctl
-\fB\-L\fR |
-\fB\-O\fR |
 \fB\-e\fR |
 \fB\-l\fR |
 \fB\-m\fR |
 \fB\-s\fR |
+\fB\-v\fR |
+\fB\-I\fR |
+\fB\-L\fR |
+\fB\-O\fR |
 \fB\-T\fR |
 \fB\-V\fR |
 [\fB\-E\fR \fIFILENAME\fR]
@@ -20,8 +22,7 @@ rasctl \- Sends management commands to the rascsi process
 [\fB\-h\fR \fIHOST\fR]
 [\fB\-p\fR \fIPORT\fR]
 [\fB\-r\fR \fIRESERVED_IDS\fR]
-[\fB\-v\fR]
-\fB\-i\fR \fIID\fR
+[\fB\-i\fR \fIID\fR
 [\fB\-c\fR \fICMD\fR]
 [\fB\-f\fR \fIFILE|PARAM\fR]
 [\fB\-n\fR \fINAME\fR]
@@ -47,6 +48,9 @@ Display information on an image file.
 .TP
 .BR \-F\fI " "\fIIMAGE_FOLDER
 Set the default image folder.
+.TP
+.BR \-I\fI
+Gets the list of reserved device IDs.
 .TP
 .BR \-L\fI " "\fILOG_LEVEL
 Set the rascsi log level (trace, debug, info, warn, err, critical, off).

--- a/doc/rasctl_man_page.txt
+++ b/doc/rasctl_man_page.txt
@@ -6,7 +6,7 @@ NAME
        rasctl - Sends management commands to the rascsi process
 
 SYNOPSIS
-       rasctl  -L  |  -e  |  -l  |  -m  | -s | -T | -V | [-E FILENAME] [-F IM‐
+       rasctl  -L  |  -O | -e | -l | -m | -s | -T | -V | [-E FILENAME] [-F IM‐
        AGE_FOLDER] [-C FILENAME:FILESIZE] [-x CURRENT_NAME:NEW_NAME] [-R  CUR‐
        RENT_NAME:NEW_NAME]   [-g  LOG_LEVEL]  [-h  HOST]  [-p  PORT]  [-r  RE‐
        SERVED_IDS] [-v] -i ID [-c CMD] [-f FILE|PARAM] [-n NAME] [-t TYPE] [-u
@@ -46,10 +46,13 @@ OPTIONS
        -N     Lists  all  available  network interfaces provided that they are
               up.
 
-       -l     List all of the devices that are  currently  being  emulated  by
+       -O     Display the available rascsi server log levels and  the  current
+              log level.
+
+       -l     List  all  of  the  devices that are currently being emulated by
               RaSCSI, as well as their current status.
 
-       -m     List  all  file  extensions  recognized by RaSCSI and the device
+       -m     List all file extensions recognized by  RaSCSI  and  the  device
               types they map to.
 
        -R CURRENT_NAME:NEW_NAME
@@ -61,7 +64,7 @@ OPTIONS
        -r RESERVED_IDS
               Comma-separated list of IDs to reserve.
 
-       -s     Display server-side settings like available images or  supported
+       -s     Display  server-side settings like available images or supported
               device types.
 
        -T     Display all device types and their properties.
@@ -83,7 +86,7 @@ OPTIONS
                  d(etach): Detach disk
                  i(nsert): Insert media (removable media devices only)
                  e(ject): Eject media (removable media devices only)
-                 p(rotect):  Write  protect the medium (not for CD-ROMs, which
+                 p(rotect): Write protect the medium (not for  CD-ROMs,  which
               are always read-only)
                  u(nprotect): Remove write protection from the medium (not for
               CD-ROMs, which are always read-only)
@@ -93,18 +96,18 @@ OPTIONS
 
        -b BLOCK_SIZE
               The optional block size. For SCSI drives 512, 1024, 2048 or 4096
-              bytes, default size is 512 bytes. For SASI drives  256  or  1024
+              bytes,  default  size  is 512 bytes. For SASI drives 256 or 1024
               bytes, default is 256 bytes.
 
        -f FILE|PARAM
               Device-specific: Either a path to a disk image file, or a param‐
-              eter for a non-disk device. See the rascsi(1) man page for  per‐
+              eter  for a non-disk device. See the rascsi(1) man page for per‐
               mitted file types.
 
        -t TYPE
-              Specifies  the device type. This type overrides the type derived
+              Specifies the device type. This type overrides the type  derived
               from  the  file  extension  of  the  specified  image.  See  the
-              rascsi(1)  man  page  for  the  available device types. For some
+              rascsi(1) man page for the  available  device  types.  For  some
               types there are shortcuts (only the first letter is required):
                  hd: SCSI hard disk drive
                  rm: SCSI removable media drive
@@ -114,16 +117,16 @@ OPTIONS
                  daynaport: DaynaPORT network adapter
 
        -n VENDOR:PRODUCT:REVISION
-              The vendor, product and revision for the device, to be  returned
+              The  vendor, product and revision for the device, to be returned
               with the INQUIRY data. A complete set of name components must be
               provided. VENDOR may have up to 8, PRODUCT up to 16, REVISION up
               to 4 characters. Padding with blanks to the maxium length is au‐
-              tomatically applied. Once set the name of  a  device  cannot  be
+              tomatically  applied.  Once  set  the name of a device cannot be
               changed.
 
        -u UNIT
-              Unit  number  (0  or  1). This will default to 0. This option is
-              only used when there are multiple SCSI devices on a shared  SCSI
+              Unit number (0 or 1). This will default to  0.  This  option  is
+              only  used when there are multiple SCSI devices on a shared SCSI
               controller. (This is not common)
 
 EXAMPLES

--- a/doc/rasctl_man_page.txt
+++ b/doc/rasctl_man_page.txt
@@ -6,10 +6,10 @@ NAME
        rasctl - Sends management commands to the rascsi process
 
 SYNOPSIS
-       rasctl  -L  |  -O | -e | -l | -m | -s | -T | -V | [-E FILENAME] [-F IM‐
-       AGE_FOLDER] [-C FILENAME:FILESIZE] [-x CURRENT_NAME:NEW_NAME] [-R  CUR‐
-       RENT_NAME:NEW_NAME]   [-g  LOG_LEVEL]  [-h  HOST]  [-p  PORT]  [-r  RE‐
-       SERVED_IDS] [-v] -i ID [-c CMD] [-f FILE|PARAM] [-n NAME] [-t TYPE] [-u
+       rasctl  -e | -l | -m | -s | -v | -I | -L | -O | -T | -V | [-E FILENAME]
+       [-F IMAGE_FOLDER] [-C FILENAME:FILESIZE] [-x CURRENT_NAME:NEW_NAME] [-R
+       CURRENT_NAME:NEW_NAME]  [-g  LOG_LEVEL]  [-h  HOST]  [-p  PORT] [-r RE‐
+       SERVED_IDS] [-i ID [-c CMD] [-f FILE|PARAM] [-n  NAME]  [-t  TYPE]  [-u
        UNIT]
 
 DESCRIPTION
@@ -33,6 +33,8 @@ OPTIONS
 
        -F IMAGE_FOLDER
               Set the default image folder.
+
+       -I     Gets the list of reserved device IDs.
 
        -L LOG_LEVEL
               Set the rascsi log level (trace, debug, info, warn, err,  criti‐

--- a/doc/rasctl_man_page.txt
+++ b/doc/rasctl_man_page.txt
@@ -6,8 +6,8 @@ NAME
        rasctl - Sends management commands to the rascsi process
 
 SYNOPSIS
-       rasctl  -L  |  -e | -l | -m | -s | -T | [-E FILENAME] [-F IMAGE_FOLDER]
-       [-C   FILENAME:FILESIZE]   [-x    CURRENT_NAME:NEW_NAME]    [-R    CUR‐
+       rasctl  -L  |  -e  |  -l  |  -m  | -s | -T | -V | [-E FILENAME] [-F IM‐
+       AGE_FOLDER] [-C FILENAME:FILESIZE] [-x CURRENT_NAME:NEW_NAME] [-R  CUR‐
        RENT_NAME:NEW_NAME]   [-g  LOG_LEVEL]  [-h  HOST]  [-p  PORT]  [-r  RE‐
        SERVED_IDS] [-v] -i ID [-c CMD] [-f FILE|PARAM] [-n NAME] [-t TYPE] [-u
        UNIT]
@@ -66,7 +66,9 @@ OPTIONS
 
        -T     Display all device types and their properties.
 
-       -v     Display the rascsi version.
+       -v     Display the rascsi server version.
+
+       -V     Display the rasctl version.
 
        -D FILENAME
               Delete an image file in the default image folder.
@@ -140,7 +142,7 @@ EXAMPLES
           rasctl -i 0 -f HDIIMAGE0.HDS
 
 SEE ALSO
-       rascsi(1) scsimon(1)
+       rascsi(1), scsimon(1), rasdump(1), sasidump(1)
 
        Full          documentation          is          available          at:
        <https://www.github.com/akuker/RASCSI/wiki/>

--- a/src/raspberrypi/protobuf_response_helper.cpp
+++ b/src/raspberrypi/protobuf_response_helper.cpp
@@ -270,9 +270,7 @@ PbServerInfo *ProtobufResponseHandler::GetServerInfo(PbResult& result, const vec
 {
 	PbServerInfo *server_info = new PbServerInfo();
 
-	server_info->set_major_version(rascsi_major_version);
-	server_info->set_minor_version(rascsi_minor_version);
-	server_info->set_patch_version(rascsi_patch_version);
+	server_info->set_allocated_version_info(GetVersionInfo(result));
 	GetLogLevels(*server_info);
 	server_info->set_current_log_level(log_level);
 	GetAllDeviceTypeProperties(*server_info->mutable_device_types_info());
@@ -287,6 +285,19 @@ PbServerInfo *ProtobufResponseHandler::GetServerInfo(PbResult& result, const vec
 	result.set_status(true);
 
 	return server_info;
+}
+
+PbVersionInfo *ProtobufResponseHandler::GetVersionInfo(PbResult& result)
+{
+	PbVersionInfo *version_info = new PbVersionInfo();
+
+	version_info->set_major_version(rascsi_major_version);
+	version_info->set_minor_version(rascsi_minor_version);
+	version_info->set_patch_version(rascsi_patch_version);
+
+	result.set_status(true);
+
+	return version_info;
 }
 
 void ProtobufResponseHandler::GetLogLevels(PbServerInfo& server_info)

--- a/src/raspberrypi/protobuf_response_helper.cpp
+++ b/src/raspberrypi/protobuf_response_helper.cpp
@@ -266,13 +266,12 @@ PbDeviceTypesInfo *ProtobufResponseHandler::GetDeviceTypesInfo(PbResult& result,
 }
 
 PbServerInfo *ProtobufResponseHandler::GetServerInfo(PbResult& result, const vector<Device *>& devices, const set<int>& reserved_ids,
-		const string& image_folder, const string& log_level)
+		const string& image_folder, const string& current_log_level)
 {
 	PbServerInfo *server_info = new PbServerInfo();
 
 	server_info->set_allocated_version_info(GetVersionInfo(result));
-	GetLogLevels(*server_info);
-	server_info->set_current_log_level(log_level);
+	server_info->set_allocated_log_level_info(GetLogLevelInfo(result, current_log_level));
 	GetAllDeviceTypeProperties(*server_info->mutable_device_types_info());
 	GetAvailableImages(result, *server_info, image_folder);
 	server_info->set_allocated_network_interfaces_info(GetNetworkInterfacesInfo(result));
@@ -300,11 +299,19 @@ PbVersionInfo *ProtobufResponseHandler::GetVersionInfo(PbResult& result)
 	return version_info;
 }
 
-void ProtobufResponseHandler::GetLogLevels(PbServerInfo& server_info)
+PbLogLevelInfo *ProtobufResponseHandler::GetLogLevelInfo(PbResult& result, const string& current_log_level)
 {
+	PbLogLevelInfo *log_level_info = new PbLogLevelInfo();
+
 	for (const auto& log_level : log_levels) {
-		server_info.add_log_levels(log_level);
+		log_level_info->add_log_levels(log_level);
 	}
+
+	log_level_info->set_current_log_level(current_log_level);
+
+	result.set_status(true);
+
+	return log_level_info;
 }
 
 PbNetworkInterfacesInfo *ProtobufResponseHandler::GetNetworkInterfacesInfo(PbResult& result)

--- a/src/raspberrypi/protobuf_response_helper.cpp
+++ b/src/raspberrypi/protobuf_response_helper.cpp
@@ -206,12 +206,24 @@ void ProtobufResponseHandler::GetAvailableImages(PbResult& result, PbServerInfo&
 	result.set_status(true);
 }
 
-void ProtobufResponseHandler::GetDevices(PbServerInfo& serverInfo, const vector<Device *>& devices, const string& image_folder)
+PbReservedIds *ProtobufResponseHandler::GetReservedIds(PbResult& result, const set<int>& ids)
+{
+	PbReservedIds *reserved_ids = new PbReservedIds();
+	for (int id : ids) {
+		reserved_ids->add_ids(id);
+	}
+
+	result.set_status(true);
+
+	return reserved_ids;
+}
+
+void ProtobufResponseHandler::GetDevices(PbServerInfo& server_info, const vector<Device *>& devices, const string& image_folder)
 {
 	for (const Device *device : devices) {
 		// Skip if unit does not exist or is not assigned
 		if (device) {
-			PbDevice *pb_device = serverInfo.mutable_devices()->add_devices();
+			PbDevice *pb_device = server_info.mutable_devices()->add_devices();
 			GetDevice(device, pb_device, image_folder);
 		}
 	}
@@ -277,9 +289,7 @@ PbServerInfo *ProtobufResponseHandler::GetServerInfo(PbResult& result, const vec
 	server_info->set_allocated_network_interfaces_info(GetNetworkInterfacesInfo(result));
 	server_info->set_allocated_mapping_info(GetMappingInfo(result));
 	GetDevices(*server_info, devices, image_folder);
-	for (int id : reserved_ids) {
-		server_info->add_reserved_ids(id);
-	}
+	server_info->set_allocated_reserved_ids(GetReservedIds(result, reserved_ids));
 
 	result.set_status(true);
 

--- a/src/raspberrypi/protobuf_response_helper.h
+++ b/src/raspberrypi/protobuf_response_helper.h
@@ -35,6 +35,7 @@ public:
 	void GetDevices(PbServerInfo&, const vector<Device *>&, const string&);
 	void GetDevicesInfo(PbResult&, const PbCommand&, const vector<Device *>&, const string&, int);
 	PbDeviceTypesInfo *GetDeviceTypesInfo(PbResult&, const PbCommand&);
+	PbVersionInfo *GetVersionInfo(PbResult&);
 	PbServerInfo *GetServerInfo(PbResult&, const vector<Device *>&, const set<int>&, const string&, const string&);
 	PbNetworkInterfacesInfo *GetNetworkInterfacesInfo(PbResult&);
 	PbMappingInfo *GetMappingInfo(PbResult&);

--- a/src/raspberrypi/protobuf_response_helper.h
+++ b/src/raspberrypi/protobuf_response_helper.h
@@ -32,6 +32,7 @@ public:
 
 	bool GetImageFile(PbImageFile *, const string&, const string&);
 	PbImageFilesInfo *GetAvailableImages(PbResult&, const string&);
+	PbReservedIds *GetReservedIds(PbResult&, const set<int>&);
 	void GetDevices(PbServerInfo&, const vector<Device *>&, const string&);
 	void GetDevicesInfo(PbResult&, const PbCommand&, const vector<Device *>&, const string&, int);
 	PbDeviceTypesInfo *GetDeviceTypesInfo(PbResult&, const PbCommand&);

--- a/src/raspberrypi/protobuf_response_helper.h
+++ b/src/raspberrypi/protobuf_response_helper.h
@@ -39,6 +39,7 @@ public:
 	PbServerInfo *GetServerInfo(PbResult&, const vector<Device *>&, const set<int>&, const string&, const string&);
 	PbNetworkInterfacesInfo *GetNetworkInterfacesInfo(PbResult&);
 	PbMappingInfo *GetMappingInfo(PbResult&);
+	PbLogLevelInfo *GetLogLevelInfo(PbResult&, const string&);
 
 private:
 
@@ -51,5 +52,4 @@ private:
 	void GetAllDeviceTypeProperties(PbDeviceTypesInfo&);
 	void GetDeviceTypeProperties(PbDeviceTypesInfo&, PbDeviceType);
 	void GetAvailableImages(PbResult& result, PbServerInfo&, const string&);
-	void GetLogLevels(PbServerInfo&);
 };

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1571,13 +1571,21 @@ static void *MonThread(void *param)
 					break;
 				}
 
-
 				case SERVER_INFO: {
 					LOGTRACE("Received %s command", PbOperation_Name(command.operation()).c_str());
 
 					PbResult result;
 					result.set_allocated_server_info(response_helper.GetServerInfo(
 							result, devices, reserved_ids, default_image_folder, current_log_level));
+					SerializeMessage(fd, result);
+					break;
+				}
+
+				case VERSION_INFO: {
+					LOGTRACE("Received %s command", PbOperation_Name(command.operation()).c_str());
+
+					PbResult result;
+					result.set_allocated_version_info(response_helper.GetVersionInfo(result));
 					SerializeMessage(fd, result);
 					break;
 				}

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1590,6 +1590,15 @@ static void *MonThread(void *param)
 					break;
 				}
 
+				case LOG_LEVEL_INFO: {
+					LOGTRACE("Received %s command", PbOperation_Name(command.operation()).c_str());
+
+					PbResult result;
+					result.set_allocated_log_level_info(response_helper.GetLogLevelInfo(result, current_log_level));
+					SerializeMessage(fd, result);
+					break;
+				}
+
 				case DEFAULT_IMAGE_FILES_INFO: {
 					LOGTRACE("Received %s command", PbOperation_Name(command.operation()).c_str());
 

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1236,11 +1236,11 @@ bool ProcessCmd(const int fd, const PbCommand& command)
 			DetachAll();
 			return ReturnStatus(fd);
 
-		case RESERVE: {
+		case RESERVE_IDS: {
 			const string ids = GetParam(command, "ids");
 			string invalid_id = SetReservedIds(ids);
 			if (!invalid_id.empty()) {
-				return ReturnStatus(fd, false, "Invalid ID " + invalid_id + " for " + PbOperation_Name(RESERVE));
+				return ReturnStatus(fd, false, "Invalid ID " + invalid_id + " for " + PbOperation_Name(RESERVE_IDS));
 			}
 
 			return ReturnStatus(fd);
@@ -1367,7 +1367,7 @@ bool ParseArgument(int argc, char* argv[], int& port)
 			case 'r': {
 					string invalid_id = SetReservedIds(optarg);
 					if (!invalid_id.empty()) {
-						cerr << "Invalid ID " << invalid_id << " for " << PbOperation_Name(RESERVE);
+						cerr << "Invalid ID " << invalid_id << " for " << PbOperation_Name(RESERVE_IDS);
 						return false;
 					}
 				}
@@ -1645,6 +1645,15 @@ static void *MonThread(void *param)
 
 					PbResult result;
 					result.set_allocated_mapping_info(response_helper.GetMappingInfo(result));
+					SerializeMessage(fd, result);
+					break;
+				}
+
+				case RESERVED_IDS_INFO: {
+					LOGTRACE("Received %s command", PbOperation_Name(command.operation()).c_str());
+
+					PbResult result;
+					result.set_allocated_reserved_ids(response_helper.GetReservedIds(result, reserved_ids));
 					SerializeMessage(fd, result);
 					break;
 				}

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -66,76 +66,79 @@ enum PbOperation {
     // Gets the server information
     SERVER_INFO = 10;
 
-    // Gets information on attached devices. Returns data for all attached devices if empty.
-    DEVICES_INFO = 11;
-    
+    // Gets rascsi version information
+    VERSION_INFO = 11;
+
+    // Gets information on attached devices. Returns data for all attached devices if the device list is empty.
+    DEVICES_INFO = 12;
+
     // Device properties by device type
-    DEVICE_TYPES_INFO = 12;
+    DEVICE_TYPES_INFO = 13;
 
     // Gets information on available image files in the default image folder.
-    DEFAULT_IMAGE_FILES_INFO = 13;
+    DEFAULT_IMAGE_FILES_INFO = 14;
     
     // Gets information on an image file (not necessarily in the default image folder) based on an absolute path.
     // Parameters:
     //   "file": The filename. Either an absolute path or a path relative to the default image folder.
-    IMAGE_FILE_INFO = 14;
+    IMAGE_FILE_INFO = 15;
 
     // Gets the names of the available network interfaces. Only lists interfaces that are up.
-    NETWORK_INTERFACES_INFO = 15;
+    NETWORK_INTERFACES_INFO = 16;
     
     // Gets the mapping of extensions to device types
-    MAPPING_INFO = 16;
+    MAPPING_INFO = 17;
 
     // Set the default folder for image files.
     // Parameters:
     //   "folder": The default folder name.
-    DEFAULT_FOLDER = 17;
+    DEFAULT_FOLDER = 18;
 
     // Set server log level.
     // Parameters:
     //   "level": The new log level
-    LOG_LEVEL = 18;
+    LOG_LEVEL = 19;
 
     // Block IDs from being used, usually the IDs of the initiators (computers) in the SCSI chain.
     // Parameters:
     //   "ids": A comma-separated list of IDs to reserve, or an empty string in order not to reserve any ID.
-    RESERVE = 19;
-    
+    RESERVE = 20;
+
     // Create an image file. The image file must not yet exist.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
     //   "size": The file size in bytes, must be a multiple of 512
     //   "read_only": "true" (case-insensitive) in order to create a read-only file, otherwise "false"
-    CREATE_IMAGE = 20;
+    CREATE_IMAGE = 21;
 
     // Delete an image file.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    DELETE_IMAGE = 21;
+    DELETE_IMAGE = 22;
 
     // Rename an image file.
     // Parameters:
     //   "from": The old filename, relative to the default image folder. It must not contain a slash.
     //   "to": The new filename, relative to the default image folder. It must not contain a slash.
     // The new filename must not yet exist.
-    RENAME_IMAGE = 22;
+    RENAME_IMAGE = 23;
 
     // Copy an image file.
     // Parameters:
     //   "from": The source filename, relative to the default image folder. It must not contain a slash.
     //   "to": The destination filename, relative to the default image folder. It must not contain a slash.
     // The destination filename must not yet exist.
-    COPY_IMAGE = 23;
+    COPY_IMAGE = 24;
     
     // Write-protect an image file.
     // Parameters:
     //  "file": The filename, relative to the default image folder. It must not contain a slash.
-    PROTECT_IMAGE = 24;
+    PROTECT_IMAGE = 25;
 
     // Make an image file writable.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
-    UNPROTECT_IMAGE = 25;
+    UNPROTECT_IMAGE = 26;
 }
 
 // The supported file extensions mapped to their respective device types
@@ -162,7 +165,7 @@ message PbDeviceProperties {
     // List of default parameters, if any (requires supports_params to be true)
     map<string, string> default_params = 8;
     // Number of supported LUNs, at least 1 (for LUN 0)
-    uint32 luns = 9;
+    int32 luns = 9;
     // Unordered list of permitted block sizes in bytes, empty if the block size is not configurable
     repeated uint32 block_sizes = 10;
 }
@@ -244,11 +247,19 @@ message PbDevice {
     // Block size in bytes
     int32 block_size = 11;
     // Number of blocks
-    int64 block_count = 12;
+    uint64 block_count = 12;
 }
 
 message PbDevices {
     repeated PbDevice devices = 1;
+}
+
+message PbVersionInfo {
+    // The rascsi version
+    int32 major_version = 1;
+    int32 minor_version = 2;
+    // < 0 for a development version, = 0 if there is no patch yet
+    int32 patch_version = 3;
 }
 
 // Commands rascsi can execute and their parameters
@@ -270,41 +281,39 @@ message PbResult {
     oneof result {
         // The result of a SERVER_INFO command
         PbServerInfo server_info = 3;
+        // The result of a VERSION_INFO command
+        PbVersionInfo version_info = 4;
         // The result of a DEVICE_INFO command
-        PbDevices device_info = 4;
+        PbDevices device_info = 5;
         // The result of a DEVICE_TYPES_INFO command
-        PbDeviceTypesInfo device_types_info = 5;
+        PbDeviceTypesInfo device_types_info = 6;
         // The result of a DEFAULT_IMAGE_FILES_INFO command
-        PbImageFilesInfo image_files_info = 6;
+        PbImageFilesInfo image_files_info = 7;
         // The result of an IMAGE_FILE_INFO command
-        PbImageFile image_file_info = 7;
+        PbImageFile image_file_info = 8;
         // The result of a NETWORK_INTERFACES_INFO command
-        PbNetworkInterfacesInfo network_interfaces_info = 8;
+        PbNetworkInterfacesInfo network_interfaces_info = 9;
         // The result of an MAPPING_INFO command
-        PbMappingInfo mapping_info = 9;
+        PbMappingInfo mapping_info = 10;
     }
 }
 
 // The rascsi server information
 message PbServerInfo {
-    // The rascsi server version
-    uint32 major_version = 1;
-    uint32 minor_version = 2;
-    // < 0 for a development version, = 0 if there is no patch yet
-    int32 patch_version = 3;
+    PbVersionInfo version_info = 1;
     // List of available log levels, ordered by increasing by severity
-    repeated string log_levels = 4;
-    string current_log_level = 5;
+    repeated string log_levels = 2;
+    string current_log_level = 3;
     // Supported device types and their properties, also available separately
-    PbDeviceTypesInfo device_types_info = 6;
+    PbDeviceTypesInfo device_types_info = 4;
     // The image files in the default folder, also available separately
-    PbImageFilesInfo image_files_info = 7;
+    PbImageFilesInfo image_files_info = 5;
     // The available (up) network interfaces, also available separately
-    PbNetworkInterfacesInfo network_interfaces_info = 8;
+    PbNetworkInterfacesInfo network_interfaces_info = 6;
     // The extensions to device types mapping
-    PbMappingInfo mapping_info = 9;
+    PbMappingInfo mapping_info = 7;
     // The attached devices, also available separately
-    PbDevices devices = 10;
+    PbDevices devices = 8;
     // The unsorted list of reserved IDs
-    repeated uint32 reserved_ids = 11;
+    repeated int32 reserved_ids = 9;
 }

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -91,57 +91,60 @@ enum PbOperation {
     
     // Get the mapping of extensions to device types
     MAPPING_INFO = 18;
+    
+    // Get the list of reserved device IDs
+    RESERVED_IDS_INFO = 19;
 
     // Set the default folder for image files.
     // Parameters:
     //   "folder": The default folder name.
-    DEFAULT_FOLDER = 19;
+    DEFAULT_FOLDER = 20;
 
     // Set a new log level.
     // Parameters:
     //   "level": The new log level
-    LOG_LEVEL = 20;
+    LOG_LEVEL = 21;
 
     // Block IDs from being used, usually the IDs of the initiators (computers) in the SCSI chain.
     // Parameters:
     //   "ids": A comma-separated list of IDs to reserve, or an empty string in order not to reserve any ID.
-    RESERVE = 21;
+    RESERVE_IDS = 22;
 
     // Create an image file. The image file must not yet exist.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
     //   "size": The file size in bytes, must be a multiple of 512
     //   "read_only": "true" (case-insensitive) in order to create a read-only file, otherwise "false"
-    CREATE_IMAGE = 22;
+    CREATE_IMAGE = 23;
 
     // Delete an image file.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    DELETE_IMAGE = 23;
+    DELETE_IMAGE = 24;
 
     // Rename an image file.
     // Parameters:
     //   "from": The old filename, relative to the default image folder. It must not contain a slash.
     //   "to": The new filename, relative to the default image folder. It must not contain a slash.
     // The new filename must not yet exist.
-    RENAME_IMAGE = 24;
+    RENAME_IMAGE = 25;
 
     // Copy an image file.
     // Parameters:
     //   "from": The source filename, relative to the default image folder. It must not contain a slash.
     //   "to": The destination filename, relative to the default image folder. It must not contain a slash.
     // The destination filename must not yet exist.
-    COPY_IMAGE = 25;
+    COPY_IMAGE = 26;
     
     // Write-protect an image file.
     // Parameters:
     //  "file": The filename, relative to the default image folder. It must not contain a slash.
-    PROTECT_IMAGE = 26;
+    PROTECT_IMAGE = 27;
 
     // Make an image file writable.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
-    UNPROTECT_IMAGE = 27;
+    UNPROTECT_IMAGE = 28;
 }
 
 // The supported file extensions mapped to their respective device types
@@ -264,6 +267,11 @@ message PbDevices {
     repeated PbDevice devices = 1;
 }
 
+// The reserved device IDs
+message PbReservedIds {
+    repeated int32 ids = 1;
+}
+
 // Rascsi server version information
 message PbVersionInfo {
     // The rascsi version
@@ -308,25 +316,27 @@ message PbResult {
         PbNetworkInterfacesInfo network_interfaces_info = 10;
         // The result of an MAPPING_INFO command
         PbMappingInfo mapping_info = 11;
+        // The result of a RESERVED_IDS_INFO command
+        PbReservedIds reserved_ids = 12;
     }
 }
 
-// The rascsi server information
+// The rascsi server information. All data can also be requested with individual commands.
 message PbServerInfo {
     // The rascsi server version data
     PbVersionInfo version_info = 1;
     // The available log levels and the current log level
     PbLogLevelInfo log_level_info = 2;
-    // Supported device types and their properties, also available separately
+    // Supported device types and their properties
     PbDeviceTypesInfo device_types_info = 3;
-    // The image files in the default folder, also available separately
+    // The image files in the default folder
     PbImageFilesInfo image_files_info = 4;
-    // The available (up) network interfaces, also available separately
+    // The available (up) network interfaces
     PbNetworkInterfacesInfo network_interfaces_info = 5;
     // The extensions to device types mapping
     PbMappingInfo mapping_info = 6;
-    // The attached devices, also available separately
+    // The attached devices
     PbDevices devices = 7;
-    // The unsorted list of reserved IDs
-    repeated int32 reserved_ids = 8;
+    // The reserved device IDs
+    PbReservedIds reserved_ids = 8;
 }

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -66,79 +66,82 @@ enum PbOperation {
     // Gets the server information
     SERVER_INFO = 10;
 
-    // Gets rascsi version information
+    // Get rascsi version information
     VERSION_INFO = 11;
 
-    // Gets information on attached devices. Returns data for all attached devices if the device list is empty.
+    // Get information on attached devices. Returns data for all attached devices if the device list is empty.
     DEVICES_INFO = 12;
 
-    // Device properties by device type
+    // Get device properties by device type
     DEVICE_TYPES_INFO = 13;
 
-    // Gets information on available image files in the default image folder.
+    // Get information on available image files in the default image folder.
     DEFAULT_IMAGE_FILES_INFO = 14;
     
-    // Gets information on an image file (not necessarily in the default image folder) based on an absolute path.
+    // Get information on an image file (not necessarily in the default image folder) based on an absolute path.
     // Parameters:
     //   "file": The filename. Either an absolute path or a path relative to the default image folder.
     IMAGE_FILE_INFO = 15;
 
-    // Gets the names of the available network interfaces. Only lists interfaces that are up.
-    NETWORK_INTERFACES_INFO = 16;
+    // Get information on the available log levels and the current log level
+    LOG_LEVEL_INFO = 16;
+
+    // Get the names of the available network interfaces. Only lists interfaces that are up.
+    NETWORK_INTERFACES_INFO = 17;
     
-    // Gets the mapping of extensions to device types
-    MAPPING_INFO = 17;
+    // Get the mapping of extensions to device types
+    MAPPING_INFO = 18;
 
     // Set the default folder for image files.
     // Parameters:
     //   "folder": The default folder name.
-    DEFAULT_FOLDER = 18;
+    DEFAULT_FOLDER = 19;
 
-    // Set server log level.
+    // Set a new log level.
     // Parameters:
     //   "level": The new log level
-    LOG_LEVEL = 19;
+    LOG_LEVEL = 20;
 
     // Block IDs from being used, usually the IDs of the initiators (computers) in the SCSI chain.
     // Parameters:
     //   "ids": A comma-separated list of IDs to reserve, or an empty string in order not to reserve any ID.
-    RESERVE = 20;
+    RESERVE = 21;
 
     // Create an image file. The image file must not yet exist.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
     //   "size": The file size in bytes, must be a multiple of 512
     //   "read_only": "true" (case-insensitive) in order to create a read-only file, otherwise "false"
-    CREATE_IMAGE = 21;
+    CREATE_IMAGE = 22;
 
     // Delete an image file.
     // Parameters:
     //    "file": The filename, relative to the default image folder. It must not contain a slash.
-    DELETE_IMAGE = 22;
+    DELETE_IMAGE = 23;
 
     // Rename an image file.
     // Parameters:
     //   "from": The old filename, relative to the default image folder. It must not contain a slash.
     //   "to": The new filename, relative to the default image folder. It must not contain a slash.
     // The new filename must not yet exist.
-    RENAME_IMAGE = 23;
+    RENAME_IMAGE = 24;
 
     // Copy an image file.
     // Parameters:
     //   "from": The source filename, relative to the default image folder. It must not contain a slash.
     //   "to": The destination filename, relative to the default image folder. It must not contain a slash.
     // The destination filename must not yet exist.
-    COPY_IMAGE = 24;
+    COPY_IMAGE = 25;
     
     // Write-protect an image file.
     // Parameters:
     //  "file": The filename, relative to the default image folder. It must not contain a slash.
-    PROTECT_IMAGE = 25;
+    PROTECT_IMAGE = 26;
 
     // Make an image file writable.
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
-    UNPROTECT_IMAGE = 26;
+    UNPROTECT_IMAGE = 27;
 }
 
 // The supported file extensions mapped to their respective device types
@@ -208,6 +211,13 @@ message PbImageFilesInfo {
     repeated PbImageFile image_files = 2;
 }
 
+// Log level information
+message PbLogLevelInfo {
+    // List of available log levels, ordered by increasing by severity
+    repeated string log_levels = 2;
+    string current_log_level = 3;
+}
+
 // The network interfaces information
 message PbNetworkInterfacesInfo {
     repeated string name = 1;
@@ -254,6 +264,7 @@ message PbDevices {
     repeated PbDevice devices = 1;
 }
 
+// Rascsi server version information
 message PbVersionInfo {
     // The rascsi version
     int32 major_version = 1;
@@ -283,37 +294,39 @@ message PbResult {
         PbServerInfo server_info = 3;
         // The result of a VERSION_INFO command
         PbVersionInfo version_info = 4;
+        // The result of a LOG_LEVEL_INFO command
+        PbLogLevelInfo log_level_info = 5;
         // The result of a DEVICE_INFO command
-        PbDevices device_info = 5;
+        PbDevices device_info = 6;
         // The result of a DEVICE_TYPES_INFO command
-        PbDeviceTypesInfo device_types_info = 6;
+        PbDeviceTypesInfo device_types_info = 7;
         // The result of a DEFAULT_IMAGE_FILES_INFO command
-        PbImageFilesInfo image_files_info = 7;
+        PbImageFilesInfo image_files_info = 8;
         // The result of an IMAGE_FILE_INFO command
-        PbImageFile image_file_info = 8;
+        PbImageFile image_file_info = 9;
         // The result of a NETWORK_INTERFACES_INFO command
-        PbNetworkInterfacesInfo network_interfaces_info = 9;
+        PbNetworkInterfacesInfo network_interfaces_info = 10;
         // The result of an MAPPING_INFO command
-        PbMappingInfo mapping_info = 10;
+        PbMappingInfo mapping_info = 11;
     }
 }
 
 // The rascsi server information
 message PbServerInfo {
+    // The rascsi server version data
     PbVersionInfo version_info = 1;
-    // List of available log levels, ordered by increasing by severity
-    repeated string log_levels = 2;
-    string current_log_level = 3;
+    // The available log levels and the current log level
+    PbLogLevelInfo log_level_info = 2;
     // Supported device types and their properties, also available separately
-    PbDeviceTypesInfo device_types_info = 4;
+    PbDeviceTypesInfo device_types_info = 3;
     // The image files in the default folder, also available separately
-    PbImageFilesInfo image_files_info = 5;
+    PbImageFilesInfo image_files_info = 4;
     // The available (up) network interfaces, also available separately
-    PbNetworkInterfacesInfo network_interfaces_info = 6;
+    PbNetworkInterfacesInfo network_interfaces_info = 5;
     // The extensions to device types mapping
-    PbMappingInfo mapping_info = 7;
+    PbMappingInfo mapping_info = 6;
     // The attached devices, also available separately
-    PbDevices devices = 8;
+    PbDevices devices = 7;
     // The unsorted list of reserved IDs
-    repeated int32 reserved_ids = 9;
+    repeated int32 reserved_ids = 8;
 }


### PR DESCRIPTION
This PR improves the interface granularity. All information provided by the SERVER_INFO command can now also be queried with individual. This is useful for clients with screens that only display partial information and/or use asynchronous request processing, e.g. apps or JavaScript.

@rdmark Note that PbServerInfo has changed. All data which were not yet available a separate messages have been extracted to individual messages. The data structures as such have not changed. Please see the .proto file for details