### PR TITLE
Detach all devices when shutting down/restarting

### DIFF
--- a/src/web/web.py
+++ b/src/web/web.py
@@ -449,7 +449,8 @@ def device_info():
 @app.route("/pi/reboot", methods=["POST"])
 def restart():
     detach_all()
-    flash("Restarting the Pi momentarily...")
+    flash("Safely detached all devices.")
+    flash("Rebooting the Pi momentarily...")
     reboot_pi()
     return redirect(url_for("index"))
 
@@ -457,14 +458,16 @@ def restart():
 @app.route("/rascsi/restart", methods=["POST"])
 def rascsi_restart():
     detach_all()
-    rascsi_service("restart")
+    flash("Safely detached all devices.")
     flash("Restarting RaSCSI Service...")
+    rascsi_service("restart")
     return redirect(url_for("index"))
 
 
 @app.route("/pi/shutdown", methods=["POST"])
 def shutdown():
     detach_all()
+    flash("Safely detached all devices.")
     flash("Shutting down the Pi momentarily...")
     shutdown_pi()
     return redirect(url_for("index"))


### PR DESCRIPTION
As per discussion in https://github.com/akuker/RASCSI/issues/317 we should issue a detach all command before shutting down rascsi to avoid data loss on the scsi host side.