### PR TITLE
Graceful shutdown of rascsi in the systemd service

### DIFF
--- a/src/raspberrypi/os_integration/rascsi.service
+++ b/src/raspberrypi/os_integration/rascsi.service
@@ -16,7 +16,7 @@ ExecStart=/usr/local/bin/rascsi -r 7
 #
 # ExecStart=/usr/local/bin/rascsi -r 0,7
 #
-# This functionality isn't implmented yet: ExecStop=/usr/local/bin/rasctl -stop
+ExecStop=/usr/local/bin/rasctl -X
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=RASCSI


### PR DESCRIPTION
Leverages the new 'rasctl -X' option to gracefully shut down rascsi