### PR TITLE
Bring back manual unzip

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -134,6 +134,16 @@
 		{% if file["name"] in attached_images %}
 		<center>Attached!</center>
 		{% else %}
+                {% if file["name"].lower().endswith(archive_file_suffix) %}
+                <form action="/files/unzip" method="post">
+                    <input type="hidden" name="image" value="{{file["name"]}}">
+                    <input type="submit" value="Unzip" />
+                </form>
+                <form action="/files/delete" method="post" onsubmit="return confirm('Delete file?')">
+                    <input type="hidden" name="image" value="{{file["name"]}}">
+                    <input type="submit" value="Delete" />
+                </form>
+		{% else %}
                 <form action="/scsi/attach" method="post">
                     <input type="hidden" name="file_name" value="{{file["name"]}}">
                     <input type="hidden" name="file_size" value="{{file["size"]}}">
@@ -168,6 +178,7 @@
 		    <input type="submit" value="Properties">
 		</form>
 		{% endif %}
+                {% endif %}
 		{% endif %}
             </td>
         </tr>
@@ -219,7 +230,7 @@
     <details>
     <summary>Upload File</summary>
     <ul>
-    <li>Uploads file to <tt>{{base_dir}}</tt>. The largest file size accepted is {{max_file_size}} MB. Zip files will be unzipped.</li>
+    <li>Uploads file to <tt>{{base_dir}}</tt>. The largest file size accepted is {{max_file_size}} MB.</li>
     <li>For unrecognized file types, try renaming hard drive images to '.hds' and CD-ROM images to '.iso' before uploading.</li>
     <li>Recognized file types: {{valid_file_suffix}}</li>
     </ul>

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -108,6 +108,7 @@ def index():
         device_types=device_types["device_types"],
         free_disk=int(disk["free"] / 1024 / 1024),
         valid_file_suffix=valid_file_suffix,
+        archive_file_suffix=ARCHIVE_FILE_SUFFIX,
         removable_device_types=REMOVABLE_DEVICE_TYPES,
     )
 
@@ -570,12 +571,9 @@ def upload_file():
             return make_response(("Transferred file corrupted!", 500))
         else:
             log.info(f"File {file.filename} has been uploaded successfully")
-            if filename.lower().endswith(".zip"):
-                unzip_file(filename)
     else:
         log.debug(f"Chunk {current_chunk + 1} of {total_chunks} "
                   f"for file {file.filename} completed.")
-
 
     return make_response(("File upload successful!", 200))
 
@@ -634,6 +632,18 @@ def delete():
             return redirect(url_for("index"))
 
     return redirect(url_for("index"))
+
+
+@app.route("/files/unzip", methods=["POST"])
+def unzip():
+    image = request.form.get("image")
+
+    if unzip_file(image):
+        flash("Unzipped file " + image)
+        return redirect(url_for("index"))
+    else:
+        flash("Failed to unzip " + image, "error")
+        return redirect(url_for("index"))
 
 
 @app.route("/files/prop", methods=["POST"])


### PR DESCRIPTION
Also remove automatic unzip on upload (which was flaky), and show only relevant controls for zip files

For the record: manual unzip was removed from develop at one point, when rascsi itself was aggressively filtering what was considered a valid image file, so zip files were filtered out. In the current develop, rascsi is more lenient with image validation.