### PR TITLE
Capture files being extracted from a zip archive as well as inflated ones

### DIFF
--- a/src/web/file_cmds.py
+++ b/src/web/file_cmds.py
@@ -154,7 +154,7 @@ def unzip_file(file_name):
         return {"status": False, "msg": stderr}
 
     from re import findall
-    unzipped = findall("inflating:(.+)\n", unzip_proc.stdout.decode("utf-8"))
+    unzipped = findall("(?:inflating|extracting):(.+)\n", unzip_proc.stdout.decode("utf-8"))
     return {"status": True, "msg": unzipped}
 
 


### PR DESCRIPTION
Improve the regex for unzip stdout to capture files being extracted in addition to inflated