### PR TITLE
Fix OLED screen rotation handling

### DIFF
--- a/src/oled_monitor/rascsi_oled_monitor.py
+++ b/src/oled_monitor/rascsi_oled_monitor.py
@@ -65,8 +65,10 @@ print("Will update the OLED display every " + str(DELAY_TIME_MS) + "ms (approxim
 if len(argv) > 1:
     if str(argv[1]) == "0":
         ROTATION = 0
+        print("Using 0 degrees screen rotation.")
     elif str(argv[1]) == "180":
         ROTATION = 2
+        print("Using 180 degrees screen rotation.")
     else:
         exit("Only 0 and 180 are valid arguments for screen rotation.")
 else:

--- a/src/oled_monitor/start.sh
+++ b/src/oled_monitor/start.sh
@@ -105,5 +105,10 @@ while [ "$1" != "" ]; do
     shift
 done
 
-echo "Starting OLED Screen with $ROTATION degrees rotation..."
-python3 rascsi_oled_monitor.py "${ROTATION}"
+echo "Starting OLED Screen..."
+if [ -z ${ROTATION+x} ]; then
+    echo "No screen rotation parameter given; falling back to the default."
+else
+    echo "Screen rotation set to $ROTATION degrees."
+fi
+python3 rascsi_oled_monitor.py ${ROTATION}


### PR DESCRIPTION
To address an issue reported by jrumball where the OLED script fails when no rotation parameter is passed to start.sh