### PR TITLE
DaynaPort: Remove scsi_cmd_read_6_t struct, it was not correct

### DIFF
--- a/src/raspberrypi/devices/scsi_daynaport.cpp
+++ b/src/raspberrypi/devices/scsi_daynaport.cpp
@@ -207,17 +207,16 @@ int SCSIDaynaPort::Read(const DWORD *cdb, BYTE *buf, uint64_t block)
 {
 	int rx_packet_size = 0;
 	scsi_resp_read_t *response = (scsi_resp_read_t*)buf;
-	scsi_cmd_read_6_t *command = (scsi_cmd_read_6_t*)cdb;
 
 	ostringstream s;
 	s << __PRETTY_FUNCTION__ << " reading DaynaPort block " << block;
 	LOGTRACE("%s", s.str().c_str());
 
-	if (command->operation_code != 0x08) {
-		LOGERROR("Received unexpected cdb command: %02X. Expected 0x08", command->operation_code);
+	if (cdb[0] != 0x08) {
+		LOGERROR("Received unexpected cdb command: %02X. Expected 0x08", cdb[0]);
 	}
 
-	int requested_length = command->transfer_length;
+	int requested_length = cdb[4];
 	LOGTRACE("%s Read maximum length %d, (%04X)", __PRETTY_FUNCTION__, requested_length, requested_length);
 
 

--- a/src/raspberrypi/devices/scsi_daynaport.h
+++ b/src/raspberrypi/devices/scsi_daynaport.h
@@ -151,11 +151,3 @@ private:
 	static const BYTE m_bcast_addr[6];
 	static const BYTE m_apple_talk_addr[6];
 };
-
-typedef struct __attribute__((packed)) {
-	BYTE operation_code;
-	BYTE lba_msb_bits_4_0;
-	uint16_t logical_block_address;
-	BYTE transfer_length;
-	BYTE control;
-} scsi_cmd_read_6_t;


### PR DESCRIPTION
The DWORDs in `cdb *` are not raw packed data from the wire, they
are manually copied in a previous function.  Trying to cast that
unpacked, aligned-on-byte-boundary data into the packed
scsi_cmd_read_6_t structure is not correct and does not put the
correct DWORDs into the proper fields.

Just do away with this struct and refer to the 2 cdb DWORDs (opcode
and length) manually.