### PR TITLE
Transliterate non-ASCII for display on the OLED screen

### DIFF
--- a/src/oled_monitor/ractl_cmds.py
+++ b/src/oled_monitor/ractl_cmds.py
@@ -2,6 +2,7 @@
 Module for commands sent to the RaSCSI backend service.
 """
 from os import path
+from unidecode import unidecode
 from socket_cmds import send_pb_command
 import rascsi_interface_pb2 as proto
 
@@ -34,7 +35,8 @@ def device_list():
         if dstat.locked and dprop.lockable:
             dstat_msg.append("Locked")
 
-        dfile = path.basename(result.devices_info.devices[i].file.name)
+        # Transliterate non-ASCII chars in the file name to ASCII
+        dfile = unidecode(path.basename(result.devices_info.devices[i].file.name))
         dven = result.devices_info.devices[i].vendor
         dprod = result.devices_info.devices[i].product
 

--- a/src/oled_monitor/requirements.txt
+++ b/src/oled_monitor/requirements.txt
@@ -13,3 +13,4 @@ rpi-ws281x==4.3.0
 RPi.GPIO==0.7.0
 sysv-ipc==1.1.0
 protobuf==3.17.3
+unidecode==1.3.2


### PR DESCRIPTION
- Since we're using a very simple font for the OLED screen with only ASCII chars (and not even a complete set of ASCII), this transliterates anything in other charsets to ASCII