### PR TITLE
Inquiry command length incorrect

### DIFF
--- a/src/raspberrypi/devices/scsihd.cpp
+++ b/src/raspberrypi/devices/scsihd.cpp
@@ -145,7 +145,7 @@ int SCSIHD::Inquiry(const DWORD *cdb, BYTE *buf)
 	buf[1] = IsRemovable() ? 0x80 : 0x00;
 	buf[2] = 0x02;
 	buf[3] = 0x02;
-	buf[4] = 122 + 3;	// Value close to real HDD
+	buf[4] = 28 + 3;	// Value close to real HDD
 
 	// Padded vendor, product, revision
 	memcpy(&buf[8], GetPaddedName().c_str(), 28);


### PR DESCRIPTION
Fix to only report the data that is actually supplied.
See issue #458 