### PR TITLE
Updates for running on Bullseye

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -79,8 +79,15 @@ function installRaScsi() {
 
     cd "$BASE/src/raspberrypi" || exit 1
 
+    # Compiler flags needed for gcc v10 and up
+    if [[ `gcc --version | awk '/gcc/' | awk -F ' ' '{print $3}' | awk -F '.' '{print $1}'` -ge 10 ]]; then
+        echo "gcc 10 or later detected. Will compile with the appropriate flags."
+        COMPILER_FLAGS="-DSPDLOG_FMT_EXTERNAL -DFMT_HEADER_ONLY"
+	echo $COMPILER_FLAGS
+    fi
+
     echo "Compiling with ${CORES-1} simultaneous cores..."
-    ( make clean && make -j "${CORES-1}" all CONNECT_TYPE="${CONNECT_TYPE-FULLSPEC}" && sudo make install CONNECT_TYPE="${CONNECT_TYPE-FULLSPEC}" ) </dev/null
+    ( make clean && EXTRA_FLAGS="$COMPILER_FLAGS" make -j "${CORES-1}" all CONNECT_TYPE="${CONNECT_TYPE-FULLSPEC}" && sudo make install CONNECT_TYPE="${CONNECT_TYPE-FULLSPEC}" ) </dev/null
 
     sudo sed -i "s@^ExecStart.*@& -F $VIRTUAL_DRIVER_PATH@" /etc/systemd/system/rascsi.service
     echo "Configured rascsi.service to use $VIRTUAL_DRIVER_PATH as default image dir."

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -81,7 +81,7 @@ function installRaScsi() {
 
     # Compiler flags needed for gcc v10 and up
     if [[ `gcc --version | awk '/gcc/' | awk -F ' ' '{print $3}' | awk -F '.' '{print $1}'` -ge 10 ]]; then
-        echo "gcc 10 or later detected. Will compile with the appropriate flags."
+        echo -n "gcc 10 or later detected. Will compile with the following flags: "
         COMPILER_FLAGS="-DSPDLOG_FMT_EXTERNAL -DFMT_HEADER_ONLY"
         echo $COMPILER_FLAGS
     fi

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -83,7 +83,7 @@ function installRaScsi() {
     if [[ `gcc --version | awk '/gcc/' | awk -F ' ' '{print $3}' | awk -F '.' '{print $1}'` -ge 10 ]]; then
         echo "gcc 10 or later detected. Will compile with the appropriate flags."
         COMPILER_FLAGS="-DSPDLOG_FMT_EXTERNAL -DFMT_HEADER_ONLY"
-	echo $COMPILER_FLAGS
+        echo $COMPILER_FLAGS
     fi
 
     echo "Compiling with ${CORES-1} simultaneous cores..."

--- a/src/oled_monitor/monitor_rascsi.service
+++ b/src/oled_monitor/monitor_rascsi.service
@@ -9,8 +9,6 @@ ExecStart=/home/pi/RASCSI/src/oled_monitor/start.sh
 ExecStop=/bin/echo "Shutting down the OLED Monitor gracefully..."
 ExecStop=/bin/pkill --signal 2 -f "python3 rascsi_oled_monitor.py"
 ExecStop=/bin/sleep 2
-StandardOutput=syslog
-StandardError=syslog
 SyslogIdentifier=RASCSIMON
 
 [Install]

--- a/src/raspberrypi/os_integration/rascsi.service
+++ b/src/raspberrypi/os_integration/rascsi.service
@@ -17,8 +17,6 @@ ExecStart=/usr/local/bin/rascsi -r 7
 # ExecStart=/usr/local/bin/rascsi -r 0,7
 #
 ExecStop=/usr/local/bin/rasctl -X
-StandardOutput=syslog
-StandardError=syslog
 SyslogIdentifier=RASCSI
 
 [Install]

--- a/src/web/service-infra/rascsi-web.service
+++ b/src/web/service-infra/rascsi-web.service
@@ -6,8 +6,6 @@ After=network.target
 Type=simple
 Restart=always
 ExecStart=/home/pi/RASCSI/src/web/start.sh
-StandardOutput=syslog
-StandardError=syslog
 SyslogIdentifier=RASCSIWEB
 
 [Install]


### PR DESCRIPTION
- Conditionally use compiler flags needed for gcc 10+
- Remove deprecated systemd options