### PR TITLE
Updated manpage path to /usr/local/man/man1

### DIFF
--- a/src/raspberrypi/Makefile
+++ b/src/raspberrypi/Makefile
@@ -57,7 +57,7 @@ RSYSLOG_CONF = /etc/rsyslog.d/rascsi.conf
 RSYSLOG_LOG  = /var/log/rascsi.log
 
 USR_LOCAL_BIN = /usr/local/bin
-MAN_PAGE_DIR  = /usr/share/man/man1
+MAN_PAGE_DIR  = /usr/local/man/man1
 DOC_DIR = ../../doc
 OS_FILES = ./os_integration
 


### PR DESCRIPTION
For consistency updated the manpage installation path in the Makefile to /usr/local/man, which is a link to /usr/share/man. So the effective location does not change.