### PR TITLE
User authentication in the Web Interface

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -873,7 +873,7 @@ function runChoice() {
           12)
               echo "Enabling authentication for the RaSCSI Web Interface"
               echo "This script will make the following changes to your system:"
-              echo "- Modify user groups"
+              echo "- Modify users and user groups"
               sudoCheck
               enableWebInterfaceAuth
               echo "Enabling authentication for the RaSCSI Web Interface - Complete!"

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -702,15 +702,17 @@ function notifyBackup {
 
 # Creates the group and modifies current user for Web Interface auth
 function enableWebInterfaceAuth {
-    if [ $(getent group rascsi) ]; then
-        echo "The 'rascsi' group already exists."
+    AUTH_GROUP="rascsi"
+
+    if [ $(getent group "$AUTH_GROUP") ]; then
+        echo "The '$AUTH_GROUP' group already exists."
     else
-        echo "Creating the 'rascsi' group."
-        sudo groupadd rascsi
+        echo "Creating the '$AUTH_GROUP' group."
+        sudo groupadd "$AUTH_GROUP"
     fi
 
-    echo "Adding user '$USER' to the 'rascsi' group."
-    sudo usermod -a -G rascsi "$USER"
+    echo "Adding user '$USER' to the '$AUTH_GROUP' group."
+    sudo usermod -a -G "$AUTH_GROUP" "$USER"
 }
 
 # Executes the keyword driven scripts for a particular action in the main menu

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -700,6 +700,19 @@ function notifyBackup {
     fi
 }
 
+# Creates the group and modifies current user for Web Interface auth
+function enableWebInterfaceAuth {
+    if [ $(getent group rascsi) ]; then
+        echo "The 'rascsi' group already exists."
+    else
+        echo "Creating the 'rascsi' group."
+        sudo groupadd rascsi
+    fi
+
+    echo "Adding user '$USER' to the 'rascsi' group."
+    sudo usermod -a -G rascsi "$USER"
+}
+
 # Executes the keyword driven scripts for a particular action in the main menu
 function runChoice() {
   case $1 in
@@ -855,6 +868,15 @@ function runChoice() {
               echo "Configuring RaSCSI Web Interface stand-alone - Complete!"
               echo "Launch the Web Interface with the 'start.sh' script. To use a custom port for the web server: 'start.sh --port=8081"
           ;;
+          12)
+              echo "Enabling authentication for the RaSCSI Web Interface"
+              echo "This script will make the following changes to your system:"
+              echo "- Modify user groups"
+              sudoCheck
+              enableWebInterfaceAuth
+              echo "Enabling authentication for the RaSCSI Web Interface - Complete!"
+              echo "Use the credentials for user '$USER' to log in to the Web Interface."
+          ;;
           -h|--help|h|help)
               showMenu
           ;;
@@ -868,7 +890,7 @@ function runChoice() {
 function readChoice() {
    choice=-1
 
-   until [ $choice -ge "0" ] && [ $choice -le "11" ]; do
+   until [ $choice -ge "0" ] && [ $choice -le "12" ]; do
        echo -n "Enter your choice (0-9) or CTRL-C to exit: "
        read -r choice
    done
@@ -897,6 +919,7 @@ function showMenu() {
     echo "ADVANCED OPTIONS"
     echo " 10) compile and install RaSCSI stand-alone"
     echo " 11) configure the RaSCSI Web Interface stand-alone"
+    echo " 12) enable authentication for the RaSCSI Web Interface"
 }
 
 # parse arguments passed to the script
@@ -919,7 +942,7 @@ while [ "$1" != "" ]; do
             ;;
     esac
     case $VALUE in
-        FULLSPEC | STANDARD | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11)
+        FULLSPEC | STANDARD | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12)
             ;;
         *)
             echo "ERROR: unknown option \"$VALUE\""

--- a/src/web/pi_cmds.py
+++ b/src/web/pi_cmds.py
@@ -116,3 +116,18 @@ def introspect_file(file_path, re_term):
         if match(re_term, line):
             return True
     return False
+
+
+def auth_active():
+    """
+    Inspects if the 'rascsi' group exists on the system.
+    If it exists, tell the webapp to enable authentication.
+    """
+    from grp import getgrall
+    groups = [g.gr_name for g in getgrall()]
+    if "rascsi" in groups:
+        return {
+                "status": True,
+                "msg": "You must log in to use this function!",
+                }
+    return {"status": False, "msg": ""}

--- a/src/web/pi_cmds.py
+++ b/src/web/pi_cmds.py
@@ -3,6 +3,7 @@ Module for methods controlling and getting information about the Pi's Linux syst
 """
 
 import subprocess
+from settings import AUTH_GROUP
 
 
 def systemd_service(service, action):
@@ -120,12 +121,13 @@ def introspect_file(file_path, re_term):
 
 def auth_active():
     """
-    Inspects if the 'rascsi' group exists on the system.
+    Inspects if the group defined in AUTH_GROUP exists on the system.
     If it exists, tell the webapp to enable authentication.
+    Returns a (dict) with (bool) status and (str) msg
     """
     from grp import getgrall
     groups = [g.gr_name for g in getgrall()]
-    if "rascsi" in groups:
+    if AUTH_GROUP in groups:
         return {
                 "status": True,
                 "msg": "You must log in to use this function!",

--- a/src/web/requirements.txt
+++ b/src/web/requirements.txt
@@ -6,5 +6,4 @@ Jinja2==3.0.1
 MarkupSafe==2.0.1
 protobuf==3.17.3
 requests==2.26.0
-flask-login==0.5.0
 simplepam==0.1.5

--- a/src/web/requirements.txt
+++ b/src/web/requirements.txt
@@ -6,3 +6,4 @@ Jinja2==3.0.1
 MarkupSafe==2.0.1
 protobuf==3.17.3
 requests==2.26.0
+flask-login==0.5.0

--- a/src/web/requirements.txt
+++ b/src/web/requirements.txt
@@ -7,3 +7,4 @@ MarkupSafe==2.0.1
 protobuf==3.17.3
 requests==2.26.0
 flask-login==0.5.0
+simplepam==0.1.5

--- a/src/web/settings.py
+++ b/src/web/settings.py
@@ -27,3 +27,6 @@ REMOVABLE_DEVICE_TYPES = ("SCCD", "SCRM", "SCMO")
 # The RESERVATIONS list is used to keep track of the reserved ID memos.
 # Initialize with a list of 8 empty strings.
 RESERVATIONS = ["" for x in range(0, 8)]
+
+# The user group that is used for webapp authentication
+AUTH_GROUP = "rascsi"

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -31,12 +31,23 @@
 <body>
 <div class="content">
     <div class="header">
-<span style="display: inline-block; width: 100%; color: white; background-color: green; text-align: center; vertical-align: center; font-family: Arial, Helvetica, sans-serif;">Service Running</span>
+        {% if username %}
+        <span style="display: inline-block; width: 100%; color: white; background-color: green; text-align: center; vertical-align: center; font-family: Arial, Helvetica, sans-serif;">Logged in as {{ username }} &#8211; <a href="/logout">Log Out</a></span>
+        {% else %}
+        <span style="display: inline-block; width: 100%; color: white; background-color: red; text-align: center; vertical-align: center; font-family: Arial, Helvetica, sans-serif;">
+            <form method="POST" action="/login">
+            <div>Log In to Use Web Interface</div>
+            <input type="text" name="username" placeholder="Username">
+            <input type="password" name="password" placeholder="Password">
+            <input type="submit" value="Login">
+            </form>
+        </span>
+        {% endif %}
     <table width="100%">
         <tbody>
         <tr style="background-color: black;">
             <td style="background-color: black;">
-                <a href="http://github.com/akuker/RASCSI">
+                <a href="http://github.com/akuker/RASCSI" target="_blank">
                     <h1>RaSCSI - 68kmla Edition</h1>
                 </a>
             </td>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -33,7 +33,7 @@
     <div class="header">
         {% if auth_active %}
         {% if username %}
-        <span style="display: inline-block; width: 100%; color: white; background-color: green; text-align: center; vertical-align: center; font-family: Arial, Helvetica, sans-serif;">Logged in as {{ username }} &#8211; <a href="/logout">Log Out</a></span>
+        <span style="display: inline-block; width: 100%; color: white; background-color: green; text-align: center; vertical-align: center; font-family: Arial, Helvetica, sans-serif;">Logged in as <em>{{ username }}</em> &#8211; <a href="/logout">Log Out</a></span>
         {% else %}
         <span style="display: inline-block; width: 100%; color: white; background-color: red; text-align: center; vertical-align: center; font-family: Arial, Helvetica, sans-serif;">
             <form method="POST" action="/login">

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -31,6 +31,7 @@
 <body>
 <div class="content">
     <div class="header">
+        {% if auth_active %}
         {% if username %}
         <span style="display: inline-block; width: 100%; color: white; background-color: green; text-align: center; vertical-align: center; font-family: Arial, Helvetica, sans-serif;">Logged in as {{ username }} &#8211; <a href="/logout">Log Out</a></span>
         {% else %}
@@ -42,6 +43,9 @@
             <input type="submit" value="Login">
             </form>
         </span>
+        {% endif %}
+        {% else %}
+        <span style="display: inline-block; width: 100%; color: white; background-color: green; text-align: center; vertical-align: center; font-family: Arial, Helvetica, sans-serif;">Web Interface Authentication Disabled &#8211; See <a href="https://github.com/akuker/RASCSI/wiki/Web-Interface#Security_Notice" target="_blank">Wiki</a> for more information</span>
         {% endif %}
     <table width="100%">
         <tbody>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -68,7 +68,7 @@
         {% block content %}{% endblock content %}
     </div>
     <div class="footer">
-        <center><tt>RaSCSI version: <strong>{{ version }} <a href="https://github.com/akuker/RASCSI/commit/{{ running_env['git'] }}">{{ running_env["git"][:7] }}</a></strong></tt></center>
+        <center><tt>RaSCSI version: <strong>{{ version }} <a href="https://github.com/akuker/RASCSI/commit/{{ running_env['git'] }}" target="_blank">{{ running_env["git"][:7] }}</a></strong></tt></center>
         <center><tt>Pi environment: {{ running_env["env"] }}</tt></center>
     </div>
 </div>

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -795,6 +795,9 @@ def upload_file():
     Uploads a file from the local computer to the images dir on the Pi
     Depending on the Dropzone.js JavaScript library
     """
+    if "username" not in session:
+        return make_response(("You must log in to use this function!", 403))
+
     from werkzeug.utils import secure_filename
     from os import path
 

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -227,10 +227,15 @@ def login():
     """
     username = request.form["username"]
     password = request.form["password"]
-    if authenticate(str(username), str(password)):
-        session["username"] = request.form["username"]
-        return redirect(url_for("index"))
-    flash("Invalid username/password", "error")
+
+    from grp import getgrall
+
+    groups = [g.gr_name for g in getgrall() if username in g.gr_mem]
+    if "sudo" in groups:
+        if authenticate(str(username), str(password)):
+            session["username"] = request.form["username"]
+            return redirect(url_for("index"))
+    flash("Must log in with credentials for a user with sudoers privileges!", "error")
     return redirect(url_for("index"))
 
 

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -44,6 +44,7 @@ from pi_cmds import (
     disk_space,
     get_ip_address,
     introspect_file,
+    auth_active,
 )
 from ractl_cmds import (
     attach_image,
@@ -149,6 +150,7 @@ def index():
         removable_file_suffix=tuple(server_info["scrm"]),
         mo_file_suffix=tuple(server_info["scmo"]),
         username=username,
+        auth_active=auth_active()["status"],
         ARCHIVE_FILE_SUFFIX=ARCHIVE_FILE_SUFFIX,
         PROPERTIES_SUFFIX=PROPERTIES_SUFFIX,
         REMOVABLE_DEVICE_TYPES=REMOVABLE_DEVICE_TYPES,
@@ -217,6 +219,7 @@ def drive_list():
         free_disk=int(disk["free"] / 1024 / 1024),
         cdrom_file_suffix=tuple(server_info["sccd"]),
         username=username,
+        auth_active=auth_active()["status"],
     )
 
 
@@ -231,11 +234,11 @@ def login():
     from grp import getgrall
 
     groups = [g.gr_name for g in getgrall() if username in g.gr_mem]
-    if "sudo" in groups:
+    if "rascsi" in groups:
         if authenticate(str(username), str(password)):
             session["username"] = request.form["username"]
             return redirect(url_for("index"))
-    flash("You must log in with credentials for a user with sudoers privileges!", "error")
+    flash("You must log in with credentials for a user in the 'rascsi' group!", "error")
     return redirect(url_for("index"))
 
 
@@ -261,8 +264,9 @@ def drive_create():
     """
     Creates the image and properties file pair
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     vendor = request.form.get("vendor")
@@ -303,8 +307,9 @@ def drive_cdrom():
     """
     Creates a properties file for a CD-ROM image
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     vendor = request.form.get("vendor")
@@ -335,8 +340,9 @@ def config_save():
     """
     Saves a config file to disk
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     file_name = request.form.get("name") or "default"
@@ -356,8 +362,9 @@ def config_load():
     """
     Loads a config file from disk
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     file_name = request.form.get("name")
@@ -412,8 +419,9 @@ def log_level():
     """
     Sets RaSCSI backend log level
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     level = request.form.get("level") or "info"
@@ -432,8 +440,9 @@ def daynaport_attach():
     """
     Attaches a DaynaPORT ethernet adapter device
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     scsi_id = request.form.get("scsi_id")
@@ -480,8 +489,9 @@ def attach():
     """
     Attaches a file image as a device
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     file_name = request.form.get("file_name")
@@ -536,8 +546,9 @@ def detach_all_devices():
     """
     Detaches all currently attached devices
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     process = detach_all()
@@ -554,8 +565,9 @@ def detach():
     """
     Detaches a specified device
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     scsi_id = request.form.get("scsi_id")
@@ -575,8 +587,9 @@ def eject():
     """
     Ejects a specified removable device image, but keeps the device attached
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     scsi_id = request.form.get("scsi_id")
@@ -631,8 +644,9 @@ def reserve_id():
     """
     Reserves a SCSI ID and stores the memo for that reservation
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     scsi_id = request.form.get("scsi_id")
@@ -653,8 +667,9 @@ def unreserve_id():
     """
     Removes the reservation of a SCSI ID as well as the memo for the reservation
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     scsi_id = request.form.get("scsi_id")
@@ -674,8 +689,9 @@ def restart():
     """
     Restarts the Pi
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     detach_all()
@@ -690,8 +706,9 @@ def rascsi_restart():
     """
     Restarts the RaSCSI backend service
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     detach_all()
@@ -707,8 +724,9 @@ def shutdown():
     """
     Shuts down the Pi
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     detach_all()
@@ -723,8 +741,9 @@ def download_to_iso():
     """
     Downloads a remote file and creates a CD-ROM image formatted with HFS that contains the file
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     scsi_id = request.form.get("scsi_id")
@@ -753,8 +772,9 @@ def download_img():
     """
     Downloads a remote file onto the images dir on the Pi
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     url = request.form.get("url")
@@ -774,8 +794,9 @@ def download_afp():
     """
     Downloads a remote file onto the AFP shared dir on the Pi
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     url = request.form.get("url")
@@ -795,8 +816,9 @@ def upload_file():
     Uploads a file from the local computer to the images dir on the Pi
     Depending on the Dropzone.js JavaScript library
     """
-    if "username" not in session:
-        return make_response(("You must log in to use this function!", 403))
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        return make_response(auth["msg"], 403)
 
     from werkzeug.utils import secure_filename
     from os import path
@@ -846,8 +868,9 @@ def create_file():
     """
     Creates an empty image file in the images dir
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     file_name = request.form.get("file_name")
@@ -871,8 +894,9 @@ def download():
     """
     Downloads a file from the Pi to the local computer
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     image = request.form.get("file")
@@ -884,8 +908,9 @@ def delete():
     """
     Deletes a specified file in the images dir
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     file_name = request.form.get("image")
@@ -916,8 +941,9 @@ def unzip():
     """
     Unzips a specified zip file
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
+    auth = auth_active()
+    if auth["status"] and "username" not in session:
+        flash(auth["msg"], "error")
         return redirect(url_for("index"))
 
     zip_file = request.form.get("zip_file")

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -795,10 +795,6 @@ def upload_file():
     Uploads a file from the local computer to the images dir on the Pi
     Depending on the Dropzone.js JavaScript library
     """
-    if "username" not in session:
-        flash("You must log in to use this function!", "error")
-        return redirect(url_for("index"))
-
     from werkzeug.utils import secure_filename
     from os import path
 

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -235,7 +235,7 @@ def login():
         if authenticate(str(username), str(password)):
             session["username"] = request.form["username"]
             return redirect(url_for("index"))
-    flash("Must log in with credentials for a user with sudoers privileges!", "error")
+    flash("You must log in with credentials for a user with sudoers privileges!", "error")
     return redirect(url_for("index"))
 
 

--- a/src/web/web.py
+++ b/src/web/web.py
@@ -5,7 +5,6 @@ Module for the Flask app rendering and endpoints
 import logging
 from sys import argv
 from pathlib import Path
-from simplepam import authenticate
 
 from flask import (
     Flask,
@@ -74,6 +73,7 @@ from settings import (
     DRIVE_PROPERTIES_FILE,
     REMOVABLE_DEVICE_TYPES,
     RESERVATIONS,
+    AUTH_GROUP,
 )
 
 APP = Flask(__name__)
@@ -231,14 +231,15 @@ def login():
     username = request.form["username"]
     password = request.form["password"]
 
+    from simplepam import authenticate
     from grp import getgrall
 
     groups = [g.gr_name for g in getgrall() if username in g.gr_mem]
-    if "rascsi" in groups:
+    if AUTH_GROUP in groups:
         if authenticate(str(username), str(password)):
             session["username"] = request.form["username"]
             return redirect(url_for("index"))
-    flash("You must log in with credentials for a user in the 'rascsi' group!", "error")
+    flash(f"You must log in with credentials for a user in the '{AUTH_GROUP}' group!", "error")
     return redirect(url_for("index"))
 
 


### PR DESCRIPTION
- Introduce login endpoint that authenticates with Linux users in the sudo group using the simplepam library
- Introduce logout endpoint that removes the authenticated user from the session
- Add a login form to the header of the base page (instead of the now-useless "service active" banner), and a logout link for when logged in
- Stops execution of potentially destructive endpoints unless a user is actively authenticated
- Open links to github in new tabs (since there's a heightened risk for misclicking now)