### PR TITLE
Bump to Macproxy release 21.12.1

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -333,7 +333,7 @@ function startRaScsiScreen() {
 }
 
 # Starts the macproxy service if installed
-function startRaScsiScreen() {
+function startMacproxy() {
     if [ -f "$SYSTEMD_PATH/macproxy.service" ]; then
         sudo systemctl start macproxy.service
         showMacproxyStatus
@@ -356,7 +356,7 @@ function showRaScsiScreenStatus() {
 }
 
 # Shows status for the macproxy service
-function showRaScsiScreenStatus() {
+function showMacproxyStatus() {
     systemctl status macproxy | tee
 }
 

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -699,9 +699,8 @@ function installMacproxy {
         exit 1
     fi
     cd "$HOME" || exit 1
-    wget -O "macproxy-$MACPROXY_VER.tar.gz" "https://github.com/rdmark/macproxy/archive/refs/tags/v$MACPROXY_VER.tar.gz" </dev/null
+    wget -O "macproxy-$MACPROXY_VER.tar.gz" "https://github.com/rdmark/macproxy/archive/refs/tags/$MACPROXY_VER.tar.gz" </dev/null
     tar -xzvf "macproxy-$MACPROXY_VER.tar.gz"
-    cd "$MACPROXY_PATH" || exit 1
 
     stopMacproxy
     sudo cp "$MACPROXY_PATH/macproxy.service" "$SYSTEMD_PATH"

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -672,7 +672,7 @@ function installMacproxy {
 
     ( sudo apt-get update && sudo apt-get install python3 python3-venv --assume-yes ) </dev/null
 
-    MACPROXY_VER="21.11"
+    MACPROXY_VER="21.12.1"
     MACPROXY_PATH="$HOME/macproxy-$MACPROXY_VER"
     if [ -d "$MACPROXY_PATH" ]; then
         echo "The $MACPROXY_PATH directory already exists. Delete it to proceed with the installation."


### PR DESCRIPTION
- Macproxy 21.12.1 fixes an issue where the start script errors out when running from a release package (and not a git repo)
- Adds script functions for starting and stopping Macproxy