### PR TITLE
Optional authentication by access token

### DIFF
--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -5,6 +5,7 @@ rascsi \- Emulates SCSI devices using the Raspberry Pi GPIO pins
 .B rascsi
 [\fB\-F\f® \fIFOLDER\fR]
 [\fB\-L\f® \fILOG_LEVEL\fR]
+[\fB\-P\f® \fIACCESS_TOKEN_FILE\fR]
 [\fB\-h\fR]
 [\fB\-n\fR \fIVENDOR:PRODUCT:REVISION\fR]
 [\fB\-p\f® \fIPORT\fR]
@@ -51,6 +52,9 @@ The default folder for image files. For files in this folder no absolute path ne
 .TP
 .BR \-L\fI " " \fILOG_LEVEL
 The rascsi log level (trace, debug, info, warn, err, critical, off). The default log level is 'info'.
+.TP
+.BR \-P\fI " " \fIACCESS_TOKEN_FILE
+Enable authentication and read the access token from the specified file.
 .TP
 .BR \-h\fI " " \fI
 Show a help page.

--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -54,7 +54,7 @@ The default folder for image files. For files in this folder no absolute path ne
 The rascsi log level (trace, debug, info, warn, err, critical, off). The default log level is 'info'.
 .TP
 .BR \-P\fI " " \fIACCESS_TOKEN_FILE
-Enable authentication and read the access token from the specified file.
+Enable authentication and read the access token from the specified file. The access token file must be owned by root and must be readable by root only.
 .TP
 .BR \-h\fI " " \fI
 Show a help page.

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -67,24 +67,25 @@ OPTIONS
 
        -P ACCESS_TOKEN_FILE
               Enable  authentication and read the access token from the speci‐
-              fied file.
+              fied file. The access token file must be owned by root and  must
+              be readable by root only.
 
        -h     Show a help page.
 
        -n VENDOR:PRODUCT:REVISION
-              Set the vendor, product and revision for the device, to  be  re‐
-              turned  with the INQUIRY data. A complete set of name components
+              Set  the  vendor, product and revision for the device, to be re‐
+              turned with the INQUIRY data. A complete set of name  components
               must be provided. VENDOR may have up to 8, PRODUCT up to 16, RE‐
-              VISION  up  to  4  characters. Padding with blanks to the maxium
-              length is automatically applied. Once set the name of  a  device
+              VISION up to 4 characters. Padding with  blanks  to  the  maxium
+              length  is  automatically applied. Once set the name of a device
               cannot be changed.
 
        -p PORT
               The rascsi server port, default is 6868.
 
        -r RESERVED_IDS
-              Comma-separated  list  of  IDs to reserve.  -p TYPE The optional
-              case-insensitive device type  (SAHD,  SCHD,  SCRM,  SCCD,  SCMO,
+              Comma-separated list of IDs to reserve.  -p  TYPE  The  optional
+              case-insensitive  device  type  (SAHD,  SCHD,  SCRM, SCCD, SCMO,
               SCBR, SCDP). If no type is specified for devices that support an
               image file, rascsi tries to derive the type from the file exten‐
               sion.
@@ -92,17 +93,17 @@ OPTIONS
        -v     Display the rascsi version.
 
        -IDn[:u] FILE
-              n  is  the  SCSI  ID  number (0-7). u (0-31) is the optional LUN
+              n is the SCSI ID number (0-7). u  (0-31)  is  the  optional  LUN
               (logical unit). The default LUN is 0.
 
-              FILE is the name of the image file to use for the  SCSI  device.
-              For  devices  that  do  not support an image file (SCBR, SCDP) a
+              FILE  is  the name of the image file to use for the SCSI device.
+              For devices that do not support an image  file  (SCBR,  SCDP)  a
               dummy name must be provided.
 
        -HDn[:u] FILE
-              n is the SASI ID number (0-15). The effective SASI ID is  calcu‐
-              lated  as  n/2,  the effective SASI LUN is calculated is the re‐
-              mainder of n/2. Alternatively the n:u syntax can be used,  where
+              n  is the SASI ID number (0-15). The effective SASI ID is calcu‐
+              lated as n/2, the effective SASI LUN is calculated  is  the  re‐
+              mainder  of n/2. Alternatively the n:u syntax can be used, where
               ns is the SASI ID (0-7) and u the LUN (0-1).
 
               FILE is the name of the image file to use for the SASI device.
@@ -119,7 +120,7 @@ EXAMPLES
           rascsi -ID0 /path/to/harddrive.hda -ID2 /path/to/cdimage.iso
 
        Launch RaSCSI with a removable SCSI drive image as ID 0 and the raw de‐
-       vice file /dev/hdb (e.g. a USB stick) and a DaynaPort  network  adapter
+       vice  file  /dev/hdb (e.g. a USB stick) and a DaynaPort network adapter
        as ID 6:
           rascsi -ID0 -t scrm /dev/hdb -ID6 -t scdp DUMMY_FILENAME
 

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -1,16 +1,14 @@
 !!   ------ THIS FILE IS AUTO_GENERATED! DO NOT MANUALLY UPDATE!!!
-!!   ------ The native file is rascsi.1. Re-run 'make docs' after updating
-
-
+!!   ------ The native file is rascsi.1. Re-run 'make docs' after updating\n\n
 rascsi(1)                   General Commands Manual                  rascsi(1)
 
 NAME
        rascsi - Emulates SCSI devices using the Raspberry Pi GPIO pins
 
 SYNOPSIS
-       rascsi  [-F[u00AE]  FOLDER] [-L[u00AE] LOG_LEVEL] [-h] [-n VENDOR:PROD‐
-       UCT:REVISION]  [-p[u00AE]  PORT]  [-r  RESERVED_IDS]  [-n  TYPE]   [-v]
-       [-IDn:[u] FILE] [-HDn[:u] FILE]...
+       rascsi  [-F[u00AE]  FOLDER] [-L[u00AE] LOG_LEVEL] [-P[u00AE] ACCESS_TO‐
+       KEN_FILE] [-h] [-n VENDOR:PRODUCT:REVISION] [-p[u00AE]  PORT]  [-r  RE‐
+       SERVED_IDS] [-n TYPE] [-v] [-IDn:[u] FILE] [-HDn[:u] FILE]...
 
 DESCRIPTION
        rascsi Emulates SCSI devices using the Raspberry Pi GPIO pins.
@@ -67,22 +65,26 @@ OPTIONS
               The rascsi log level (trace, debug, info, warn,  err,  critical,
               off). The default log level is 'info'.
 
+       -P ACCESS_TOKEN_FILE
+              Enable  authentication and read the access token from the speci‐
+              fied file.
+
        -h     Show a help page.
 
        -n VENDOR:PRODUCT:REVISION
-              Set  the  vendor, product and revision for the device, to be re‐
-              turned with the INQUIRY data. A complete set of name  components
+              Set the vendor, product and revision for the device, to  be  re‐
+              turned  with the INQUIRY data. A complete set of name components
               must be provided. VENDOR may have up to 8, PRODUCT up to 16, RE‐
-              VISION up to 4 characters. Padding with  blanks  to  the  maxium
-              length  is  automatically applied. Once set the name of a device
+              VISION  up  to  4  characters. Padding with blanks to the maxium
+              length is automatically applied. Once set the name of  a  device
               cannot be changed.
 
        -p PORT
               The rascsi server port, default is 6868.
 
        -r RESERVED_IDS
-              Comma-separated list of IDs to reserve.  -p  TYPE  The  optional
-              case-insensitive  device  type  (SAHD,  SCHD,  SCRM, SCCD, SCMO,
+              Comma-separated  list  of  IDs to reserve.  -p TYPE The optional
+              case-insensitive device type  (SAHD,  SCHD,  SCRM,  SCCD,  SCMO,
               SCBR, SCDP). If no type is specified for devices that support an
               image file, rascsi tries to derive the type from the file exten‐
               sion.
@@ -90,17 +92,17 @@ OPTIONS
        -v     Display the rascsi version.
 
        -IDn[:u] FILE
-              n is the SCSI ID number (0-7). u  (0-31)  is  the  optional  LUN
+              n  is  the  SCSI  ID  number (0-7). u (0-31) is the optional LUN
               (logical unit). The default LUN is 0.
 
-              FILE  is  the name of the image file to use for the SCSI device.
-              For devices that do not support an image  file  (SCBR,  SCDP)  a
+              FILE is the name of the image file to use for the  SCSI  device.
+              For  devices  that  do  not support an image file (SCBR, SCDP) a
               dummy name must be provided.
 
        -HDn[:u] FILE
-              n  is the SASI ID number (0-15). The effective SASI ID is calcu‐
-              lated as n/2, the effective SASI LUN is calculated  is  the  re‐
-              mainder  of n/2. Alternatively the n:u syntax can be used, where
+              n is the SASI ID number (0-15). The effective SASI ID is  calcu‐
+              lated  as  n/2,  the effective SASI LUN is calculated is the re‐
+              mainder of n/2. Alternatively the n:u syntax can be used,  where
               ns is the SASI ID (0-7) and u the LUN (0-1).
 
               FILE is the name of the image file to use for the SASI device.
@@ -117,7 +119,7 @@ EXAMPLES
           rascsi -ID0 /path/to/harddrive.hda -ID2 /path/to/cdimage.iso
 
        Launch RaSCSI with a removable SCSI drive image as ID 0 and the raw de‐
-       vice  file  /dev/hdb (e.g. a USB stick) and a DaynaPort network adapter
+       vice file /dev/hdb (e.g. a USB stick) and a DaynaPort  network  adapter
        as ID 6:
           rascsi -ID0 -t scrm /dev/hdb -ID6 -t scdp DUMMY_FILENAME
 

--- a/doc/rasctl.1
+++ b/doc/rasctl.1
@@ -12,6 +12,7 @@ rasctl \- Sends management commands to the rascsi process
 \fB\-I\fR |
 \fB\-L\fR |
 \fB\-O\fR |
+\fB\-P\fR |
 \fB\-T\fR |
 \fB\-V\fR |
 \fB\-X\fR |
@@ -71,6 +72,9 @@ Lists all available network interfaces provided that they are up.
 .TP
 .BR \-O\fI
 Display the available rascsi server log levels and the current log level.
+.TP
+.BR \-P\fI
+Prompt for the access token in case rascsi requires authentication.
 .TP
 .BR \-l\fI
 List all of the devices that are currently being emulated by RaSCSI, as well as their current status.

--- a/doc/rasctl_man_page.txt
+++ b/doc/rasctl_man_page.txt
@@ -1,15 +1,13 @@
 !!   ------ THIS FILE IS AUTO_GENERATED! DO NOT MANUALLY UPDATE!!!
-!!   ------ The native file is rasctl.1. Re-run 'make docs' after updating
-
-
+!!   ------ The native file is rasctl.1. Re-run 'make docs' after updating\n\n
 rascsi(1)                   General Commands Manual                  rascsi(1)
 
 NAME
        rasctl - Sends management commands to the rascsi process
 
 SYNOPSIS
-       rasctl  -e | -l | -m | -s | -v | -D | -I | -L | -O | -T | -V | -X | [-C
-       FILENAME:FILESIZE]   [-E   FILENAME]   [-F   IMAGE_FOLDER]   [-R   CUR‐
+       rasctl -e | -l | -m | -s | -v | -D | -I | -L | -O | -P | -T | -V | -X |
+       [-C  FILENAME:FILESIZE]  [-E  FILENAME]  [-F  IMAGE_FOLDER]  [-R   CUR‐
        RENT_NAME:NEW_NAME]  [-c  CMD] [-f FILE|PARAM] [-g LOG_LEVEL] [-h HOST]
        [-i ID [-n NAME] [-p PORT] [-r RESERVED_IDS] [-t TYPE]  [-u  UNIT]  [-x
        CURRENT_NAME:NEW_NAME]
@@ -55,10 +53,13 @@ OPTIONS
        -O     Display the available rascsi server log levels and  the  current
               log level.
 
-       -l     List  all  of  the  devices that are currently being emulated by
+       -P     Prompt  for the access token in case rascsi requires authentica‐
+              tion.
+
+       -l     List all of the devices that are  currently  being  emulated  by
               RaSCSI, as well as their current status.
 
-       -m     List all file extensions recognized by  RaSCSI  and  the  device
+       -m     List  all  file  extensions  recognized by RaSCSI and the device
               types they map to.
 
        -R CURRENT_NAME:NEW_NAME
@@ -70,7 +71,7 @@ OPTIONS
        -r RESERVED_IDS
               Comma-separated list of IDs to reserve.
 
-       -s     Display  server-side settings like available images or supported
+       -s     Display server-side settings like available images or  supported
               device types.
 
        -T     Display all device types and their properties.
@@ -94,7 +95,7 @@ OPTIONS
                  d(etach): Detach disk
                  i(nsert): Insert media (removable media devices only)
                  e(ject): Eject media (removable media devices only)
-                 p(rotect): Write protect the medium (not for  CD-ROMs,  which
+                 p(rotect):  Write  protect the medium (not for CD-ROMs, which
               are always read-only)
                  u(nprotect): Remove write protection from the medium (not for
               CD-ROMs, which are always read-only)
@@ -104,18 +105,18 @@ OPTIONS
 
        -b BLOCK_SIZE
               The optional block size. For SCSI drives 512, 1024, 2048 or 4096
-              bytes,  default  size  is 512 bytes. For SASI drives 256 or 1024
+              bytes, default size is 512 bytes. For SASI drives  256  or  1024
               bytes, default is 256 bytes.
 
        -f FILE|PARAM
               Device-specific: Either a path to a disk image file, or a param‐
-              eter  for a non-disk device. See the rascsi(1) man page for per‐
+              eter for a non-disk device. See the rascsi(1) man page for  per‐
               mitted file types.
 
        -t TYPE
-              Specifies the device type. This type overrides the type  derived
+              Specifies  the device type. This type overrides the type derived
               from  the  file  extension  of  the  specified  image.  See  the
-              rascsi(1) man page for the  available  device  types.  For  some
+              rascsi(1)  man  page  for  the  available device types. For some
               types there are shortcuts (only the first letter is required):
                  hd: SCSI hard disk drive
                  rm: SCSI removable media drive
@@ -125,16 +126,16 @@ OPTIONS
                  daynaport: DaynaPORT network adapter
 
        -n VENDOR:PRODUCT:REVISION
-              The  vendor, product and revision for the device, to be returned
+              The vendor, product and revision for the device, to be  returned
               with the INQUIRY data. A complete set of name components must be
               provided. VENDOR may have up to 8, PRODUCT up to 16, REVISION up
               to 4 characters. Padding with blanks to the maxium length is au‐
-              tomatically  applied.  Once  set  the name of a device cannot be
+              tomatically applied. Once set the name of  a  device  cannot  be
               changed.
 
        -u UNIT
-              Unit number (0-31). This will default to 0. This option is  only
-              used  when there are multiple SCSI devices on a shared SCSI con‐
+              Unit  number (0-31). This will default to 0. This option is only
+              used when there are multiple SCSI devices on a shared SCSI  con‐
               troller. (This is not common)
 
 EXAMPLES

--- a/src/raspberrypi/protobuf_util.cpp
+++ b/src/raspberrypi/protobuf_util.cpp
@@ -120,7 +120,7 @@ int protobuf_util::ReadNBytes(int fd, uint8_t *buf, int n)
 }
 
 
-bool protobuf_util::ReturnStatus(int fd, bool status, const string msg)
+bool protobuf_util::ReturnStatus(int fd, bool status, const string msg, const PbErrorCode error_code)
 {
 	if (!status && !msg.empty()) {
 		LOGERROR("%s", msg.c_str());
@@ -142,6 +142,7 @@ bool protobuf_util::ReturnStatus(int fd, bool status, const string msg)
 	else {
 		PbResult result;
 		result.set_status(status);
+		result.set_error_code(error_code);
 		result.set_msg(msg);
 		SerializeMessage(fd, result);
 	}

--- a/src/raspberrypi/protobuf_util.h
+++ b/src/raspberrypi/protobuf_util.h
@@ -29,6 +29,6 @@ namespace protobuf_util
 	void SerializeMessage(int, const google::protobuf::Message&);
 	void DeserializeMessage(int, google::protobuf::Message&);
 	int ReadNBytes(int, uint8_t *, int);
-	bool ReturnStatus(int, bool = true, const string = "");
+	bool ReturnStatus(int, bool = true, const string = "", const PbErrorCode error_code = PbErrorCode::NO_ERROR_CODE);
 	bool ReturnStatus(int, bool, const ostringstream&);
 }

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1416,8 +1416,7 @@ static void *MonThread(void *param)
 			PbCommand command;
 			DeserializeMessage(fd, command);
 
-			// VERSION_INFO is the only operation that never requires authentication
-			if (command.operation() != VERSION_INFO && !access_token.empty()) {
+			if (!access_token.empty()) {
 				if (access_token != GetParam(command, "token")) {
 					ReturnStatus(fd, false, "Authentication failed", PbErrorCode::UNAUTHORIZED);
 					continue;

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1418,7 +1418,7 @@ static void *MonThread(void *param)
 			// VERSION_INFO is the only operation that never requires authentication
 			if (command.operation() != VERSION_INFO && !access_token.empty()) {
 				if (access_token != GetParam(command, "token")) {
-					ReturnStatus(fd, false, "Authentication failed");
+					ReturnStatus(fd, false, "Authentication failed", PbErrorCode::UNAUTHORIZED);
 					continue;
 				}
 			}

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1011,7 +1011,7 @@ bool ProcessCmd(int fd, const PbDeviceDefinition& pb_device, const PbCommand& co
 			assert(dryRun);
 			break;
 
-		case NONE:
+		case NO_OPERATION:
 			// Do nothing, just log
 			LOGTRACE("Received %s command", PbOperation_Name(operation).c_str());
 			break;

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1415,6 +1415,7 @@ static void *MonThread(void *param)
 			PbCommand command;
 			DeserializeMessage(fd, command);
 
+			// VERSION_INFO is the only operation that never requires authentication
 			if (command.operation() != VERSION_INFO && !access_token.empty()) {
 				if (access_token != GetParam(command, "token")) {
 					ReturnStatus(fd, false, "Authentication failed");

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1011,6 +1011,7 @@ bool ProcessCmd(int fd, const PbDeviceDefinition& pb_device, const PbCommand& co
 			assert(dryRun);
 			break;
 
+		case CHECK_AUTHENTICATION:
 		case NO_OPERATION:
 			// Do nothing, just log
 			LOGTRACE("Received %s command", PbOperation_Name(operation).c_str());

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1415,7 +1415,7 @@ static void *MonThread(void *param)
 			PbCommand command;
 			DeserializeMessage(fd, command);
 
-			if (!access_token.empty()) {
+			if (command.operation() != VERSION_INFO && !access_token.empty()) {
 				if (access_token != GetParam(command, "token")) {
 					ReturnStatus(fd, false, "Authentication failed");
 					continue;

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -31,7 +31,7 @@ enum PbDeviceType {
 
 // rascsi remote operations, returning PbResult
 enum PbOperation {
-    NONE = 0;
+    NO_OPERATION = 0;
 
     // Attach devices and return the new device list (PbDevicesInfo)
     // Parameters (mutually exclusive):
@@ -163,7 +163,7 @@ enum PbErrorCode {
     // No error code available
     NO_ERROR_CODE = 0;
     // Authentication/Authorization error
-    UNAUTHORIZED = 403;
+    UNAUTHORIZED = 1;
 }
 
 // The supported file extensions mapped to their respective device types

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -158,6 +158,14 @@ enum PbOperation {
     UNPROTECT_IMAGE = 29;
 }
 
+// rascsi special purpose error codes for cases where a textual error message is not sufficient
+enum PbErrorCode {
+    // No error code available
+    NO_ERROR_CODE = 0;
+    // Authentication/Authorization error
+    UNAUTHORIZED = 403;
+}
+
 // The supported file extensions mapped to their respective device types
 message PbMappingInfo {
     map<string, PbDeviceType> mapping = 1;
@@ -307,6 +315,8 @@ message PbResult {
     bool status = 1;
     // An optional error or information message, depending on the status. A string without trailing CR/LF.
     string msg = 2;
+    // An optional error code. Only to be used in cases where textual information is not sufficient.
+    PbErrorCode error_code = 13;
     // Optional additional result data
     oneof result {
         // The result of a SERVER_INFO command

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -158,7 +158,8 @@ enum PbOperation {
     UNPROTECT_IMAGE = 29;
     
     // Check whether an authentication token is valid. A client can use this in operation  in order
-    // to use rascsi authentication for securing client-internal operations.
+    // find out whether rascsi authentication is enable or to use rascsi authentication for securing
+    // client-internal operations.
     CHECK_AUTHENTICATION = 30;
 }
 

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -157,7 +157,7 @@ enum PbOperation {
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
     UNPROTECT_IMAGE = 29;
     
-    // Check whether an authentication token is valid. A client can use this in operation  in order
+    // Check whether an authentication token is valid. A client can use this in operation  in order to
     // find out whether rascsi authentication is enable or to use rascsi authentication for securing
     // client-internal operations.
     CHECK_AUTHENTICATION = 30;

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -2,6 +2,8 @@
 // Each rascsi message sent to the rascsi server is preceded by the magic string "RASCSI".
 // A message starts with a little endian 32 bit header which contains the protobuf message size.
 // Unless explicitly specified the order of repeated data returned is undefined.
+// All operations accept an optional access token, specified by the "token" parameter.
+// Only the VERSION_INFO operation never requires authentication.
 //
 
 syntax = "proto3";

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -156,6 +156,10 @@ enum PbOperation {
     // Parameters:
     //   "file": The filename, relative to the default image folder. It must not contain a slash.
     UNPROTECT_IMAGE = 29;
+    
+    // Check whether an authentication token is valid. A client can use this in operation  in order
+    // to use rascsi authentication for securing client-internal operations.
+    CHECK_AUTHENTICATION = 30;
 }
 
 // rascsi special purpose error codes for cases where a textual error message is not sufficient

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
 		cerr << "version " << rascsi_get_version_string() << " (" << __DATE__ << ", " << __TIME__ << ")" << endl;
 		cerr << "Usage: " << argv[0] << " -i ID [-u UNIT] [-c CMD] [-C FILE] [-t TYPE] [-b BLOCK_SIZE] [-n NAME] [-f FILE|PARAM] ";
 		cerr << "[-F IMAGE_FOLDER] [-L LOG_LEVEL] [-h HOST] [-p PORT] [-r RESERVED_IDS] ";
-		cerr << "[-C FILENAME:FILESIZE] [-d FILENAME] [-w FILENAME] [-R CURRENT_NAME:NEW_NAME] [-x CURRENT_NAME:NEW_NAME] ";
+		cerr << "[-C FILENAME:FILESIZE] [-d FILENAME] [-w FILENAME] [-P TOKEN] [-R CURRENT_NAME:NEW_NAME] [-x CURRENT_NAME:NEW_NAME] ";
 		cerr << "[-e] [-E FILENAME] [-D] [-I] [-l] [-L] [-m] [-O] [-s] [-v] [-V] [-y] [-X]" << endl;
 		cerr << " where  ID := {0-7}" << endl;
 		cerr << "        UNIT := {0-31}, default is 0" << endl;
@@ -134,11 +134,12 @@ int main(int argc, char* argv[])
 	string reserved_ids;
 	string image_params;
 	string filename;
+	string token;
 	bool list = false;
 
 	opterr = 1;
 	int opt;
-	while ((opt = getopt(argc, argv, "elmsvDINOTVXa:b:c:d:f:h:i:n:p:r:t:u:x:C:E:F:L:R:")) != -1) {
+	while ((opt = getopt(argc, argv, "elmsvDINOPTVXa:b:c:d:f:h:i:n:p:r:t:u:x:C:E:F:L:R:")) != -1) {
 		switch (opt) {
 			case 'i': {
 				int id;
@@ -301,6 +302,10 @@ int main(int argc, char* argv[])
 				exit(EXIT_SUCCESS);
 				break;
 
+			case 'P':
+				token = getpass("Password: ");
+				break;
+
 			case 'V':
 				command.set_operation(VERSION_INFO);
 				break;
@@ -329,7 +334,7 @@ int main(int argc, char* argv[])
 	if (list) {
 		PbCommand command_list;
 		command_list.set_operation(DEVICES_INFO);
-		RasctlCommands rasctl_commands(command_list, hostname, port);
+		RasctlCommands rasctl_commands(command_list, hostname, port, token);
 		rasctl_commands.CommandDevicesInfo();
 		exit(EXIT_SUCCESS);
 	}
@@ -340,7 +345,7 @@ int main(int argc, char* argv[])
 		AddParam(*device, "file", param);
 	}
 
-	RasctlCommands rasctl_commands(command, hostname, port);
+	RasctlCommands rasctl_commands(command, hostname, port, token);
 
 	switch(command.operation()) {
 		case LOG_LEVEL:

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -52,7 +52,7 @@ PbOperation ParseOperation(const char *optarg)
 			return DEVICES_INFO;
 
 		default:
-			return NONE;
+			return NO_OPERATION;
 	}
 }
 
@@ -177,7 +177,7 @@ int main(int argc, char* argv[])
 
 			case 'c':
 				command.set_operation(ParseOperation(optarg));
-				if (command.operation() == NONE) {
+				if (command.operation() == NO_OPERATION) {
 					cerr << "Error: Unknown operation '" << optarg << "'" << endl;
 					exit(EXIT_FAILURE);
 				}

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -139,7 +139,7 @@ int main(int argc, char* argv[])
 
 	opterr = 1;
 	int opt;
-	while ((opt = getopt(argc, argv, "elmsvDINOPTVXa:b:c:d:f:h:i:n:p:r:t:u:x:C:E:F:L:R:")) != -1) {
+	while ((opt = getopt(argc, argv, "elmsvDINOTVXa:b:c:d:f:h:i:n:p:r:t:u:x:C:E:F:L:R:P::")) != -1) {
 		switch (opt) {
 			case 'i': {
 				int id;
@@ -303,7 +303,7 @@ int main(int argc, char* argv[])
 				break;
 
 			case 'P':
-				token = getpass("Password: ");
+				token = optarg ? optarg : getpass("Password: ");
 				break;
 
 			case 'V':

--- a/src/raspberrypi/rasctl_commands.cpp
+++ b/src/raspberrypi/rasctl_commands.cpp
@@ -25,15 +25,20 @@ using namespace std;
 using namespace rascsi_interface;
 using namespace protobuf_util;
 
-RasctlCommands::RasctlCommands(PbCommand& command, const string& hostname, int port)
+RasctlCommands::RasctlCommands(PbCommand& command, const string& hostname, int port, const string& token)
 {
 	this->command = command;
 	this->hostname = hostname;
 	this->port = port;
+	this->token = token;
 }
 
 void RasctlCommands::SendCommand()
 {
+	if (!token.empty()) {
+		AddParam(command, "token", token);
+	}
+
 	// Send command
 	int fd = -1;
 	try {

--- a/src/raspberrypi/rasctl_commands.h
+++ b/src/raspberrypi/rasctl_commands.h
@@ -20,7 +20,7 @@ class RasctlCommands
 {
 public:
 
-	RasctlCommands(PbCommand&, const string&, int);
+	RasctlCommands(PbCommand&, const string&, int, const string&);
 	~RasctlCommands() {};
 
 	void SendCommand();
@@ -48,6 +48,7 @@ private:
 	PbCommand command;
 	string hostname;
 	int port;
+	string token;
 
 	PbResult result;
 


### PR DESCRIPTION
Authentication is enabled with the new rascsi -P option, which expects the full path of a token file. The first line of the token file is the token string. The token file must be owned by root and must be readable by root only.
When started with the new -P option rascsl prompts the user for a password.

```
>rasctl -l
Error: Authentication failed
>rasctl -l -P
Password:
No images currently attached.
```

The VERSION_INFO operation is the only operation that does not require authentication, because a client may need the version number in order to make decisions on how to proceed. @rdmark I'm not really sure whether VERSION_INFO should be covered by authentication or not and would like to hear your thoughts on this.

In order to be able to handle authentication errors specifically without parsing an error message string (error message string contents are undefined and may change any time) the PbErrorCode enum was introduced, see .proto file.

All changes are backwards compatible.