### PR TITLE
Recursive image file scan and image file filter

### DIFF
--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -5,7 +5,7 @@ rascsi \- Emulates SCSI devices using the Raspberry Pi GPIO pins
 .B rascsi
 [\fB\-F\f® \fIFOLDER\fR]
 [\fB\-L\f® \fILOG_LEVEL\fR]
-[\fB\-R\fR]
+[\fB\-R\fR \fISCAN_DEPTH\fR]
 [\fB\-h\fR]
 [\fB\-n\fR \fIVENDOR:PRODUCT:REVISION\fR]
 [\fB\-p\f® \fIPORT\fR]
@@ -53,8 +53,8 @@ The default folder for image files. For files in this folder no absolute path ne
 .BR \-L\fI " " \fILOG_LEVEL
 The rascsi log level (trace, debug, info, warn, err, critical, off). The default log level is 'info'.
 .TP
-.BR \-R\fI " " \fI
-List image files recursively. Be careful when using this option with many sub-folders in the default image folder.
+.BR \-R\fI " " \fISCAN_DEPTH
+Scan for image files recursively, up to a depth -f SCAN_DEPTH. Be careful when using this option with many sub-folders in the default image folder.
 .TP
 .BR \-h\fI " " \fI
 Show a help page.

--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -5,6 +5,7 @@ rascsi \- Emulates SCSI devices using the Raspberry Pi GPIO pins
 .B rascsi
 [\fB\-F\f® \fIFOLDER\fR]
 [\fB\-L\f® \fILOG_LEVEL\fR]
+[\fB\-R\fR]
 [\fB\-h\fR]
 [\fB\-n\fR \fIVENDOR:PRODUCT:REVISION\fR]
 [\fB\-p\f® \fIPORT\fR]
@@ -51,6 +52,9 @@ The default folder for image files. For files in this folder no absolute path ne
 .TP
 .BR \-L\fI " " \fILOG_LEVEL
 The rascsi log level (trace, debug, info, warn, err, critical, off). The default log level is 'info'.
+.TP
+.BR \-R\fI " " \fI
+List image files recursively. Be careful when using this option with many sub-folders in the default image folder.
 .TP
 .BR \-h\fI " " \fI
 Show a help page.

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -6,9 +6,9 @@ NAME
        rascsi - Emulates SCSI devices using the Raspberry Pi GPIO pins
 
 SYNOPSIS
-       rascsi  [-F[u00AE]  FOLDER]  [-L[u00AE]  LOG_LEVEL]  [-R] [-h] [-n VEN‐
-       DOR:PRODUCT:REVISION] [-p[u00AE] PORT] [-r RESERVED_IDS] [-n TYPE] [-v]
-       [-IDn:[u] FILE] [-HDn[:u] FILE]...
+       rascsi  [-F[u00AE]  FOLDER]  [-L[u00AE] LOG_LEVEL] [-R SCAN_DEPTH] [-h]
+       [-n VENDOR:PRODUCT:REVISION] [-p[u00AE]  PORT]  [-r  RESERVED_IDS]  [-n
+       TYPE] [-v] [-IDn:[u] FILE] [-HDn[:u] FILE]...
 
 DESCRIPTION
        rascsi Emulates SCSI devices using the Raspberry Pi GPIO pins.
@@ -65,25 +65,27 @@ OPTIONS
               The rascsi log level (trace, debug, info, warn,  err,  critical,
               off). The default log level is 'info'.
 
-       -R     List  image files recursively. Be careful when using this option
-              with many sub-folders in the default image folder.
+       -R SCAN_DEPTH
+              Scan  for  image files recursively, up to a depth -f SCAN_DEPTH.
+              Be careful when using this option with many sub-folders  in  the
+              default image folder.
 
        -h     Show a help page.
 
        -n VENDOR:PRODUCT:REVISION
-              Set the vendor, product and revision for the device, to  be  re‐
-              turned  with the INQUIRY data. A complete set of name components
+              Set  the  vendor, product and revision for the device, to be re‐
+              turned with the INQUIRY data. A complete set of name  components
               must be provided. VENDOR may have up to 8, PRODUCT up to 16, RE‐
-              VISION  up  to  4  characters. Padding with blanks to the maxium
-              length is automatically applied. Once set the name of  a  device
+              VISION up to 4 characters. Padding with  blanks  to  the  maxium
+              length  is  automatically applied. Once set the name of a device
               cannot be changed.
 
        -p PORT
               The rascsi server port, default is 6868.
 
        -r RESERVED_IDS
-              Comma-separated  list  of  IDs to reserve.  -p TYPE The optional
-              case-insensitive device type  (SAHD,  SCHD,  SCRM,  SCCD,  SCMO,
+              Comma-separated list of IDs to reserve.  -p  TYPE  The  optional
+              case-insensitive  device  type  (SAHD,  SCHD,  SCRM, SCCD, SCMO,
               SCBR, SCDP). If no type is specified for devices that support an
               image file, rascsi tries to derive the type from the file exten‐
               sion.
@@ -91,17 +93,17 @@ OPTIONS
        -v     Display the rascsi version.
 
        -IDn[:u] FILE
-              n  is  the  SCSI  ID  number (0-7). u (0-31) is the optional LUN
+              n is the SCSI ID number (0-7). u  (0-31)  is  the  optional  LUN
               (logical unit). The default LUN is 0.
 
-              FILE is the name of the image file to use for the  SCSI  device.
-              For  devices  that  do  not support an image file (SCBR, SCDP) a
+              FILE  is  the name of the image file to use for the SCSI device.
+              For devices that do not support an image  file  (SCBR,  SCDP)  a
               dummy name must be provided.
 
        -HDn[:u] FILE
-              n is the SASI ID number (0-15). The effective SASI ID is  calcu‐
-              lated  as  n/2,  the effective SASI LUN is calculated is the re‐
-              mainder of n/2. Alternatively the n:u syntax can be used,  where
+              n  is the SASI ID number (0-15). The effective SASI ID is calcu‐
+              lated as n/2, the effective SASI LUN is calculated  is  the  re‐
+              mainder  of n/2. Alternatively the n:u syntax can be used, where
               ns is the SASI ID (0-7) and u the LUN (0-1).
 
               FILE is the name of the image file to use for the SASI device.
@@ -118,7 +120,7 @@ EXAMPLES
           rascsi -ID0 /path/to/harddrive.hda -ID2 /path/to/cdimage.iso
 
        Launch RaSCSI with a removable SCSI drive image as ID 0 and the raw de‐
-       vice file /dev/hdb (e.g. a USB stick) and a DaynaPort  network  adapter
+       vice  file  /dev/hdb (e.g. a USB stick) and a DaynaPort network adapter
        as ID 6:
           rascsi -ID0 -t scrm /dev/hdb -ID6 -t scdp DUMMY_FILENAME
 

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -1,15 +1,13 @@
 !!   ------ THIS FILE IS AUTO_GENERATED! DO NOT MANUALLY UPDATE!!!
-!!   ------ The native file is rascsi.1. Re-run 'make docs' after updating
-
-
+!!   ------ The native file is rascsi.1. Re-run 'make docs' after updating\n\n
 rascsi(1)                   General Commands Manual                  rascsi(1)
 
 NAME
        rascsi - Emulates SCSI devices using the Raspberry Pi GPIO pins
 
 SYNOPSIS
-       rascsi  [-F[u00AE]  FOLDER] [-L[u00AE] LOG_LEVEL] [-h] [-n VENDOR:PROD‐
-       UCT:REVISION]  [-p[u00AE]  PORT]  [-r  RESERVED_IDS]  [-n  TYPE]   [-v]
+       rascsi  [-F[u00AE]  FOLDER]  [-L[u00AE]  LOG_LEVEL]  [-R] [-h] [-n VEN‐
+       DOR:PRODUCT:REVISION] [-p[u00AE] PORT] [-r RESERVED_IDS] [-n TYPE] [-v]
        [-IDn:[u] FILE] [-HDn[:u] FILE]...
 
 DESCRIPTION
@@ -67,22 +65,25 @@ OPTIONS
               The rascsi log level (trace, debug, info, warn,  err,  critical,
               off). The default log level is 'info'.
 
+       -R     List  image files recursively. Be careful when using this option
+              with many sub-folders in the default image folder.
+
        -h     Show a help page.
 
        -n VENDOR:PRODUCT:REVISION
-              Set  the  vendor, product and revision for the device, to be re‐
-              turned with the INQUIRY data. A complete set of name  components
+              Set the vendor, product and revision for the device, to  be  re‐
+              turned  with the INQUIRY data. A complete set of name components
               must be provided. VENDOR may have up to 8, PRODUCT up to 16, RE‐
-              VISION up to 4 characters. Padding with  blanks  to  the  maxium
-              length  is  automatically applied. Once set the name of a device
+              VISION  up  to  4  characters. Padding with blanks to the maxium
+              length is automatically applied. Once set the name of  a  device
               cannot be changed.
 
        -p PORT
               The rascsi server port, default is 6868.
 
        -r RESERVED_IDS
-              Comma-separated list of IDs to reserve.  -p  TYPE  The  optional
-              case-insensitive  device  type  (SAHD,  SCHD,  SCRM, SCCD, SCMO,
+              Comma-separated  list  of  IDs to reserve.  -p TYPE The optional
+              case-insensitive device type  (SAHD,  SCHD,  SCRM,  SCCD,  SCMO,
               SCBR, SCDP). If no type is specified for devices that support an
               image file, rascsi tries to derive the type from the file exten‐
               sion.
@@ -90,17 +91,17 @@ OPTIONS
        -v     Display the rascsi version.
 
        -IDn[:u] FILE
-              n is the SCSI ID number (0-7). u  (0-31)  is  the  optional  LUN
+              n  is  the  SCSI  ID  number (0-7). u (0-31) is the optional LUN
               (logical unit). The default LUN is 0.
 
-              FILE  is  the name of the image file to use for the SCSI device.
-              For devices that do not support an image  file  (SCBR,  SCDP)  a
+              FILE is the name of the image file to use for the  SCSI  device.
+              For  devices  that  do  not support an image file (SCBR, SCDP) a
               dummy name must be provided.
 
        -HDn[:u] FILE
-              n  is the SASI ID number (0-15). The effective SASI ID is calcu‐
-              lated as n/2, the effective SASI LUN is calculated  is  the  re‐
-              mainder  of n/2. Alternatively the n:u syntax can be used, where
+              n is the SASI ID number (0-15). The effective SASI ID is  calcu‐
+              lated  as  n/2,  the effective SASI LUN is calculated is the re‐
+              mainder of n/2. Alternatively the n:u syntax can be used,  where
               ns is the SASI ID (0-7) and u the LUN (0-1).
 
               FILE is the name of the image file to use for the SASI device.
@@ -117,7 +118,7 @@ EXAMPLES
           rascsi -ID0 /path/to/harddrive.hda -ID2 /path/to/cdimage.iso
 
        Launch RaSCSI with a removable SCSI drive image as ID 0 and the raw de‐
-       vice  file  /dev/hdb (e.g. a USB stick) and a DaynaPort network adapter
+       vice file /dev/hdb (e.g. a USB stick) and a DaynaPort  network  adapter
        as ID 6:
           rascsi -ID0 -t scrm /dev/hdb -ID6 -t scdp DUMMY_FILENAME
 

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -68,7 +68,7 @@ pthread_mutex_t ctrl_mutex;					// Semaphore for the ctrl array
 static void *MonThread(void *param);
 string current_log_level;			// Some versions of spdlog do not support get_log_level()
 set<int> reserved_ids;
-bool recursive_image_files = false;
+bool recursive_image_file_scan = false;
 DeviceFactory& device_factory = DeviceFactory::instance();
 RascsiImage rascsi_image;
 RascsiResponse rascsi_response(&device_factory, &rascsi_image);
@@ -1206,7 +1206,7 @@ bool ParseArgument(int argc, char* argv[], int& port)
 				continue;
 
 			case 'R':
-				recursive_image_files = true;
+				recursive_image_file_scan = true;
 				continue;
 
 			case 'n':
@@ -1432,7 +1432,8 @@ static void *MonThread(void *param)
 
 					PbResult result;
 					result.set_allocated_server_info(rascsi_response.GetServerInfo(
-							result, devices, reserved_ids, current_log_level, recursive_image_files));
+							result, devices, reserved_ids, current_log_level, GetParam(command, "filename_pattern"),
+							recursive_image_file_scan));
 					SerializeMessage(fd, result);
 					break;
 				}
@@ -1459,7 +1460,8 @@ static void *MonThread(void *param)
 					LOGTRACE("Received %s command", PbOperation_Name(command.operation()).c_str());
 
 					PbResult result;
-					result.set_allocated_image_files_info(rascsi_response.GetAvailableImages(result, recursive_image_files));
+					result.set_allocated_image_files_info(rascsi_response.GetAvailableImages(result,
+							GetParam(command, "filename_pattern"), recursive_image_file_scan));
 					SerializeMessage(fd, result);
 					break;
 				}

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -64,7 +64,9 @@ enum PbOperation {
     // Make medium writable (not possible for read-only media)
     UNPROTECT = 9;
 
-    // Gets the server information (PbServerInfo)
+    // Gets the server information (PbServerInfo). Calling this operation should be avoided because it
+    // may return a lot of data. More specific other operations should be used instead.
+    // "filename_pattern": Optional filter, only filenames containing the case-insensitive pattern are returned
     SERVER_INFO = 10;
 
     // Get rascsi version information (PbVersionInfo)
@@ -78,6 +80,8 @@ enum PbOperation {
     DEVICE_TYPES_INFO = 13;
 
     // Get information on available image files in the default image folder (PbImageFilesInfo)
+    // Parameters:
+    // "filename_pattern": Optional filter, only filenames containing the case-insensitive pattern are returned
     DEFAULT_IMAGE_FILES_INFO = 14;
     
     // Get information on an image file (not necessarily in the default image folder) based on an absolute path.

--- a/src/raspberrypi/rascsi_response.cpp
+++ b/src/raspberrypi/rascsi_response.cpp
@@ -141,68 +141,70 @@ bool RascsiResponse::GetImageFile(PbImageFile *image_file, const string& filenam
 }
 
 void RascsiResponse::GetAvailableImages(PbImageFilesInfo& image_files_info, const string& default_image_folder,
-		const string& folder, const string& pattern, bool recursive) {
+		const string& folder, const string& pattern, int scan_depth) {
 	string pattern_lower = pattern;
 	transform(pattern_lower.begin(), pattern_lower.end(), pattern_lower.begin(), ::tolower);
 
-	DIR *d = opendir(folder.c_str());
-	if (d) {
-		struct dirent *dir;
-		while ((dir = readdir(d))) {
-			string filename = folder + "/" + dir->d_name;
+	if (scan_depth-- >= 0) {
+		DIR *d = opendir(folder.c_str());
+		if (d) {
+			struct dirent *dir;
+			while ((dir = readdir(d))) {
+				string filename = folder + "/" + dir->d_name;
 
-			string name_lower = filename;
-			if (!pattern.empty()) {
-				transform(name_lower.begin(), name_lower.end(), name_lower.begin(), ::tolower);
-			}
+				string name_lower = filename;
+				if (!pattern.empty()) {
+					transform(name_lower.begin(), name_lower.end(), name_lower.begin(), ::tolower);
+				}
 
-			bool is_supported_type = dir->d_type == DT_REG || dir->d_type == DT_DIR || dir->d_type == DT_LNK || dir->d_type == DT_BLK;
-			if (is_supported_type && dir->d_name[0] != '.') {
-				struct stat st;
-				if (dir->d_type == DT_REG && !stat(filename.c_str(), &st)) {
-					if (!st.st_size) {
-						LOGTRACE("File '%s' in image folder '%s' has a size of 0 bytes", dir->d_name, folder.c_str());
+				bool is_supported_type = dir->d_type == DT_REG || dir->d_type == DT_DIR || dir->d_type == DT_LNK || dir->d_type == DT_BLK;
+				if (is_supported_type && dir->d_name[0] != '.') {
+					struct stat st;
+					if (dir->d_type == DT_REG && !stat(filename.c_str(), &st)) {
+						if (!st.st_size) {
+							LOGTRACE("File '%s' in image folder '%s' has a size of 0 bytes", dir->d_name, folder.c_str());
+							continue;
+						}
+					} else if (dir->d_type == DT_LNK && stat(filename.c_str(), &st)) {
+						LOGTRACE("Symlink '%s' in image folder '%s' is broken", dir->d_name, folder.c_str());
+						continue;
+					} else if (dir->d_type == DT_DIR) {
+						GetAvailableImages(image_files_info, default_image_folder, filename, pattern, scan_depth);
 						continue;
 					}
-				} else if (dir->d_type == DT_LNK && stat(filename.c_str(), &st)) {
-					LOGTRACE("Symlink '%s' in image folder '%s' is broken", dir->d_name, folder.c_str());
-					continue;
-				} else if (dir->d_type == DT_DIR && recursive) {
-					GetAvailableImages(image_files_info, default_image_folder, filename, pattern, recursive);
-		            continue;
-				}
 
-				if (pattern.empty() || name_lower.find(pattern_lower) != string::npos) {
-					PbImageFile *image_file = new PbImageFile();
-					if (GetImageFile(image_file, filename)) {
-						GetImageFile(image_files_info.add_image_files(), filename.substr(default_image_folder.length() + 1));
+					if (pattern.empty() || name_lower.find(pattern_lower) != string::npos) {
+						PbImageFile *image_file = new PbImageFile();
+						if (GetImageFile(image_file, filename)) {
+							GetImageFile(image_files_info.add_image_files(), filename.substr(default_image_folder.length() + 1));
+						}
+						delete image_file;
 					}
-					delete image_file;
 				}
 			}
-		}
 
-	    closedir(d);
+			closedir(d);
+		}
 	}
 }
 
-PbImageFilesInfo *RascsiResponse::GetAvailableImages(PbResult& result, const string& pattern, bool recursive)
+PbImageFilesInfo *RascsiResponse::GetAvailableImages(PbResult& result, const string& pattern, int scan_depth)
 {
 	PbImageFilesInfo *image_files_info = new PbImageFilesInfo();
 
 	string default_image_folder = rascsi_image->GetDefaultImageFolder();
 	image_files_info->set_default_image_folder(default_image_folder);
 
-	GetAvailableImages(*image_files_info, default_image_folder, default_image_folder, pattern, recursive);
+	GetAvailableImages(*image_files_info, default_image_folder, default_image_folder, pattern, scan_depth);
 
 	result.set_status(true);
 
 	return image_files_info;
 }
 
-void RascsiResponse::GetAvailableImages(PbResult& result, PbServerInfo& server_info, const string& pattern, bool recursive)
+void RascsiResponse::GetAvailableImages(PbResult& result, PbServerInfo& server_info, const string& pattern, int scan_depth)
 {
-	PbImageFilesInfo *image_files_info = GetAvailableImages(result, pattern, recursive);
+	PbImageFilesInfo *image_files_info = GetAvailableImages(result, pattern, scan_depth);
 	image_files_info->set_default_image_folder(rascsi_image->GetDefaultImageFolder());
 	server_info.set_allocated_image_files_info(image_files_info);
 
@@ -281,14 +283,14 @@ PbDeviceTypesInfo *RascsiResponse::GetDeviceTypesInfo(PbResult& result, const Pb
 }
 
 PbServerInfo *RascsiResponse::GetServerInfo(PbResult& result, const vector<Device *>& devices, const set<int>& reserved_ids,
-		const string& current_log_level, const string& filename_pattern, bool recursive)
+		const string& current_log_level, const string& filename_pattern, int scan_depth)
 {
 	PbServerInfo *server_info = new PbServerInfo();
 
 	server_info->set_allocated_version_info(GetVersionInfo(result));
 	server_info->set_allocated_log_level_info(GetLogLevelInfo(result, current_log_level));
 	GetAllDeviceTypeProperties(*server_info->mutable_device_types_info());
-	GetAvailableImages(result, *server_info, filename_pattern, recursive);
+	GetAvailableImages(result, *server_info, filename_pattern, scan_depth);
 	server_info->set_allocated_network_interfaces_info(GetNetworkInterfacesInfo(result));
 	server_info->set_allocated_mapping_info(GetMappingInfo(result));
 	GetDevices(*server_info, devices);

--- a/src/raspberrypi/rascsi_response.cpp
+++ b/src/raspberrypi/rascsi_response.cpp
@@ -157,10 +157,7 @@ void RascsiResponse::GetAvailableImages(PbImageFilesInfo& image_files_info, cons
 			}
 
 			bool is_supported_type = dir->d_type == DT_REG || dir->d_type == DT_DIR || dir->d_type == DT_LNK || dir->d_type == DT_BLK;
-			bool is_supported_name = dir->d_name[0] != '.'
-					&& (pattern.empty() || name_lower.find(pattern_lower) != string::npos);
-
-			if (is_supported_type && is_supported_name) {
+			if (is_supported_type && dir->d_name[0] != '.') {
 				struct stat st;
 				if (dir->d_type == DT_REG && !stat(filename.c_str(), &st)) {
 					if (!st.st_size) {
@@ -175,11 +172,13 @@ void RascsiResponse::GetAvailableImages(PbImageFilesInfo& image_files_info, cons
 		            continue;
 				}
 
-				PbImageFile *image_file = new PbImageFile();
-				if (GetImageFile(image_file, filename)) {
-					GetImageFile(image_files_info.add_image_files(), filename.substr(default_image_folder.length() + 1));
+				if (pattern.empty() || name_lower.find(pattern_lower) != string::npos) {
+					PbImageFile *image_file = new PbImageFile();
+					if (GetImageFile(image_file, filename)) {
+						GetImageFile(image_files_info.add_image_files(), filename.substr(default_image_folder.length() + 1));
+					}
+					delete image_file;
 				}
-				delete image_file;
 			}
 		}
 

--- a/src/raspberrypi/rascsi_response.h
+++ b/src/raspberrypi/rascsi_response.h
@@ -29,13 +29,13 @@ public:
 	~RascsiResponse() {};
 
 	bool GetImageFile(PbImageFile *, const string&);
-	PbImageFilesInfo *GetAvailableImages(PbResult&, bool);
+	PbImageFilesInfo *GetAvailableImages(PbResult&, const string&, bool);
 	PbReservedIdsInfo *GetReservedIds(PbResult&, const set<int>&);
 	void GetDevices(PbServerInfo&, const vector<Device *>&);
 	void GetDevicesInfo(PbResult&, const PbCommand&, const vector<Device *>&, int);
 	PbDeviceTypesInfo *GetDeviceTypesInfo(PbResult&, const PbCommand&);
 	PbVersionInfo *GetVersionInfo(PbResult&);
-	PbServerInfo *GetServerInfo(PbResult&, const vector<Device *>&, const set<int>&, const string&, bool);
+	PbServerInfo *GetServerInfo(PbResult&, const vector<Device *>&, const set<int>&, const string&, const string&, bool);
 	PbNetworkInterfacesInfo *GetNetworkInterfacesInfo(PbResult&);
 	PbMappingInfo *GetMappingInfo(PbResult&);
 	PbLogLevelInfo *GetLogLevelInfo(PbResult&, const string&);
@@ -51,6 +51,6 @@ private:
 	void GetDevice(const Device *, PbDevice *);
 	void GetAllDeviceTypeProperties(PbDeviceTypesInfo&);
 	void GetDeviceTypeProperties(PbDeviceTypesInfo&, PbDeviceType);
-	void GetAvailableImages(PbImageFilesInfo&, const string&, const string&, bool);
-	void GetAvailableImages(PbResult& result, PbServerInfo&, bool);
+	void GetAvailableImages(PbImageFilesInfo&, const string&, const string&, const string&, bool);
+	void GetAvailableImages(PbResult& result, PbServerInfo&, const string&, bool);
 };

--- a/src/raspberrypi/rascsi_response.h
+++ b/src/raspberrypi/rascsi_response.h
@@ -51,5 +51,6 @@ private:
 	void GetDevice(const Device *, PbDevice *);
 	void GetAllDeviceTypeProperties(PbDeviceTypesInfo&);
 	void GetDeviceTypeProperties(PbDeviceTypesInfo&, PbDeviceType);
+	void GetAvailableImages(PbImageFilesInfo&, const string&);
 	void GetAvailableImages(PbResult& result, PbServerInfo&);
 };

--- a/src/raspberrypi/rascsi_response.h
+++ b/src/raspberrypi/rascsi_response.h
@@ -29,13 +29,13 @@ public:
 	~RascsiResponse() {};
 
 	bool GetImageFile(PbImageFile *, const string&);
-	PbImageFilesInfo *GetAvailableImages(PbResult&);
+	PbImageFilesInfo *GetAvailableImages(PbResult&, bool);
 	PbReservedIdsInfo *GetReservedIds(PbResult&, const set<int>&);
 	void GetDevices(PbServerInfo&, const vector<Device *>&);
 	void GetDevicesInfo(PbResult&, const PbCommand&, const vector<Device *>&, int);
 	PbDeviceTypesInfo *GetDeviceTypesInfo(PbResult&, const PbCommand&);
 	PbVersionInfo *GetVersionInfo(PbResult&);
-	PbServerInfo *GetServerInfo(PbResult&, const vector<Device *>&, const set<int>&, const string&);
+	PbServerInfo *GetServerInfo(PbResult&, const vector<Device *>&, const set<int>&, const string&, bool);
 	PbNetworkInterfacesInfo *GetNetworkInterfacesInfo(PbResult&);
 	PbMappingInfo *GetMappingInfo(PbResult&);
 	PbLogLevelInfo *GetLogLevelInfo(PbResult&, const string&);
@@ -51,6 +51,6 @@ private:
 	void GetDevice(const Device *, PbDevice *);
 	void GetAllDeviceTypeProperties(PbDeviceTypesInfo&);
 	void GetDeviceTypeProperties(PbDeviceTypesInfo&, PbDeviceType);
-	void GetAvailableImages(PbImageFilesInfo&, const string&);
-	void GetAvailableImages(PbResult& result, PbServerInfo&);
+	void GetAvailableImages(PbImageFilesInfo&, const string&, const string&, bool);
+	void GetAvailableImages(PbResult& result, PbServerInfo&, bool);
 };

--- a/src/raspberrypi/rascsi_response.h
+++ b/src/raspberrypi/rascsi_response.h
@@ -29,13 +29,13 @@ public:
 	~RascsiResponse() {};
 
 	bool GetImageFile(PbImageFile *, const string&);
-	PbImageFilesInfo *GetAvailableImages(PbResult&, const string&, bool);
+	PbImageFilesInfo *GetAvailableImages(PbResult&, const string&, int);
 	PbReservedIdsInfo *GetReservedIds(PbResult&, const set<int>&);
 	void GetDevices(PbServerInfo&, const vector<Device *>&);
 	void GetDevicesInfo(PbResult&, const PbCommand&, const vector<Device *>&, int);
 	PbDeviceTypesInfo *GetDeviceTypesInfo(PbResult&, const PbCommand&);
 	PbVersionInfo *GetVersionInfo(PbResult&);
-	PbServerInfo *GetServerInfo(PbResult&, const vector<Device *>&, const set<int>&, const string&, const string&, bool);
+	PbServerInfo *GetServerInfo(PbResult&, const vector<Device *>&, const set<int>&, const string&, const string&, int);
 	PbNetworkInterfacesInfo *GetNetworkInterfacesInfo(PbResult&);
 	PbMappingInfo *GetMappingInfo(PbResult&);
 	PbLogLevelInfo *GetLogLevelInfo(PbResult&, const string&);
@@ -51,6 +51,6 @@ private:
 	void GetDevice(const Device *, PbDevice *);
 	void GetAllDeviceTypeProperties(PbDeviceTypesInfo&);
 	void GetDeviceTypeProperties(PbDeviceTypesInfo&, PbDeviceType);
-	void GetAvailableImages(PbImageFilesInfo&, const string&, const string&, const string&, bool);
-	void GetAvailableImages(PbResult& result, PbServerInfo&, const string&, bool);
+	void GetAvailableImages(PbImageFilesInfo&, const string&, const string&, const string&, int);
+	void GetAvailableImages(PbResult& result, PbServerInfo&, const string&, int);
 };


### PR DESCRIPTION
When launching rascsi with the -R n option the default image file folder is scanned for images recursively, up to depth n. Default is 0 which is backwards compatible.

The operations SERVER_INFO and DEFAULT_IMAGE_FILE_INFO support an optional "filename_pattern" parameter for filtering. Filtering only takes the relative filename into account, not the folder name.