### PR TITLE
Adjust bus settle delay to match SCSI standard

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -83,15 +83,8 @@ function installPackages() {
 function compileRaScsi() {
     cd "$BASE/src/raspberrypi" || exit 1
 
-    # Compiler flags needed for gcc v10 and up
-    if [[ `gcc --version | awk '/gcc/' | awk -F ' ' '{print $3}' | awk -F '.' '{print $1}'` -ge 10 ]]; then
-        echo -n "gcc 10 or later detected. Will compile with the following flags: "
-        COMPILER_FLAGS="-DFMT_HEADER_ONLY"
-        echo $COMPILER_FLAGS
-    fi
-
     echo "Compiling with ${CORES:-1} simultaneous cores..."
-    ( make clean && EXTRA_FLAGS="$COMPILER_FLAGS" make -j "${CORES:-1}" all CONNECT_TYPE="${CONNECT_TYPE:-FULLSPEC}" ) </dev/null
+    ( make clean && make -j "${CORES:-1}" all CONNECT_TYPE="${CONNECT_TYPE:-FULLSPEC}" ) </dev/null
 }
 
 # install the RaSCSI binaries and modify the service configuration

--- a/src/raspberrypi/Makefile
+++ b/src/raspberrypi/Makefile
@@ -31,6 +31,16 @@ CXXFLAGS += -std=c++17 -Wno-psabi -iquote . -D_FILE_OFFSET_BITS=64 -MD -MP
 CFLAGS += $(EXTRA_FLAGS)
 CXXFLAGS += $(EXTRA_FLAGS)
 
+# If we're using GCC version 10 or later, we need to add the FMT_HEADER_ONLY definition
+GCCVERSION10 := $(shell expr `gcc -dumpversion` \>= 10)
+
+ifeq "$(GCCVERSION10)" "1"
+	CFLAGS += -DFMT_HEADER_ONLY
+	CXXFLAGS += -DFMT_HEADER_ONLY
+endif
+
+
+
 ##   CONNECT_TYPE=FULLSPEC : Specify the type of RaSCSI board type
 ##              that you are using. The typical options are 
 ##              STANDARD or FULLSPEC. The default is FULLSPEC

--- a/src/raspberrypi/gpiobus.cpp
+++ b/src/raspberrypi/gpiobus.cpp
@@ -840,7 +840,7 @@ int GPIOBUS::CommandHandShake(BYTE *buf)
 	BOOL ret = WaitSignal(PIN_ACK, TRUE);
 
 	// Wait until the signal line stabilizes
-	SysTimer::SleepNsec(GPIO_DATA_SETTLING);
+	SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 
 	// Get data
 	*buf = GetDAT();
@@ -874,7 +874,7 @@ int GPIOBUS::CommandHandShake(BYTE *buf)
 		ret = WaitSignal(PIN_ACK, TRUE);
 
 		// Wait until the signal line stabilizes
-		SysTimer::SleepNsec(GPIO_DATA_SETTLING);
+		SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 
 		// Get data
 		*buf = GetDAT();
@@ -930,7 +930,7 @@ int GPIOBUS::ReceiveHandShake(BYTE *buf, int count)
 			ret = WaitSignal(PIN_ACK, TRUE);
 
 			// Wait until the signal line stabilizes
-			SysTimer::SleepNsec(GPIO_DATA_SETTLING);
+			SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 
 			// Get data
 			*buf = GetDAT();
@@ -973,7 +973,7 @@ int GPIOBUS::ReceiveHandShake(BYTE *buf, int count)
 			}
 
 			// Wait until the signal line stabilizes
-			SysTimer::SleepNsec(GPIO_DATA_SETTLING);
+			SysTimer::SleepNsec(SCSI_DELAY_BUS_SETTLE_DELAY_NS);
 
 			// Get data
 			*buf = GetDAT();

--- a/src/raspberrypi/gpiobus.h
+++ b/src/raspberrypi/gpiobus.h
@@ -433,7 +433,6 @@
 //	Constant declarations (bus control timing)
 //
 //---------------------------------------------------------------------------
-#define GPIO_DATA_SETTLING 100			// Data bus stabilization time (ns)
 // SCSI Bus timings taken from:
 //     https://www.staff.uni-mainz.de/tacke/scsi/SCSI2-05.html
 #define SCSI_DELAY_ARBITRATION_DELAY_NS          2400


### PR DESCRIPTION
As discussed in issue #504 , there is an incompatibility with a Yamaha sampler. The root cause of this is that RaSCSI is not using the correct bus settle delay. This PR updates the bus settle delay to match the SCSI standard.

Additionally, GCC 10 requires a special define to work with spdlog. This was originally only in easyinstall.sh, so if you just ran "make all", the build would fail. I've moved that special logic into the Makefile so that "make all" will work on GCC 10 hosts.