### PR TITLE
Carry out an extra detach_all() when shutting down thru web interface

### DIFF
--- a/src/web/web.py
+++ b/src/web/web.py
@@ -737,6 +737,9 @@ def restart():
     """
     Restarts the Pi
     """
+    # Extra safeguard to avoid potential data loss.
+    # See https://github.com/akuker/RASCSI/issues/538
+    detach_all()
     shutdown_pi("reboot")
     return redirect(url_for("index"))
 
@@ -747,6 +750,8 @@ def shutdown():
     """
     Shuts down the Pi
     """
+    # Same as above
+    detach_all()
     shutdown_pi("system")
     return redirect(url_for("index"))
 


### PR DESCRIPTION
As per the discussion in https://github.com/akuker/RASCSI/issues/538 there are signs that the way the RaSCSI C++ executes system calls to restart/shut down the Pi may not be considerate of clean systemd service termination. As such, there is the risk that the clean shutdown of rascsi won't take effect. Introducing extra detach_all() calls here to give rascsi an extra chance to avoid data loss on shutdown.