### PR TITLE
Bumps pillow from 8.4.0 to 9.0.0. As recommended by dependabot.

### DIFF
--- a/python/oled/requirements.txt
+++ b/python/oled/requirements.txt
@@ -4,7 +4,7 @@ adafruit-circuitpython-framebuf==1.4.7
 adafruit-circuitpython-ssd1306==2.12.2
 Adafruit-PlatformDetect==3.17.2
 Adafruit-PureIO==1.1.9
-Pillow==8.4.0
+Pillow==9.0.0
 pkg-resources==0.0.0
 pyftdi==0.53.3
 pyserial==3.5


### PR DESCRIPTION
See https://github.com/akuker/RASCSI/pull/604