### PR TITLE
return code mapper gettext extract fix

### DIFF
--- a/python/web/src/return_code_mapper.py
+++ b/python/web/src/return_code_mapper.py
@@ -41,5 +41,5 @@ class ReturnCodeMapper:
 
         parameters = payload["parameters"]
 
-        payload["msg"] = _(ReturnCodeMapper.MESSAGES[payload["return_code"]], **parameters)
+        payload["msg"] = ReturnCodeMapper.MESSAGES[payload["return_code"]] % parameters
         return payload

--- a/python/web/src/return_code_mapper.py
+++ b/python/web/src/return_code_mapper.py
@@ -1,7 +1,7 @@
 """Module for mapping between rascsi return codes and translated strings"""
 
 from rascsi.return_codes import ReturnCodes
-from flask_babel import _
+from flask_babel import _, lazy_gettext
 
 
 # pylint: disable=too-few-public-methods
@@ -41,5 +41,5 @@ class ReturnCodeMapper:
 
         parameters = payload["parameters"]
 
-        payload["msg"] = ReturnCodeMapper.MESSAGES[payload["return_code"]] % parameters
+        payload["msg"] = lazy_gettext(ReturnCodeMapper.MESSAGES[payload["return_code"]], **parameters)
         return payload


### PR DESCRIPTION
The return code string is actually translated on msg injection not in the constant definitions. The constants are only strings as the variables used are unknown when the strings are defined. The translation takes place when the msg key is returned and the variables are replaced with the dictionary parameters. Thus, the _( wrapper exists twice even though the second one isn't an actual string, but the actual translation taking place. pybabel sees that second _( on the pybabel extract run. If gettext_lazy is used, the translation takes place at runtime and pybabel extract doesn't add those to the .po as gettext_lazy is not a pybabel extraction keyword.