### PR TITLE
Try to prevent frequent sudo timeout after compiling rascsi

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -89,7 +89,7 @@ function compileRaScsi() {
     echo "Compiling with ${CORES:-1} simultaneous cores..."
     make clean </dev/null
     sudo -v
-    make -j "${CORES:-1}" all CONNECT_TYPE="${CONNECT_TYPE:-FULLSPEC}" ) </dev/null
+    make -j "${CORES:-1}" all CONNECT_TYPE="${CONNECT_TYPE:-FULLSPEC}" </dev/null
     sudo -v
 }
 

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -87,7 +87,10 @@ function compileRaScsi() {
     cd "$BASE/src/raspberrypi" || exit 1
 
     echo "Compiling with ${CORES:-1} simultaneous cores..."
-    ( make clean && make -j "${CORES:-1}" all CONNECT_TYPE="${CONNECT_TYPE:-FULLSPEC}" ) </dev/null
+    make clean </dev/null
+    sudo -v
+    make -j "${CORES:-1}" all CONNECT_TYPE="${CONNECT_TYPE:-FULLSPEC}" ) </dev/null
+    sudo -v
 }
 
 function cleanupOutdatedManPage() {


### PR DESCRIPTION
This is not a perfect solution since a very long-running compilation process (e.g. Pi Zero) will still trigger the timeout, but it may prevent some corner cases.