### PR TITLE
Support for LUNs > 0 for SCDP and SCBR

### DIFF
--- a/src/raspberrypi/devices/device_factory.cpp
+++ b/src/raspberrypi/devices/device_factory.cpp
@@ -188,7 +188,7 @@ Device *DeviceFactory::CreateDevice(PbDeviceType type, const string& filename)
 
 			case SCBR:
 				device = new SCSIBR();
-				device->SetSupportedLuns(1);
+				device->SetSupportedLuns(32);
 				device->SetProduct("SCSI HOST BRIDGE");
 				device->SupportsParams(true);
 				device->SetDefaultParams(default_params[SCBR]);
@@ -196,7 +196,7 @@ Device *DeviceFactory::CreateDevice(PbDeviceType type, const string& filename)
 
 			case SCDP:
 				device = new SCSIDaynaPort();
-				device->SetSupportedLuns(1);
+				device->SetSupportedLuns(32);
 				// Since this is an emulation for a specific device the full INQUIRY data have to be set accordingly
 				device->SetVendor("Dayna");
 				device->SetProduct("SCSI/Link");


### PR DESCRIPTION
@rdmark Would also be nice to have this change as part of the next release. This change only has an effect with drivers that support it. But at least for the Atari some drivers are still actively developed, so RaSCSI should not limit them.