### PR TITLE
Make the network adapter UI in the web interface more flexible

### DIFF
--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -298,23 +298,23 @@
 
 <details>
     <summary class="heading">
-        {{ _("Attach Ethernet Adapter") }}
+        {{ _("Attach Network Adapter") }}
     </summary>
     <ul>
-        <li>{{ _("Emulates a SCSI DaynaPORT Ethernet Adapter. <a href=\"%(url)s\">Host drivers and configuration required</a>.", url="https://github.com/akuker/RASCSI/wiki/Dayna-Port-SCSI-Link") }}
+        <li>{{ _("Emulates either a <a href=\"%(url1)s\">SCSI DaynaPORT Ethernet Adapter</a>, or an <a href=\"%(url2)s\">X68000 Host Bridge</a>.", url1="https://github.com/akuker/RASCSI/wiki/Dayna-Port-SCSI-Link", url2="https://github.com/akuker/RASCSI/wiki/X68000#Host_File_System_driver") }}
         </li>
         <li>{{ _("If you have a DHCP setup, choose only the interface you have configured the bridge with. You can ignore the Static IP fields when attaching.") }}</li>
         <li>{{ _("Configure the network bridge by running easyinstall.sh, or follow the <a href=\"%(url)s\">manual steps in the wiki</a>.", url="https://github.com/akuker/RASCSI/wiki/Dayna-Port-SCSI-Link#manual-setup") }}
         </li>
         <li style="list-style: none">{% if bridge_configured %}</li>
-        <li>{{ _("The <tt>rascsi_bridge</tt> interface is active and ready to be used by DaynaPORT!") }}</li>
+        <li>{{ _("The <tt>rascsi_bridge</tt> network bridge is active and ready to be used by the emulated network adapter!") }}</li>
         <li style="list-style: none">{% endif %}</li>
     </ul>
 </details>
 <table style="border: none">
     <tr style="border: none">
         <td style="border: none; vertical-align:top;">
-            <form action="/daynaport/attach" method="post">
+            <form action="/scsi/attach_network" method="post">
                 <label for="if">{{ _("Interface:") }}</label>
                 <select name="if">
                 {% for if in netinfo["ifs"] %}
@@ -326,6 +326,15 @@
                 <label for="ip">{{ _("Static IP (optional):") }}</label>
                 <input name="ip" type="text" size="15" placeholder="10.10.20.1" minlength="7" maxlength="15" pattern="^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$">
                 <input name="mask" type="number" size="2" placeholder="24" min="16" max="30">
+                <label for="type">{{ _("Type:") }}</label>
+                <select name="type">
+                    <option selected value="SCDP">
+                    {{ _("DaynaPORT") }}
+                    </option>
+                    <option value="SCBR">
+                    {{ _("Host Bridge") }}
+                    </option>
+                </select>
                 <label for="scsi_id">{{ _("SCSI ID:") }}</label>
                 <select name="scsi_id">
                 {% for id in scsi_ids %}
@@ -334,6 +343,8 @@
                     </option>
                 {% endfor %}
                 </select>
+                <label for="unit">{{ _("LUN") }}</label>
+                <input name="unit" type="number" size="2" value="0" min="0" max="31">
                 <input type="submit" value="{{ _("Attach") }}">
             </form>
         </td>

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -482,13 +482,15 @@ def log_level():
     return redirect(url_for("index"))
 
 
-@APP.route("/daynaport/attach", methods=["POST"])
+@APP.route("/scsi/attach_network", methods=["POST"])
 @login_required
-def daynaport_attach():
+def attach_network_adapter():
     """
-    Attaches a DaynaPORT ethernet adapter device
+    Attaches a network adapter device
     """
     scsi_id = request.form.get("scsi_id")
+    unit = request.form.get("unit")
+    device_type = request.form.get("type")
     interface = request.form.get("if")
     ip_addr = request.form.get("ip")
     mask = request.form.get("mask")
@@ -515,7 +517,7 @@ def daynaport_attach():
             flash(error_msg, "error")
             return redirect(url_for("index"))
 
-    kwargs = {"device_type": "SCDP"}
+    kwargs = {"unit": int(unit), "device_type": device_type}
     if interface != "":
         arg = interface
         if "" not in (ip_addr, mask):
@@ -525,7 +527,15 @@ def daynaport_attach():
     process = ractl.attach_image(scsi_id, **kwargs)
     process = ReturnCodeMapper.add_msg(process)
     if process["status"]:
-        flash(_("Attached DaynaPORT to SCSI ID %(id_number)s", id_number=scsi_id))
+        flash(_(
+            (
+                "Attached network device of type %(device_type)s "
+                "to SCSI ID %(id_number)s LUN %(unit_number)s"
+            ),
+            device_type=device_type,
+            id_number=scsi_id,
+            unit_number=unit,
+            ))
         return redirect(url_for("index"))
 
     flash(process["msg"], "error")


### PR DESCRIPTION
- Since rascsi now supports attaching SCBR and SCDP to LUNs > 0, add this functionality to the web interface
- Also, add the Host Bridge (SCBR) as a selectable type, while retaining DaynaPORT (SCDP) as the default choice.