### PR TITLE
Create a mapping of human-readable and internationalized device names

### DIFF
--- a/python/web/src/device_utils.py
+++ b/python/web/src/device_utils.py
@@ -2,6 +2,8 @@
 Module for RaSCSI device management utility methods
 """
 
+from flask_babel import _
+
 
 def get_valid_scsi_ids(devices, reserved_ids):
     """
@@ -48,3 +50,31 @@ def sort_and_format_devices(devices):
     formatted_devices.sort(key=lambda dic: str(dic["id"]))
 
     return formatted_devices
+
+
+def extend_device_names(device_types):
+    """
+    Takes a (list) of (str) device_types with the four letter device acronyms
+    Returns a (dict) of device_type:device_name mappings of localized device names
+    """
+    mapped_device_types = []
+    for device_type in device_types:
+        if device_type is "SAHD":
+            device_name = _("SASI Hard Drive")
+        elif device_type is "SCHD":
+            device_name = _("SCSI Hard Drive")
+        elif device_type is "SCRM":
+            device_name = _("Removable Drive")
+        elif device_type is "SCMO":
+            device_name = _("Magneto-Optical Drive")
+        elif device_type is "SCCD":
+            device_name = _("CD-ROM Drive")
+        elif device_type is "SCBR":
+            device_name = _("X68000 Host Bridge")
+        elif device_type is "SCDP":
+            device_name = _("DaynaPORT SCSI/Link")
+        else:
+            device_name = _("Unknown Device")
+        mapped_device_types.append({device_type: device_name})
+
+    return mapped_device_types

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -156,7 +156,6 @@
         <li>{{ _("Select a valid SCSI ID and <a href=\"%(url)s\">LUN</a> to attach to. Unless you know what you're doing, always use LUN 0.", url="https://en.wikipedia.org/wiki/Logical_unit_number") }}
         </li>
         <li>{{ _("If RaSCSI was unable to detect the device type associated with the image, you can choose the type from the dropdown.") }}</li>
-        <li>{{ _("Types: SAHD = SASI HDD | SCHD = SCSI HDD | SCRM = Removable | SCMO = Magneto-Optical | SCCD = CD-ROM | SCBR = Host Bridge | SCDP = DaynaPORT") }}</li>
     </ul>
 </details>
 
@@ -250,7 +249,7 @@
                     <input name="file_name" type="hidden" value="{{ file['name'] }}">
                     <input name="file_size" type="hidden" value="{{ file['size'] }}">
                     <label for="id">{{ _("ID") }}</label>
-                        <select name="scsi_id">
+                    <select name="scsi_id">
                         {% for id in scsi_ids %}
                         <option name="id" value="{{id}}"{% if id == recommended_id %} selected{% endif %}>
                             {{ id }}
@@ -261,19 +260,29 @@
                     <input name="unit" type="number" size="2" value="0" min="0" max="31">
                     {% if file["detected_type"] != "UNDEFINED" %}
                         <input name="type" type="hidden" value="{{ file['detected_type'] }}">
-                        {{ file["detected_type"] }}
+                        {% for device in device_types %}
+                        {% for key, value in device.items() %}
+                        {% if file["detected_type"] == key %}
+                        {{ value }}
+                        {% endif %}
+                        {% endfor %}
+                        {% endfor %}
                     {% else %}
                         <select name="type">
                         <option selected value="">
                         {{ _("Type") }}
                         </option>
-                        {% for d in device_types %}
-                        <option value="{{ d }}">
-                            {{ d }}
+                        {% for device in device_types %}
+                        {% for key, value in device.items() %}
+                        {% if key not in ("SCBR", "SCDP") %}
+                        <option value="{{ key }}">
+                            {{ value }}
                         </option>
+                        {% endif %}
                         {% endfor %}
+                        {% endfor %}
+                        </select>
                     {% endif %}
-                    </select>
                     <input type="submit" value="{{ _("Attach") }}">
                 {% endif %}
                 </form>

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -35,6 +35,7 @@ from pi_cmds import (
 from device_utils import (
     sort_and_format_devices,
     get_valid_scsi_ids,
+    extend_device_names,
 )
 from return_code_mapper import ReturnCodeMapper
 
@@ -116,6 +117,7 @@ def index():
 
     sorted_image_files = sorted(image_files["files"], key=lambda x: x["name"].lower())
     sorted_config_files = sorted(config_files, key=lambda x: x.lower())
+    mapped_device_types = extend_device_names(device_types["device_types"])
 
     attached_images = []
     units = 0
@@ -168,7 +170,7 @@ def index():
         log_levels=server_info["log_levels"],
         current_log_level=server_info["current_log_level"],
         netinfo=ractl.get_network_info(),
-        device_types=device_types["device_types"],
+        device_types=mapped_device_types,
         free_disk=int(disk["free"] / 1024 / 1024),
         valid_file_suffix=valid_file_suffix,
         cdrom_file_suffix=tuple(server_info["sccd"]),


### PR DESCRIPTION
…. Use this in the image file management UI instead of the internal acronyms. Also remove the hard-coded helptext for device types.