### PR TITLE
Proper cleanup of old python protobuf libraries.

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -113,9 +113,17 @@ function installRaScsi() {
 }
 
 function preparePythonCommon() {
-    if [ -f "$PYTHON_COMMON_PATH/rascsi_interface_pb2.py" ]; then
-        sudo rm "$PYTHON_COMMON_PATH/rascsi_interface_pb2.py"
-        echo "Deleting old Python protobuf library rascsi_interface_pb2.py"
+    if [ -f "$WEB_INSTALL_PATH/src/rascsi_interface_pb2.py" ]; then
+        sudo rm "$WEB_INSTALL_PATH/src/rascsi_interface_pb2.py"
+        echo "Deleting old Python protobuf library $WEB_INSTALL_PATH/src/rascsi_interface_pb2.py"
+    fi
+    if [ -f "$OLED_INSTALL_PATH/src/rascsi_interface_pb2.py" ]; then
+        sudo rm "$OLED_INSTALL_PATH/src/rascsi_interface_pb2.py"
+        echo "Deleting old Python protobuf library $OLED_INSTALL_PATH/src/rascsi_interface_pb2.py"
+    fi
+    if [ -f "$PYTHON_COMMON_PATH/src/rascsi_interface_pb2.py" ]; then
+        sudo rm "$PYTHON_COMMON_PATH/src/rascsi_interface_pb2.py"
+        echo "Deleting old Python protobuf library $PYTHON_COMMON_PATH/src/rascsi_interface_pb2.py"
     fi
     echo "Compiling the Python protobuf library rascsi_interface_pb2.py..."
     protoc -I="$BASE/src/raspberrypi/" --python_out="$PYTHON_COMMON_PATH/src" rascsi_interface.proto


### PR DESCRIPTION
- Fix issue where the location of the protobuf library in the common package was incorrect
- Clean-up of the old locations of the protobuf library for web and oled. I found out the hard way that if a source file of the same name resides next to the python script being executed, it takes precedence over the one in the common package, which leads to errors when the proto interface changes.