### PR TITLE
Added support for SCSI printer device (SCLP)

### DIFF
--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -84,7 +84,7 @@ Overrides the default locale for client-faces error messages. The client can ove
 .BR \-ID\fIn[:u] " " \fIFILE
 n is the SCSI ID number (0-7). u (0-31) is the optional LUN (logical unit). The default LUN is 0.
 .IP
-FILE is the name of the image file to use for the SCSI device. For devices that do not support an image file (SCBR, SCDP, SCLP, SCHS) the filename may have a special meaning or a dummy name can be provided.
+FILE is the name of the image file to use for the SCSI device. For devices that do not support an image file (SCBR, SCDP, SCLP, SCHS) the filename may have a special meaning or a dummy name can be provided. For SCBR and SCDP it is an optioinal prioritized list of network interfaces, e.g. "eth0,eth1,wlan0". For SCLP it is the print command to be used, optionally followed by a reservation timeout in seconds, e.g. "lp -oraw:60".
 .TP 
 .BR \-HD\fIn[:u] " " \fIFILE
 n is the SASI ID number (0-15). The effective SASI ID is calculated as n/2, the effective SASI LUN is calculated is the remainder of n/2. Alternatively the n:u syntax can be used, where ns is the SASI ID (0-7) and u the LUN (0-1).

--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -84,7 +84,7 @@ Overrides the default locale for client-faces error messages. The client can ove
 .BR \-ID\fIn[:u] " " \fIFILE
 n is the SCSI ID number (0-7). u (0-31) is the optional LUN (logical unit). The default LUN is 0.
 .IP
-FILE is the name of the image file to use for the SCSI device. For devices that do not support an image file (SCBR, SCDP, SCLP, SCHS) the filename may have a special meaning or a dummy name can be provided. For SCBR and SCDP it is an optioinal prioritized list of network interfaces, e.g. "eth0,eth1,wlan0". For SCLP it is the print command to be used, optionally followed by a reservation timeout in seconds, e.g. "lp -oraw:60".
+FILE is the name of the image file to use for the SCSI device. For devices that do not support an image file (SCBR, SCDP, SCLP, SCHS) the filename may have a special meaning or a dummy name can be provided. For SCBR and SCDP it is an optioinal prioritized list of network interfaces, e.g. "interfaces=eth0,eth1,wlan0". For SCLP it is the print command to be used and a reservation timeout in seconds, e.g. "cmd=lp -oraw:timeout=60".
 .TP 
 .BR \-HD\fIn[:u] " " \fIFILE
 n is the SASI ID number (0-15). The effective SASI ID is calculated as n/2, the effective SASI LUN is calculated is the remainder of n/2. Alternatively the n:u syntax can be used, where ns is the SASI ID (0-7) and u the LUN (0-1).

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -111,14 +111,15 @@ OPTIONS
               For devices that do not support an image file (SCBR, SCDP, SCLP,
               SCHS) the filename may have a special meaning or  a  dummy  name
               can  be  provided.  For SCBR and SCDP it is an optioinal priori‐
-              tized list of network interfaces,  e.g.  "eth0,eth1,wlan0".  For
-              SCLP  it is the print command to be used, optionally followed by
-              a reservation timeout in seconds, e.g. "lp -oraw:60".
+              tized    list    of    network    interfaces,    e.g.    "inter‐
+              faces=eth0,eth1,wlan0".  For  SCLP it is the print command to be
+              used  and  a  reservation  timeout  in  seconds,  e.g.   "cmd=lp
+              -oraw:timeout=60".
 
        -HDn[:u] FILE
-              n is the SASI ID number (0-15). The effective SASI ID is  calcu‐
-              lated  as  n/2,  the effective SASI LUN is calculated is the re‐
-              mainder of n/2. Alternatively the n:u syntax can be used,  where
+              n  is the SASI ID number (0-15). The effective SASI ID is calcu‐
+              lated as n/2, the effective SASI LUN is calculated  is  the  re‐
+              mainder  of n/2. Alternatively the n:u syntax can be used, where
               ns is the SASI ID (0-7) and u the LUN (0-1).
 
               FILE is the name of the image file to use for the SASI device.
@@ -135,7 +136,7 @@ EXAMPLES
           rascsi -ID0 /path/to/harddrive.hda -ID2 /path/to/cdimage.iso
 
        Launch RaSCSI with a removable SCSI drive image as ID 0 and the raw de‐
-       vice file /dev/hdb (e.g. a USB stick) and a DaynaPort  network  adapter
+       vice  file  /dev/hdb (e.g. a USB stick) and a DaynaPort network adapter
        as ID 6:
           rascsi -ID0 -t scrm /dev/hdb -ID6 -t scdp daynaport
 

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -110,12 +110,15 @@ OPTIONS
               FILE is the name of the image file to use for the  SCSI  device.
               For devices that do not support an image file (SCBR, SCDP, SCLP,
               SCHS) the filename may have a special meaning or  a  dummy  name
-              can be provided.
+              can  be  provided.  For SCBR and SCDP it is an optioinal priori‐
+              tized list of network interfaces,  e.g.  "eth0,eth1,wlan0".  For
+              SCLP  it is the print command to be used, optionally followed by
+              a reservation timeout in seconds, e.g. "lp -oraw:60".
 
        -HDn[:u] FILE
-              n  is the SASI ID number (0-15). The effective SASI ID is calcu‐
-              lated as n/2, the effective SASI LUN is calculated  is  the  re‐
-              mainder  of n/2. Alternatively the n:u syntax can be used, where
+              n is the SASI ID number (0-15). The effective SASI ID is  calcu‐
+              lated  as  n/2,  the effective SASI LUN is calculated is the re‐
+              mainder of n/2. Alternatively the n:u syntax can be used,  where
               ns is the SASI ID (0-7) and u the LUN (0-1).
 
               FILE is the name of the image file to use for the SASI device.
@@ -132,7 +135,7 @@ EXAMPLES
           rascsi -ID0 /path/to/harddrive.hda -ID2 /path/to/cdimage.iso
 
        Launch RaSCSI with a removable SCSI drive image as ID 0 and the raw de‐
-       vice  file  /dev/hdb (e.g. a USB stick) and a DaynaPort network adapter
+       vice file /dev/hdb (e.g. a USB stick) and a DaynaPort  network  adapter
        as ID 6:
           rascsi -ID0 -t scrm /dev/hdb -ID6 -t scdp daynaport
 

--- a/doc/rasctl.1
+++ b/doc/rasctl.1
@@ -147,6 +147,7 @@ Specifies the device type. This type overrides the type derived from the file ex
    rm: SCSI removable media drive
    cd: CD-ROM
    mo: Magneto-Optical disk
+   lp: SCSI printer
    bridge: Bridge device (Only applicable to the Sharp X68000)
    daynaport: DaynaPort network adapter
    services: Host services device

--- a/doc/rasctl_man_page.txt
+++ b/doc/rasctl_man_page.txt
@@ -127,6 +127,7 @@ OPTIONS
                  rm: SCSI removable media drive
                  cd: CD-ROM
                  mo: Magneto-Optical disk
+                 lp: SCSI printer
                  bridge: Bridge device (Only applicable to the Sharp X68000)
                  daynaport: DaynaPort network adapter
                  services: Host services device

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -1066,7 +1066,8 @@ void SASIDEV::Receive()
 //
 //	Data transfer IN
 //	*Reset offset and length
-// TODO XferIn probably needs a dispatcher, in order to avoid subclassing Disk
+// TODO XferIn probably needs a dispatcher, in order to avoid subclassing Disk, i.e.
+// just like the actual SCSI commands XferIn should be executed by the respective device
 //
 //---------------------------------------------------------------------------
 bool SASIDEV::XferIn(BYTE *buf)
@@ -1113,7 +1114,8 @@ bool SASIDEV::XferIn(BYTE *buf)
 //
 //	Data transfer OUT
 //	*If cont=true, reset the offset and length
-// TODO XferOut probably needs a dispatcher, in order to avoid subclassing Disk
+// TODO XferOut probably needs a dispatcher, in order to avoid subclassing Disk, i.e.
+// just like the actual SCSI commands XferOut should be executed by the respective device
 //
 //---------------------------------------------------------------------------
 bool SASIDEV::XferOut(bool cont)

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -1066,6 +1066,7 @@ void SASIDEV::Receive()
 //
 //	Data transfer IN
 //	*Reset offset and length
+// TODO XferIn probably needs a dispatcher, in order to avoid subclassing Disk
 //
 //---------------------------------------------------------------------------
 bool SASIDEV::XferIn(BYTE *buf)
@@ -1112,6 +1113,7 @@ bool SASIDEV::XferIn(BYTE *buf)
 //
 //	Data transfer OUT
 //	*If cont=true, reset the offset and length
+// TODO XferOut probably needs a dispatcher, in order to avoid subclassing Disk
 //
 //---------------------------------------------------------------------------
 bool SASIDEV::XferOut(bool cont)

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -1155,7 +1155,7 @@ bool SASIDEV::XferOut(bool cont)
 			// Special case Write function for DaynaPort
 			// TODO This class must not know about DaynaPort
 			if (device->IsDaynaPort()) {
-				if (!device->Write(ctrl.cmd, ctrl.buffer, ctrl.length)) {
+				if (!((SCSIDaynaPort*)device)->Write(ctrl.cmd, ctrl.buffer, ctrl.length)) {
 					// write failed
 					return false;
 				}

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -143,7 +143,7 @@ bool SASIDEV::HasUnit()
 //	Run
 //
 //---------------------------------------------------------------------------
-BUS::phase_t SASIDEV::Process(int initiator_id)
+BUS::phase_t SASIDEV::Process(int)
 {
 	// Do nothing if not connected
 	if (ctrl.m_scsi_id < 0 || ctrl.bus == NULL) {
@@ -165,8 +165,6 @@ BUS::phase_t SASIDEV::Process(int initiator_id)
 		ctrl.bus->Reset();
 		return ctrl.phase;
 	}
-
-	ctrl.initiator_id = initiator_id;
 
 	// Phase processing
 	switch (ctrl.phase) {

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -119,7 +119,6 @@ public:
 		BYTE *buffer;					// Transfer data buffer
 		int bufsize;					// Transfer data buffer size
 		uint32_t blocks;				// Number of transfer block
-		bool is_byte_transfer;
 		DWORD next;						// Next record
 		DWORD offset;					// Transfer offset
 		DWORD length;					// Transfer remaining length

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -162,6 +162,7 @@ public:
 	void MsgIn();							// Message in phase
 	void DataOut();						// Data out phase
 
+	// Get LUN based on IDENTIFY message, with LUN from the CDB as fallback
 	int GetEffectiveLun() const;
 
 	virtual void Error(ERROR_CODES::sense_key sense_key = ERROR_CODES::sense_key::NO_SENSE,

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -132,8 +132,6 @@ public:
 
 		// The LUN from the IDENTIFY message
 		int lun;
-
-		int initiator_id;
 	} ctrl_t;
 
 public:

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -700,7 +700,7 @@ void SCSIDEV::Receive()
 //	Transfer MSG
 //
 //---------------------------------------------------------------------------
-bool SCSIDEV::XferMsg(DWORD msg)
+bool SCSIDEV::XferMsg(int msg)
 {
 	ASSERT(ctrl.phase == BUS::msgout);
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -27,7 +27,7 @@
 
 SCSIDEV::SCSIDEV() : SASIDEV()
 {
-	bytes_to_transfer = 0;
+	scsi.bytes_to_transfer = 0;
 	shutdown_mode = NONE;
 
 	// Synchronous transfer work initialization
@@ -159,7 +159,7 @@ void SCSIDEV::BusFree()
 		ctrl.lun = -1;
 
 		scsi.is_byte_transfer = false;
-		bytes_to_transfer = 0;
+		scsi.bytes_to_transfer = 0;
 
 		// When the bus is free RaSCSI or the Pi may be shut down
 		switch(shutdown_mode) {
@@ -739,7 +739,7 @@ void SCSIDEV::ReceiveBytes()
 		}
 
 		ctrl.offset += ctrl.length;
-		bytes_to_transfer = ctrl.length;
+		scsi.bytes_to_transfer = ctrl.length;
 		ctrl.length = 0;
 		return;
 	}
@@ -905,7 +905,7 @@ bool SCSIDEV::XferOut(bool cont)
 	switch (ctrl.cmd[0]) {
 		// Check for PRINT command
 		case scsi_defs::eCmdWrite6:
-			if (!device->Write(ctrl.buffer, bytes_to_transfer)) {
+			if (!device->Write(ctrl.buffer, scsi.bytes_to_transfer)) {
 				// Writing to temporary print output file failed
 				return false;
 			}

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -907,6 +907,7 @@ bool SCSIDEV::XferOut(bool cont)
 	SCSIPrinter *device = (SCSIPrinter *)ctrl.unit[lun];
 
 	switch (ctrl.cmd[0]) {
+		// Check for PRINT command
 		case scsi_defs::eCmdWrite6:
 			if (!device->Write(ctrl.buffer, bytes_to_transfer)) {
 				// Write failed

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -894,12 +894,7 @@ bool SCSIDEV::XferOut(bool cont)
 
 	ASSERT(ctrl.phase == BUS::dataout);
 
-	int lun = GetEffectiveLun();
-	if (!ctrl.unit[lun]) {
-		return false;
-	}
-
-	PrimaryDevice *device = dynamic_cast<PrimaryDevice *>(ctrl.unit[lun]);
+	PrimaryDevice *device = dynamic_cast<PrimaryDevice *>(ctrl.unit[GetEffectiveLun()]);
 	if (device && ctrl.cmd[0] == scsi_defs::eCmdWrite6) {
 		if (device->WriteBytes(ctrl.buffer, scsi.bytes_to_transfer)) {
 			return true;

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -76,13 +76,6 @@ BUS::phase_t SCSIDEV::Process(int initiator_id)
 		return ctrl.phase;
 	}
 
-	if (initiator_id != UNKNOWN_SCSI_ID) {
-		LOGTRACE("Initiator ID is %d", initiator_id);
-	}
-	else {
-		LOGTRACE("Initiator ID is unknown");
-	}
-
 	ctrl.initiator_id = initiator_id;
 
 	// Phase processing
@@ -214,6 +207,13 @@ void SCSIDEV::Selection()
 		}
 
 		LOGTRACE("%s Selection Phase ID=%d (with device)", __PRETTY_FUNCTION__, (int)ctrl.m_scsi_id);
+
+		if (ctrl.initiator_id != UNKNOWN_SCSI_ID) {
+			LOGTRACE("%s Initiator ID is %d", __PRETTY_FUNCTION__, ctrl.initiator_id);
+		}
+		else {
+			LOGTRACE("%s Initiator ID is unknown", __PRETTY_FUNCTION__);
+		}
 
 		// Phase setting
 		ctrl.phase = BUS::selection;

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -899,25 +899,16 @@ bool SCSIDEV::XferOut(bool cont)
 		return false;
 	}
 
-	// TODO This might not be a printer, but currently always is
-	SCSIPrinter *device = (SCSIPrinter *)ctrl.unit[lun];
-
-	switch (ctrl.cmd[0]) {
-		// Check for PRINT command
-		case scsi_defs::eCmdWrite6:
-			if (!device->Write(ctrl.buffer, scsi.bytes_to_transfer)) {
-				// Writing to temporary print output file failed
-				return false;
-			}
-
-			break;
-
-		default:
+	PrimaryDevice *device = dynamic_cast<PrimaryDevice *>(ctrl.unit[lun]);
+	if (device && ctrl.cmd[0] == scsi_defs::eCmdWrite6) {
+		if (device->WriteBytes(ctrl.buffer, scsi.bytes_to_transfer)) {
+			return true;
+		}
+		else {
 			LOGWARN("Received an unexpected command ($%02X) in %s", (WORD)ctrl.cmd[0] , __PRETTY_FUNCTION__)
-			break;
+		}
 	}
 
-	// Data transferred successfully
-	return true;
+	return false;
 }
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -896,13 +896,10 @@ bool SCSIDEV::XferOut(bool cont)
 
 	PrimaryDevice *device = dynamic_cast<PrimaryDevice *>(ctrl.unit[GetEffectiveLun()]);
 	if (device && ctrl.cmd[0] == scsi_defs::eCmdWrite6) {
-		if (device->WriteBytes(ctrl.buffer, scsi.bytes_to_transfer)) {
-			return true;
-		}
-		else {
-			LOGWARN("Received an unexpected command ($%02X) in %s", (WORD)ctrl.cmd[0] , __PRETTY_FUNCTION__)
-		}
+		return device->WriteBytes(ctrl.buffer, scsi.bytes_to_transfer);
 	}
+
+	LOGWARN("Received an unexpected command ($%02X) in %s", (WORD)ctrl.cmd[0] , __PRETTY_FUNCTION__)
 
 	return false;
 }

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -76,6 +76,13 @@ BUS::phase_t SCSIDEV::Process(int initiator_id)
 		return ctrl.phase;
 	}
 
+	if (initiator_id != UNKNOWN_SCSI_ID) {
+		LOGTRACE("Initiator ID is %d", initiator_id);
+	}
+	else {
+		LOGTRACE("Initiator ID is unknown");
+	}
+
 	ctrl.initiator_id = initiator_id;
 
 	// Phase processing

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -76,7 +76,7 @@ BUS::phase_t SCSIDEV::Process(int initiator_id)
 		return ctrl.phase;
 	}
 
-	ctrl.initiator_id = initiator_id;
+	scsi.initiator_id = initiator_id;
 
 	// Phase processing
 	switch (ctrl.phase) {
@@ -208,8 +208,8 @@ void SCSIDEV::Selection()
 
 		LOGTRACE("%s Selection Phase ID=%d (with device)", __PRETTY_FUNCTION__, (int)ctrl.m_scsi_id);
 
-		if (ctrl.initiator_id != UNKNOWN_SCSI_ID) {
-			LOGTRACE("%s Initiator ID is %d", __PRETTY_FUNCTION__, ctrl.initiator_id);
+		if (scsi.initiator_id != UNKNOWN_SCSI_ID) {
+			LOGTRACE("%s Initiator ID is %d", __PRETTY_FUNCTION__, scsi.initiator_id);
 		}
 		else {
 			LOGTRACE("%s Initiator ID is unknown", __PRETTY_FUNCTION__);

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -903,7 +903,7 @@ bool SCSIDEV::XferOut(bool cont)
 		return false;
 	}
 
-	// TODO This might not be a printer
+	// TODO This might not be a printer, but currently always is
 	SCSIPrinter *device = (SCSIPrinter *)ctrl.unit[lun];
 
 	switch (ctrl.cmd[0]) {
@@ -921,7 +921,7 @@ bool SCSIDEV::XferOut(bool cont)
 			break;
 	}
 
-	// Data saved successfully
+	// Data transferred successfully
 	return true;
 }
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -196,7 +196,7 @@ void SCSIDEV::Selection()
 	// Phase change
 	if (ctrl.phase != BUS::selection) {
 		// invalid if IDs do not match
-		DWORD id = 1 << ctrl.m_scsi_id;
+		int id = 1 << ctrl.m_scsi_id;
 		if ((ctrl.bus->GetDAT() & id) == 0) {
 			return;
 		}
@@ -364,7 +364,7 @@ void SCSIDEV::Error(ERROR_CODES::sense_key sense_key, ERROR_CODES::asc asc, ERRO
 		return;
 	}
 
-	DWORD lun = (ctrl.cmd[1] >> 5) & 0x07;
+	int lun = GetEffectiveLun();
 	if (!ctrl.unit[lun] || asc == ERROR_CODES::INVALID_LUN) {
 		lun = 0;
 	}
@@ -894,7 +894,7 @@ bool SCSIDEV::XferOut(bool cont)
 
 	ASSERT(ctrl.phase == BUS::dataout);
 
-	DWORD lun = GetEffectiveLun();
+	int lun = GetEffectiveLun();
 	if (!ctrl.unit[lun]) {
 		return false;
 	}

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -158,7 +158,7 @@ void SCSIDEV::BusFree()
 
 		ctrl.lun = -1;
 
-		ctrl.is_byte_transfer = false;
+		scsi.is_byte_transfer = false;
 		bytes_to_transfer = 0;
 
 		// When the bus is free RaSCSI or the Pi may be shut down
@@ -496,7 +496,7 @@ void SCSIDEV::Send()
 //---------------------------------------------------------------------------
 void SCSIDEV::Receive()
 {
-	if (ctrl.is_byte_transfer) {
+	if (scsi.is_byte_transfer) {
 		ReceiveBytes();
 		return;
 	}
@@ -888,7 +888,7 @@ void SCSIDEV::ReceiveBytes()
 
 bool SCSIDEV::XferOut(bool cont)
 {
-	if (!ctrl.is_byte_transfer) {
+	if (!scsi.is_byte_transfer) {
 		return SASIDEV::XferOut(cont);
 	}
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -170,7 +170,9 @@ void SCSIDEV::BusFree()
 
 		case PI:
 			LOGINFO("Raspberry Pi shutdown requested");
-			system("init 0");
+			if (system("init 0") == -1) {
+				LOGERROR("Raspberry Pi shutdown failed: %s", strerror(errno));
+			}
 			break;
 
 		default:

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -585,7 +585,7 @@ void SCSIDEV::Receive()
 			len = GPIOBUS::GetCommandByteCount(ctrl.buffer[0]);
 
 			for (int i = 0; i < len; i++) {
-				ctrl.cmd[i] = (DWORD)ctrl.buffer[i];
+				ctrl.cmd[i] = ctrl.buffer[i];
 				LOGTRACE("%s Command Byte %d: $%02X",__PRETTY_FUNCTION__, i, ctrl.cmd[i]);
 			}
 
@@ -783,7 +783,7 @@ void SCSIDEV::ReceiveBytes()
 			len = GPIOBUS::GetCommandByteCount(ctrl.buffer[0]);
 
 			for (uint32_t i = 0; i < len; i++) {
-				ctrl.cmd[i] = (DWORD)ctrl.buffer[i];
+				ctrl.cmd[i] = ctrl.buffer[i];
 				LOGTRACE("%s Command Byte %d: $%02X",__PRETTY_FUNCTION__, i, ctrl.cmd[i]);
 			}
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -46,7 +46,9 @@ public:
 		int msc;
 		BYTE msb[256];
 
+		// -1 means that the initiator ID is unknown, e.g. with Atari ACSI and old host adapters
 		int initiator_id;
+
 		bool is_byte_transfer;
 		uint32_t bytes_to_transfer;
 	} scsi_t;

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -45,20 +45,19 @@ public:
 		bool atnmsg;
 		int msc;
 		BYTE msb[256];
+
+		int initiator_id;
 	} scsi_t;
 
-	// Basic Functions
 	SCSIDEV();
 	~SCSIDEV();
 
 	void Reset() override;
 
-	// External API
 	BUS::phase_t Process(int) override;
 
 	void Receive() override;
 
-	// Other
 	bool IsSASI() const override { return false; }
 	bool IsSCSI() const override { return true; }
 
@@ -67,6 +66,8 @@ public:
 			ERROR_CODES::status status = ERROR_CODES::status::CHECK_CONDITION) override;	// Common error handling
 
 	void ShutDown(rascsi_shutdown_mode shutdown_mode) { this->shutdown_mode = shutdown_mode; }
+
+	int GetInitiatorId() const { return scsi.initiator_id; }
 
 private:
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -47,6 +47,7 @@ public:
 		BYTE msb[256];
 
 		int initiator_id;
+		bool is_byte_transfer;
 	} scsi_t;
 
 	SCSIDEV();
@@ -68,6 +69,8 @@ public:
 	void ShutDown(rascsi_shutdown_mode shutdown_mode) { this->shutdown_mode = shutdown_mode; }
 
 	int GetInitiatorId() const { return scsi.initiator_id; }
+	bool IsByteTransfer() const { return scsi.is_byte_transfer; }
+	void SetByteTransfer(bool is_byte_transfer) { scsi.is_byte_transfer = is_byte_transfer; }
 
 private:
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -48,6 +48,7 @@ public:
 
 		int initiator_id;
 		bool is_byte_transfer;
+		uint32_t bytes_to_transfer;
 	} scsi_t;
 
 	SCSIDEV();
@@ -92,8 +93,6 @@ private:
 	void ReceiveBytes();
 
 	scsi_t scsi;								// Internal data
-
-	uint32_t bytes_to_transfer;
 
 	rascsi_shutdown_mode shutdown_mode;
 };

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -63,9 +63,10 @@ public:
 	bool IsSASI() const override { return false; }
 	bool IsSCSI() const override { return true; }
 
+	// Common error handling
 	void Error(ERROR_CODES::sense_key sense_key = ERROR_CODES::sense_key::NO_SENSE,
 			ERROR_CODES::asc asc = ERROR_CODES::asc::NO_ADDITIONAL_SENSE_INFORMATION,
-			ERROR_CODES::status status = ERROR_CODES::status::CHECK_CONDITION) override;	// Common error handling
+			ERROR_CODES::status status = ERROR_CODES::status::CHECK_CONDITION) override;
 
 	void ShutDown(rascsi_shutdown_mode shutdown_mode) { this->shutdown_mode = shutdown_mode; }
 
@@ -75,24 +76,20 @@ public:
 
 private:
 
-	// Phase
-	void BusFree() override;						// Bus free phase
-	void Selection() override;						// Selection phase
-	void Execute() override;						// Execution phase
-	void MsgOut();							// Message out phase
-
-	// commands
-	void CmdGetEventStatusNotification();
-	void CmdModeSelect10();
-	void CmdModeSense10();
+	// Phases
+	void BusFree() override;
+	void Selection() override;
+	void Execute() override;
+	void MsgOut();
 
 	// Data transfer
 	void Send() override;
-	bool XferMsg(DWORD msg);
+	bool XferMsg(int);
 	bool XferOut(bool);
 	void ReceiveBytes();
 
-	scsi_t scsi;								// Internal data
+	// Internal data
+	scsi_t scsi;
 
 	rascsi_shutdown_mode shutdown_mode;
 };

--- a/src/raspberrypi/devices/device_factory.cpp
+++ b/src/raspberrypi/devices/device_factory.cpp
@@ -202,7 +202,7 @@ Device *DeviceFactory::CreateDevice(PbDeviceType type, const string& filename)
 
 			case SCLP:
 				device = new SCSIPrinter();
-				device->SetProduct("SCSI Printer");
+				device->SetProduct("SCSI PRINTER");
 				device->SupportsParams(true);
 				device->SetDefaultParams(default_params[SCLP]);
 				break;

--- a/src/raspberrypi/devices/device_factory.cpp
+++ b/src/raspberrypi/devices/device_factory.cpp
@@ -53,7 +53,7 @@ DeviceFactory::DeviceFactory()
 
 	default_params[SCBR]["interfaces"] = network_interfaces;
 	default_params[SCDP]["interfaces"] = network_interfaces;
-	default_params[SCLP]["printer"] = "lp -oraw";
+	default_params[SCLP]["cmd"] = "lp -oraw";
 	default_params[SCLP]["timeout"] = "30";
 
 	extension_mapping["hdf"] = SAHD;

--- a/src/raspberrypi/devices/device_factory.cpp
+++ b/src/raspberrypi/devices/device_factory.cpp
@@ -98,6 +98,9 @@ PbDeviceType DeviceFactory::GetTypeForFile(const string& filename)
 	else if (filename == "daynaport") {
 		return SCDP;
 	}
+	else if (filename == "printer") {
+		return SCLP;
+	}
 	else if (filename == "services") {
 		return SCHS;
 	}

--- a/src/raspberrypi/devices/disk.h
+++ b/src/raspberrypi/devices/disk.h
@@ -53,7 +53,7 @@ private:
 		off_t image_offset;						// Offset to actual data
 	} disk_t;
 
-	Dispatcher<Disk> dispatcher;
+	Dispatcher<Disk, SASIDEV> dispatcher;
 
 public:
 	Disk(const string&);

--- a/src/raspberrypi/devices/dispatcher.h
+++ b/src/raspberrypi/devices/dispatcher.h
@@ -21,7 +21,7 @@ class SCSIDEV;
 using namespace std;
 using namespace scsi_defs;
 
-template<class T>
+template<class T, class U>
 class Dispatcher
 {
 public:
@@ -36,18 +36,18 @@ public:
 
 	typedef struct _command_t {
 		const char* name;
-		void (T::*execute)(SASIDEV *);
+		void (T::*execute)(U *);
 
-		_command_t(const char* _name, void (T::*_execute)(SASIDEV *)) : name(_name), execute(_execute) { };
+		_command_t(const char* _name, void (T::*_execute)(U *)) : name(_name), execute(_execute) { };
 	} command_t;
 	map<scsi_command, command_t*> commands;
 
-	void AddCommand(scsi_command opcode, const char* name, void (T::*execute)(SASIDEV *))
+	void AddCommand(scsi_command opcode, const char* name, void (T::*execute)(U *))
 	{
 		commands[opcode] = new command_t(name, execute);
 	}
 
-	bool Dispatch(T *instance, SCSIDEV *controller)
+	bool Dispatch(T *instance, U *controller)
 	{
 		SASIDEV::ctrl_t *ctrl = controller->GetCtrl();
 		instance->SetCtrl(ctrl);

--- a/src/raspberrypi/devices/host_services.cpp
+++ b/src/raspberrypi/devices/host_services.cpp
@@ -60,7 +60,7 @@ int HostServices::Inquiry(const DWORD *cdb, BYTE *buf)
 	return PrimaryDevice::Inquiry(3, false, cdb, buf);
 }
 
-void HostServices::StartStopUnit(SASIDEV *controller)
+void HostServices::StartStopUnit(SCSIDEV *controller)
 {
 	bool start = ctrl->cmd[4] & 0x01;
 	bool load = ctrl->cmd[4] & 0x02;

--- a/src/raspberrypi/devices/host_services.cpp
+++ b/src/raspberrypi/devices/host_services.cpp
@@ -5,6 +5,8 @@
 //
 // Copyright (C) 2022 Uwe Seimet
 //
+// Host Services with realtime clock and shutdown support
+//
 //---------------------------------------------------------------------------
 
 //

--- a/src/raspberrypi/devices/host_services.cpp
+++ b/src/raspberrypi/devices/host_services.cpp
@@ -39,6 +39,7 @@ using namespace scsi_defs;
 
 HostServices::HostServices() : ModePageDevice("SCHS")
 {
+	dispatcher.AddCommand(eCmdTestUnitReady, "TestUnitReady", &HostServices::TestUnitReady);
 	dispatcher.AddCommand(eCmdStartStop, "StartStopUnit", &HostServices::StartStopUnit);
 }
 
@@ -48,7 +49,7 @@ bool HostServices::Dispatch(SCSIDEV *controller)
 	return dispatcher.Dispatch(this, controller) ? true : super::Dispatch(controller);
 }
 
-void HostServices::TestUnitReady(SASIDEV *controller)
+void HostServices::TestUnitReady(SCSIDEV *controller)
 {
 	// Always successful
 	controller->Status();

--- a/src/raspberrypi/devices/host_services.h
+++ b/src/raspberrypi/devices/host_services.h
@@ -26,7 +26,7 @@ public:
 
 	int Inquiry(const DWORD *, BYTE *) override;
 	void TestUnitReady(SASIDEV *) override;
-	void StartStopUnit(SASIDEV *);
+	void StartStopUnit(SCSIDEV *);
 
 	int ModeSense6(const DWORD *, BYTE *);
 	int ModeSense10(const DWORD *, BYTE *);
@@ -35,7 +35,7 @@ private:
 
 	typedef ModePageDevice super;
 
-	Dispatcher<HostServices, SASIDEV> dispatcher;
+	Dispatcher<HostServices, SCSIDEV> dispatcher;
 
 	int AddRealtimeClockPage(int, BYTE *);
 };

--- a/src/raspberrypi/devices/host_services.h
+++ b/src/raspberrypi/devices/host_services.h
@@ -35,7 +35,7 @@ private:
 
 	typedef ModePageDevice super;
 
-	Dispatcher<HostServices> dispatcher;
+	Dispatcher<HostServices, SASIDEV> dispatcher;
 
 	int AddRealtimeClockPage(int, BYTE *);
 };

--- a/src/raspberrypi/devices/host_services.h
+++ b/src/raspberrypi/devices/host_services.h
@@ -25,7 +25,7 @@ public:
 	virtual bool Dispatch(SCSIDEV *) override;
 
 	int Inquiry(const DWORD *, BYTE *) override;
-	void TestUnitReady(SASIDEV *) override;
+	void TestUnitReady(SCSIDEV *);
 	void StartStopUnit(SCSIDEV *);
 
 	int ModeSense6(const DWORD *, BYTE *);

--- a/src/raspberrypi/devices/host_services.h
+++ b/src/raspberrypi/devices/host_services.h
@@ -5,7 +5,7 @@
 //
 // Copyright (C) 2022 Uwe Seimet
 //
-// RaSCSI Host Services with realtime clock and shutdown support
+// Host Services with realtime clock and shutdown support
 //
 //---------------------------------------------------------------------------
 #pragma once

--- a/src/raspberrypi/devices/interfaces/scsi_printer_commands.h
+++ b/src/raspberrypi/devices/interfaces/scsi_printer_commands.h
@@ -13,7 +13,7 @@
 
 #include "scsi_primary_commands.h"
 
-class SASIDEV;
+class SCSIDEV;
 
 class ScsiPrinterCommands : virtual public ScsiPrimaryCommands
 {
@@ -23,8 +23,8 @@ public:
 	virtual ~ScsiPrinterCommands() {}
 
 	// Mandatory commands
-	virtual void Print(SASIDEV *) = 0;
-	virtual void ReleaseUnit(SASIDEV *) = 0;
-	virtual void ReserveUnit(SASIDEV *) = 0;
-	virtual void SendDiagnostic(SASIDEV *) = 0;
+	virtual void Print(SCSIDEV *) = 0;
+	virtual void ReleaseUnit(SCSIDEV *) = 0;
+	virtual void ReserveUnit(SCSIDEV *) = 0;
+	virtual void SendDiagnostic(SCSIDEV *) = 0;
 };

--- a/src/raspberrypi/devices/mode_page_device.h
+++ b/src/raspberrypi/devices/mode_page_device.h
@@ -33,7 +33,7 @@ private:
 
 	typedef PrimaryDevice super;
 
-	Dispatcher<ModePageDevice> dispatcher;
+	Dispatcher<ModePageDevice, SASIDEV> dispatcher;
 
 	void ModeSense6(SASIDEV *);
 	void ModeSense10(SASIDEV *);

--- a/src/raspberrypi/devices/primary_device.cpp
+++ b/src/raspberrypi/devices/primary_device.cpp
@@ -184,7 +184,7 @@ int PrimaryDevice::Inquiry(int type, bool is_removable, const DWORD *cdb, BYTE *
 		memset(buf, 0, allocation_length);
 		buf[0] = type;
 		buf[1] = is_removable ? 0x80 : 0x00;
-		buf[2] = 0x01;
+		buf[2] = 0x02;
 		buf[4] = 0x1F;
 
 		// Padded vendor, product, revision

--- a/src/raspberrypi/devices/primary_device.cpp
+++ b/src/raspberrypi/devices/primary_device.cpp
@@ -232,3 +232,9 @@ int PrimaryDevice::RequestSense(const DWORD *cdb, BYTE *buf)
 	return size;
 }
 
+bool PrimaryDevice::WriteBytes(BYTE *buf, uint32_t length)
+{
+	LOGERROR("%s Writing bytes is not supported by this device", __PRETTY_FUNCTION__);
+
+	return false;
+}

--- a/src/raspberrypi/devices/primary_device.h
+++ b/src/raspberrypi/devices/primary_device.h
@@ -45,7 +45,7 @@ protected:
 
 private:
 
-	Dispatcher<PrimaryDevice> dispatcher;
+	Dispatcher<PrimaryDevice, SASIDEV> dispatcher;
 
 	void Inquiry(SASIDEV *);
 	void ReportLuns(SASIDEV *);

--- a/src/raspberrypi/devices/primary_device.h
+++ b/src/raspberrypi/devices/primary_device.h
@@ -36,6 +36,7 @@ public:
 	bool CheckReady();
 	virtual int Inquiry(const DWORD *, BYTE *) = 0;
 	virtual int RequestSense(const DWORD *, BYTE *);
+	virtual bool WriteBytes(BYTE *, uint32_t);
 
 protected:
 

--- a/src/raspberrypi/devices/scsi_daynaport.h
+++ b/src/raspberrypi/devices/scsi_daynaport.h
@@ -92,7 +92,7 @@ public:
 private:
 	typedef Disk super;
 
-	Dispatcher<SCSIDaynaPort> dispatcher;
+	Dispatcher<SCSIDaynaPort, SASIDEV> dispatcher;
 
 	typedef struct __attribute__((packed)) {
 		BYTE operation_code;

--- a/src/raspberrypi/devices/scsi_host_bridge.h
+++ b/src/raspberrypi/devices/scsi_host_bridge.h
@@ -50,7 +50,7 @@ public:
 private:
 	typedef PrimaryDevice super;
 
-	Dispatcher<SCSIBR> dispatcher;
+	Dispatcher<SCSIBR, SASIDEV> dispatcher;
 
 	int GetMacAddr(BYTE *buf);					// Get MAC address
 	void SetMacAddr(BYTE *buf);					// Set MAC address

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -112,7 +112,7 @@ void SCSIPrinter::ReserveUnit(SCSIDEV *controller)
 		return;
 	}
 
-	reserving_initiator = ctrl->initiator_id;
+	reserving_initiator = controller->GetInitiatorId();
 
 	if (reserving_initiator != -1) {
 		LOGTRACE("Reserved device ID %d, LUN %d for initiator ID %d", GetId(), GetLun(), reserving_initiator);
@@ -263,14 +263,14 @@ bool SCSIPrinter::Write(BYTE *buf, uint32_t length)
 
 bool SCSIPrinter::CheckReservation(SCSIDEV *controller)
 {
-	if (reserving_initiator == NOT_RESERVED || reserving_initiator == ctrl->initiator_id) {
+	if (reserving_initiator == NOT_RESERVED || reserving_initiator == controller->GetInitiatorId()) {
 		reservation_time = time(0);
 
 		return true;
 	}
 
-	if (ctrl->initiator_id != -1) {
-		LOGTRACE("Initiator ID %d tries to access reserved device ID %d, LUN %d", ctrl->initiator_id, GetId(), GetLun());
+	if (controller->GetInitiatorId() != -1) {
+		LOGTRACE("Initiator ID %d tries to access reserved device ID %d, LUN %d", controller->GetInitiatorId(), GetId(), GetLun());
 	}
 	else {
 		LOGTRACE("Unknown initiator tries to access reserved device ID %d, LUN %d", GetId(), GetLun());

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -121,10 +121,7 @@ void SCSIPrinter::ReserveUnit(SCSIDEV *controller)
 		LOGTRACE("Reserved device ID %d, LUN %d for unknown initiator", GetId(), GetLun());
 	}
 
-	if (fd != -1) {
-		close(fd);
-	}
-	fd = -1;
+	Cleanup();
 
 	controller->Status();
 }
@@ -229,14 +226,7 @@ void SCSIPrinter::StopPrint(SCSIDEV *controller)
 		return;
 	}
 
-	if (fd != -1) {
-		close(fd);
-		fd = -1;
-
-		unlink(filename);
-	}
-
-	LOGTRACE("Printing has been cancelled");
+	Cleanup();
 
 	controller->Status();
 }
@@ -284,12 +274,17 @@ bool SCSIPrinter::CheckReservation(SCSIDEV *controller)
 
 void SCSIPrinter::DiscardReservation()
 {
+	Cleanup();
+
+	reserving_initiator = NOT_RESERVED;
+}
+
+void SCSIPrinter::Cleanup()
+{
 	if (fd != -1) {
 		close(fd);
 		fd = -1;
 
 		unlink(filename);
 	}
-
-	reserving_initiator = NOT_RESERVED;
 }

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -5,7 +5,20 @@
 //
 // Copyright (C) 2022 Uwe Seimet
 //
+// Implementation of a SCSI printer (see SCSI-2 specification for a command description)
+//
 //---------------------------------------------------------------------------
+
+//
+// How to print:
+//
+// 1. The client reserves the printer device with RESERVER UNIT (optional step, mandatory for
+// a multi-initiator environment).
+// 2. The client sends the data to be printed with one or several PRINT commands.
+// 3. The client triggers printing with SYNCHRONIZE BUFFERS.
+// 4. The client releases the printer with RELEASE UNIT (optional step, mandatory for
+// a multi-initiator environment).
+//
 
 #include <sys/stat.h>
 #include "controllers/scsidev_ctrl.h"

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -14,7 +14,8 @@
 //
 // 1. The client reserves the printer device with RESERVER UNIT (optional step, mandatory for
 // a multi-initiator environment).
-// 2. The client sends the data to be printed with one or several PRINT commands.
+// 2. The client sends the data to be printed with one or several PRINT commands. Due to
+// https://github.com/akuker/RASCSI/issues/669 the maximum transfer size is limited to 4096 bytes.
 // 3. The client triggers printing with SYNCHRONIZE BUFFERS.
 // 4. The client releases the printer with RELEASE UNIT (optional step, mandatory for
 // a multi-initiator environment).

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -241,7 +241,7 @@ void SCSIPrinter::StopPrint(SCSIDEV *controller)
 	controller->Status();
 }
 
-bool SCSIPrinter::Write(BYTE *buf, uint32_t length)
+bool SCSIPrinter::WriteBytes(BYTE *buf, uint32_t length)
 {
 	if (fd == -1) {
 		strcpy(filename, TMP_FILE_PATTERN);

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -271,8 +271,12 @@ bool SCSIPrinter::CheckReservation(SASIDEV *controller)
 		return true;
 	}
 
-	LOGTRACE("Initiator ID %d tries to access device ID %d, LUN %d reserved by initiator ID %d",
-			ctrl->initiator_id, GetId(), GetLun(), reserving_initiator);
+	if (ctrl->initiator_id != -1) {
+		LOGTRACE("Initiator ID %d tries to access reserved device ID %d, LUN %d", ctrl->initiator_id, GetId(), GetLun());
+	}
+	else {
+		LOGTRACE("Unknown initiator tries to access reserved device ID %d, LUN %d", GetId(), GetLun());
+	}
 
 	controller->Error(ERROR_CODES::sense_key::ABORTED_COMMAND, ERROR_CODES::asc::NO_ADDITIONAL_SENSE_INFORMATION,
 			ERROR_CODES::status::RESERVATION_CONFLICT);

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -237,7 +237,7 @@ bool SCSIPrinter::WriteBytes(BYTE *buf, uint32_t length)
 		strcpy(filename, TMP_FILE_PATTERN);
 		fd = mkstemp(filename);
 		if (fd == -1) {
-			LOGERROR("Can't create temporary printer output file: %s", strerror(errno));
+			LOGERROR("Can't create printer output file: %s", strerror(errno));
 			return false;
 		}
 

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -22,7 +22,7 @@
 // A client usually does not know whether it is running in a multi-initiator environment. This is why
 // using reservation is recommended.
 //
-// The command to be used for printing can be set with the "printer" property when attaching the device.
+// The command to be used for printing can be set with the "cmd" property when attaching the device.
 // By default the data to be printed are sent to the printer unmodified, using "lp -oraw".
 // By attaching different devices/LUNs multiple printers (i.e. different print commands) are possible.
 //
@@ -186,15 +186,15 @@ void SCSIPrinter::SynchronizeBuffer(SASIDEV *controller)
 	close(fd);
 	fd = -1;
 
-	string print_cmd = GetParam("printer");
-	print_cmd += " ";
-	print_cmd += filename;
+	string cmd = GetParam("cmd");
+	cmd += " ";
+	cmd += filename;
 
-	LOGTRACE("%s", string("Printing file with " + to_string(st.st_size) +" byte(s)").c_str());
+	LOGTRACE("%s", string("Printing file with size of " + to_string(st.st_size) +" byte(s)").c_str());
 
-	LOGDEBUG("Executing '%s'", print_cmd.c_str());
+	LOGDEBUG("Executing '%s'", cmd.c_str());
 
-	if (system(print_cmd.c_str())) {
+	if (system(cmd.c_str())) {
 		LOGERROR("Printing failed, the printing system might not be configured");
 
 		controller->Error();

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -72,12 +72,9 @@ bool SCSIPrinter::Init(const map<string, string>& params)
 	// Use default parameters if no parameters were provided
 	SetParams(params.empty() ? GetDefaultParams() : params);
 
-	int t;
-	if (!GetAsInt(GetParam("timeout"), t) || t <= 0) {
+	if (!GetAsInt(GetParam("timeout"), timeout) || timeout <= 0) {
 		return false;
 	}
-
-	timeout = t;
 
 	return true;
 }

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -54,6 +54,7 @@ SCSIPrinter::SCSIPrinter() : PrimaryDevice("SCLP"), ScsiPrinterCommands()
 	reservation_time = 0;
 	timeout = 0;
 
+	dispatcher.AddCommand(eCmdTestUnitReady, "TestUnitReady", &SCSIPrinter::TestUnitReady);
 	dispatcher.AddCommand(eCmdReserve6, "ReserveUnit", &SCSIPrinter::ReserveUnit);
 	dispatcher.AddCommand(eCmdRelease6, "ReleaseUnit", &SCSIPrinter::ReleaseUnit);
 	dispatcher.AddCommand(eCmdWrite6, "Print", &SCSIPrinter::Print);
@@ -85,9 +86,9 @@ bool SCSIPrinter::Dispatch(SCSIDEV *controller)
 	return dispatcher.Dispatch(this, controller) ? true : super::Dispatch(controller);
 }
 
-void SCSIPrinter::TestUnitReady(SASIDEV *controller)
+void SCSIPrinter::TestUnitReady(SCSIDEV *controller)
 {
-	if (!CheckReservation(static_cast<SCSIDEV *>(controller))) {
+	if (!CheckReservation(controller)) {
 		return;
 	}
 

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -169,7 +169,7 @@ void SCSIPrinter::Print(SCSIDEV *controller)
 	}
 
 	ctrl->length = length;
-	ctrl->is_byte_transfer = true;
+	controller->SetByteTransfer(true);
 
 	controller->DataOut();
 }

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -73,10 +73,11 @@ bool SCSIPrinter::Init(const map<string, string>& params)
 	SetParams(params.empty() ? GetDefaultParams() : params);
 
 	int t;
-	GetAsInt(GetParam("timeout"), t);
-	if (t > 0) {
-		timeout = t;
+	if (!GetAsInt(GetParam("timeout"), t) || t <= 0) {
+		return false;
 	}
+
+	timeout = t;
 
 	return true;
 }

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -19,7 +19,7 @@
 // 4. The client releases the printer with RELEASE UNIT (optional step, mandatory for
 // a multi-initiator environment).
 //
-// Printing can be cancelled by sending a STOP PRINT command.
+// With STOP UNIT printing can be cancelled before SYNCHRONIZE BUFFER was sent.
 //
 // SEND DIAGNOSTIC currently returns no data.
 //

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -72,11 +72,7 @@ bool SCSIPrinter::Init(const map<string, string>& params)
 	// Use default parameters if no parameters were provided
 	SetParams(params.empty() ? GetDefaultParams() : params);
 
-	if (!GetAsInt(GetParam("timeout"), timeout) || timeout <= 0) {
-		return false;
-	}
-
-	return true;
+	return GetAsInt(GetParam("timeout"), timeout) || timeout <= 0;
 }
 
 bool SCSIPrinter::Dispatch(SCSIDEV *controller)

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -111,7 +111,12 @@ void SCSIPrinter::ReserveUnit(SASIDEV *controller)
 
 	reserving_initiator = ctrl->initiator_id;
 
-	LOGTRACE("Reserved device ID %d, LUN %d for initiator ID %d", GetId(), GetLun(), reserving_initiator);
+	if (reserving_initiator != -1) {
+		LOGTRACE("Reserved device ID %d, LUN %d for initiator ID %d", GetId(), GetLun(), reserving_initiator);
+	}
+	else {
+		LOGTRACE("Reserved device ID %d, LUN %d for unknown initiator", GetId(), GetLun());
+	}
 
 	if (fd != -1) {
 		close(fd);
@@ -132,7 +137,12 @@ void SCSIPrinter::ReleaseUnit(SASIDEV *controller)
 	}
 	fd = -1;
 
-	LOGTRACE("Released device ID %d, LUN %d reserved by initiator ID %d", GetId(), GetLun(), reserving_initiator);
+	if (reserving_initiator != -1) {
+		LOGTRACE("Released device ID %d, LUN %d reserved by initiator ID %d", GetId(), GetLun(), reserving_initiator);
+	}
+	else {
+		LOGTRACE("Released device ID %d, LUN %d reserved by unknown initiator", GetId(), GetLun());
+	}
 
 	reserving_initiator = NOT_RESERVED;
 

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -19,6 +19,9 @@
 // 4. The client releases the printer with RELEASE UNIT (optional step, mandatory for
 // a multi-initiator environment).
 //
+// A client usually does not know whether it is running in a multi-initiator environment. This is why
+// using reservation is recommended.
+//
 // The command to be used for printing can be set with the "printer" property when attaching the device.
 // By default the data to be printed are sent to the printer unmodified, using "lp -oraw".
 // By attaching different devices/LUNs multiple printers (i.e. different print commands) are possible.

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -88,6 +88,7 @@ int SCSIPrinter::Inquiry(const DWORD *cdb, BYTE *buf)
 
 void SCSIPrinter::ReserveUnit(SASIDEV *controller)
 {
+	// The printer is released after a configurable time in order to prevent deadlocks caused by broken clients
 	if (reservation_time + timeout < time(0)) {
 		DiscardReservation();
 	}

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -24,7 +24,9 @@
 // using reservation is recommended.
 //
 // The command to be used for printing can be set with the "cmd" property when attaching the device.
-// By default the data to be printed are sent to the printer unmodified, using "lp -oraw".
+// By default the data to be printed are sent to the printer unmodified, using "lp -oraw". This either
+// requires that the client uses a printer driver compatible with the respective printer, or that the
+// printing service on the Pi is configured to do any necessary conversions.
 // By attaching different devices/LUNs multiple printers (i.e. different print commands) are possible.
 //
 // With STOP PRINT printing can be cancelled before SYNCHRONIZE BUFFER was sent.

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -72,7 +72,11 @@ bool SCSIPrinter::Init(const map<string, string>& params)
 	// Use default parameters if no parameters were provided
 	SetParams(params.empty() ? GetDefaultParams() : params);
 
-	return GetAsInt(GetParam("timeout"), timeout) || timeout <= 0;
+	if (!GetAsInt(GetParam("timeout"), timeout) || timeout <= 0) {
+		return false;
+	}
+
+	return true;
 }
 
 bool SCSIPrinter::Dispatch(SCSIDEV *controller)

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -19,6 +19,10 @@
 // 4. The client releases the printer with RELEASE UNIT (optional step, mandatory for
 // a multi-initiator environment).
 //
+// The command to be used for printing can be set with the "printer" property when attaching the device.
+// By default the data to be printed are sent to the printer unmodified, using "lp -oraw".
+// By attaching different devices/LUNs multiple printers (i.e. different print commands) are possible.
+//
 // With STOP PRINT printing can be cancelled before SYNCHRONIZE BUFFER was sent.
 //
 // SEND DIAGNOSTIC currently returns no data.

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -133,11 +133,6 @@ void SCSIPrinter::ReleaseUnit(SASIDEV *controller)
 		return;
 	}
 
-	if (fd != -1) {
-		close(fd);
-	}
-	fd = -1;
-
 	if (reserving_initiator != -1) {
 		LOGTRACE("Released device ID %d, LUN %d reserved by initiator ID %d", GetId(), GetLun(), reserving_initiator);
 	}
@@ -145,7 +140,7 @@ void SCSIPrinter::ReleaseUnit(SASIDEV *controller)
 		LOGTRACE("Released device ID %d, LUN %d reserved by unknown initiator", GetId(), GetLun());
 	}
 
-	reserving_initiator = NOT_RESERVED;
+	DiscardReservation();
 
 	controller->Status();
 }

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -19,7 +19,7 @@
 // 4. The client releases the printer with RELEASE UNIT (optional step, mandatory for
 // a multi-initiator environment).
 //
-// With STOP UNIT printing can be cancelled before SYNCHRONIZE BUFFER was sent.
+// With STOP PRINT printing can be cancelled before SYNCHRONIZE BUFFER was sent.
 //
 // SEND DIAGNOSTIC currently returns no data.
 //

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -87,7 +87,7 @@ bool SCSIPrinter::Dispatch(SCSIDEV *controller)
 
 void SCSIPrinter::TestUnitReady(SASIDEV *controller)
 {
-	if (!CheckReservation(controller)) {
+	if (!CheckReservation(static_cast<SCSIDEV *>(controller))) {
 		return;
 	}
 
@@ -100,7 +100,7 @@ int SCSIPrinter::Inquiry(const DWORD *cdb, BYTE *buf)
 	return PrimaryDevice::Inquiry(2, false, cdb, buf);
 }
 
-void SCSIPrinter::ReserveUnit(SASIDEV *controller)
+void SCSIPrinter::ReserveUnit(SCSIDEV *controller)
 {
 	// The printer is released after a configurable time in order to prevent deadlocks caused by broken clients
 	if (reservation_time + timeout < time(0)) {
@@ -128,7 +128,7 @@ void SCSIPrinter::ReserveUnit(SASIDEV *controller)
 	controller->Status();
 }
 
-void SCSIPrinter::ReleaseUnit(SASIDEV *controller)
+void SCSIPrinter::ReleaseUnit(SCSIDEV *controller)
 {
 	if (!CheckReservation(controller)) {
 		return;
@@ -146,7 +146,7 @@ void SCSIPrinter::ReleaseUnit(SASIDEV *controller)
 	controller->Status();
 }
 
-void SCSIPrinter::Print(SASIDEV *controller)
+void SCSIPrinter::Print(SCSIDEV *controller)
 {
 	if (!CheckReservation(controller)) {
 		return;
@@ -173,7 +173,7 @@ void SCSIPrinter::Print(SASIDEV *controller)
 	controller->DataOut();
 }
 
-void SCSIPrinter::SynchronizeBuffer(SASIDEV *controller)
+void SCSIPrinter::SynchronizeBuffer(SCSIDEV *controller)
 {
 	if (!CheckReservation(controller)) {
 		return;
@@ -213,7 +213,7 @@ void SCSIPrinter::SynchronizeBuffer(SASIDEV *controller)
 	unlink(filename);
 }
 
-void SCSIPrinter::SendDiagnostic(SASIDEV *controller)
+void SCSIPrinter::SendDiagnostic(SCSIDEV *controller)
 {
 	if (!CheckReservation(controller)) {
 		return;
@@ -222,7 +222,7 @@ void SCSIPrinter::SendDiagnostic(SASIDEV *controller)
 	controller->Status();
 }
 
-void SCSIPrinter::StopPrint(SASIDEV *controller)
+void SCSIPrinter::StopPrint(SCSIDEV *controller)
 {
 	if (!CheckReservation(controller)) {
 		return;
@@ -260,7 +260,7 @@ bool SCSIPrinter::Write(BYTE *buf, uint32_t length)
 	return true;
 }
 
-bool SCSIPrinter::CheckReservation(SASIDEV *controller)
+bool SCSIPrinter::CheckReservation(SCSIDEV *controller)
 {
 	if (reserving_initiator == NOT_RESERVED || reserving_initiator == ctrl->initiator_id) {
 		reservation_time = time(0);

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -12,16 +12,17 @@
 //
 // How to print:
 //
-// 1. The client reserves the printer device with RESERVER UNIT (optional step, mandatory for
+// 1. The client reserves the printer device with RESERVE UNIT (optional step, mandatory for
 // a multi-initiator environment).
 // 2. The client sends the data to be printed with one or several PRINT commands. Due to
-// https://github.com/akuker/RASCSI/issues/669 the maximum transfer size is limited to 4096 bytes.
-// 3. The client triggers printing with SYNCHRONIZE BUFFERS.
-// 4. The client releases the printer with RELEASE UNIT (optional step, mandatory for
-// a multi-initiator environment).
+// https://github.com/akuker/RASCSI/issues/669 the maximum transfer size per PRINT command is
+// limited to 4096 bytes.
+// 3. The client triggers printing with SYNCHRONIZE BUFFER.
+// 4. The client releases the printer with RELEASE UNIT (optional step, mandatory for a
+// multi-initiator environment).
 //
 // A client usually does not know whether it is running in a multi-initiator environment. This is why
-// using reservation is recommended.
+// always using a reservation is recommended.
 //
 // The command to be used for printing can be set with the "cmd" property when attaching the device.
 // By default the data to be printed are sent to the printer unmodified, using "lp -oraw". This either

--- a/src/raspberrypi/devices/scsi_printer.h
+++ b/src/raspberrypi/devices/scsi_printer.h
@@ -33,22 +33,22 @@ public:
 
 	int Inquiry(const DWORD *, BYTE *) override;
 	void TestUnitReady(SASIDEV *) override;
-	void ReserveUnit(SASIDEV *);
-	void ReleaseUnit(SASIDEV *);
-	void Print(SASIDEV *);
-	void SynchronizeBuffer(SASIDEV *);
-	void SendDiagnostic(SASIDEV *);
-	void StopPrint(SASIDEV *);
+	void ReserveUnit(SCSIDEV *);
+	void ReleaseUnit(SCSIDEV *);
+	void Print(SCSIDEV *);
+	void SynchronizeBuffer(SCSIDEV *);
+	void SendDiagnostic(SCSIDEV *);
+	void StopPrint(SCSIDEV *);
 
 	bool Write(BYTE *, uint32_t);
-	bool CheckReservation(SASIDEV *);
+	bool CheckReservation(SCSIDEV *);
 	void DiscardReservation();
 
 private:
 
 	typedef PrimaryDevice super;
 
-	Dispatcher<SCSIPrinter> dispatcher;
+	Dispatcher<SCSIPrinter, SCSIDEV> dispatcher;
 
 	char filename[sizeof(TMP_FILE_PATTERN) + 1];
 	int fd;

--- a/src/raspberrypi/devices/scsi_printer.h
+++ b/src/raspberrypi/devices/scsi_printer.h
@@ -40,7 +40,7 @@ public:
 	void SendDiagnostic(SCSIDEV *);
 	void StopPrint(SCSIDEV *);
 
-	bool Write(BYTE *, uint32_t);
+	bool WriteBytes(BYTE *, uint32_t) override;
 	bool CheckReservation(SCSIDEV *);
 	void DiscardReservation();
 

--- a/src/raspberrypi/devices/scsi_printer.h
+++ b/src/raspberrypi/devices/scsi_printer.h
@@ -53,8 +53,6 @@ private:
 	char filename[sizeof(TMP_FILE_PATTERN) + 1];
 	int fd;
 
-	// The reserving initiator
-	// -1 means that the initiator ID is unknown (see SASIDEV), e.g. with Atari ACSI and old host adapters
 	int reserving_initiator;
 
 	time_t reservation_time;

--- a/src/raspberrypi/devices/scsi_printer.h
+++ b/src/raspberrypi/devices/scsi_printer.h
@@ -43,6 +43,7 @@ public:
 	bool WriteBytes(BYTE *, uint32_t) override;
 	bool CheckReservation(SCSIDEV *);
 	void DiscardReservation();
+	void Cleanup();
 
 private:
 

--- a/src/raspberrypi/devices/scsi_printer.h
+++ b/src/raspberrypi/devices/scsi_printer.h
@@ -32,7 +32,7 @@ public:
 	bool Init(const map<string, string>&);
 
 	int Inquiry(const DWORD *, BYTE *) override;
-	void TestUnitReady(SASIDEV *) override;
+	void TestUnitReady(SCSIDEV *);
 	void ReserveUnit(SCSIDEV *);
 	void ReleaseUnit(SCSIDEV *);
 	void Print(SCSIDEV *);

--- a/src/raspberrypi/devices/scsi_printer.h
+++ b/src/raspberrypi/devices/scsi_printer.h
@@ -38,6 +38,7 @@ public:
 	void Print(SASIDEV *);
 	void SynchronizeBuffer(SASIDEV *);
 	void SendDiagnostic(SASIDEV *);
+	void StopPrint(SASIDEV *);
 
 	bool Write(BYTE *, uint32_t);
 	bool CheckReservation(SASIDEV *);

--- a/src/raspberrypi/devices/scsi_printer.h
+++ b/src/raspberrypi/devices/scsi_printer.h
@@ -5,6 +5,8 @@
 //
 // Copyright (C) 2022 Uwe Seimet
 //
+// Implementation of a SCSI printer (see SCSI-2 specification for a command description)
+//
 //---------------------------------------------------------------------------
 #pragma once
 

--- a/src/raspberrypi/devices/scsicd.h
+++ b/src/raspberrypi/devices/scsicd.h
@@ -92,7 +92,7 @@ public:
 private:
 	typedef Disk super;
 
-	Dispatcher<SCSICD> dispatcher;
+	Dispatcher<SCSICD, SASIDEV> dispatcher;
 
 	// Open
 	void OpenCue(const Filepath& path);				// Open(CUE)

--- a/src/raspberrypi/protobuf_util.cpp
+++ b/src/raspberrypi/protobuf_util.cpp
@@ -22,6 +22,30 @@ using namespace rascsi_interface;
 
 Localizer localizer;
 
+void protobuf_util::ParseParameters(PbDeviceDefinition *device, const string& params)
+{
+	if (!params.empty()) {
+		if (params.find('=') != string::npos) {
+			stringstream ss(params);
+			string p;
+			while (getline(ss, p, ':')) {
+				if (!p.empty()) {
+					size_t separator_pos = p.find('=');
+					if (separator_pos != string::npos) {
+						AddParam(*device, p.substr(0, separator_pos), p.substr(separator_pos + 1));
+					}
+				}
+			}
+		}
+		// Old style parameters, for backwards compatibility only.
+		// Only one of these parameters will be used by rascsi, depending on the device type.
+		else {
+			AddParam(*device, "file", params);
+			AddParam(*device, "interfaces", params);
+		}
+    }
+}
+
 const string protobuf_util::GetParam(const PbCommand& command, const string& key)
 {
 	auto map = command.params();

--- a/src/raspberrypi/protobuf_util.cpp
+++ b/src/raspberrypi/protobuf_util.cpp
@@ -20,19 +20,22 @@ using namespace rascsi_interface;
 
 #define FPRT(fp, ...) fprintf(fp, __VA_ARGS__ )
 
+#define COMPONENT_SEPARATOR ':'
+#define KEY_VALUE_SEPARATOR '='
+
 Localizer localizer;
 
-void protobuf_util::ParseParameters(PbDeviceDefinition *device, const string& params)
+void protobuf_util::ParseParameters(PbDeviceDefinition& device, const string& params)
 {
 	if (!params.empty()) {
-		if (params.find('=') != string::npos) {
+		if (params.find(KEY_VALUE_SEPARATOR) != string::npos) {
 			stringstream ss(params);
 			string p;
-			while (getline(ss, p, ':')) {
+			while (getline(ss, p, COMPONENT_SEPARATOR)) {
 				if (!p.empty()) {
-					size_t separator_pos = p.find('=');
+					size_t separator_pos = p.find(KEY_VALUE_SEPARATOR);
 					if (separator_pos != string::npos) {
-						AddParam(*device, p.substr(0, separator_pos), p.substr(separator_pos + 1));
+						AddParam(device, p.substr(0, separator_pos), p.substr(separator_pos + 1));
 					}
 				}
 			}
@@ -40,8 +43,8 @@ void protobuf_util::ParseParameters(PbDeviceDefinition *device, const string& pa
 		// Old style parameters, for backwards compatibility only.
 		// Only one of these parameters will be used by rascsi, depending on the device type.
 		else {
-			AddParam(*device, "file", params);
-			AddParam(*device, "interfaces", params);
+			AddParam(device, "file", params);
+			AddParam(device, "interfaces", params);
 		}
     }
 }

--- a/src/raspberrypi/protobuf_util.cpp
+++ b/src/raspberrypi/protobuf_util.cpp
@@ -44,7 +44,9 @@ void protobuf_util::ParseParameters(PbDeviceDefinition& device, const string& pa
 		// Only one of these parameters will be used by rascsi, depending on the device type.
 		else {
 			AddParam(device, "file", params);
-			AddParam(device, "interfaces", params);
+			if (params != "bridge" && params != "daynaport" && params != "printer" && params != "services") {
+				AddParam(device, "interfaces", params);
+			}
 		}
     }
 }

--- a/src/raspberrypi/protobuf_util.h
+++ b/src/raspberrypi/protobuf_util.h
@@ -23,6 +23,7 @@ using namespace rascsi_interface;
 
 namespace protobuf_util
 {
+	void ParseParameters(PbDeviceDefinition *, const string&);
 	const string GetParam(const PbCommand&, const string&);
 	const string GetParam(const PbDeviceDefinition&, const string&);
 	void AddParam(PbCommand&, const string&, const string&);

--- a/src/raspberrypi/protobuf_util.h
+++ b/src/raspberrypi/protobuf_util.h
@@ -23,7 +23,7 @@ using namespace rascsi_interface;
 
 namespace protobuf_util
 {
-	void ParseParameters(PbDeviceDefinition *, const string&);
+	void ParseParameters(PbDeviceDefinition&, const string&);
 	const string GetParam(const PbCommand&, const string&);
 	const string GetParam(const PbDeviceDefinition&, const string&);
 	void AddParam(PbCommand&, const string&, const string&);

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -868,7 +868,7 @@ bool ProcessCmd(const CommandContext& context, const PbDeviceDefinition& pb_devi
 		bool isFirst = true;
 		for (const auto& param: pb_device.params()) {
 			if (!isFirst) {
-				s << ", ";
+				s << ":";
 			}
 			isFirst = false;
 			s << "'" << param.first << "=" << param.second << "'";

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1298,24 +1298,7 @@ bool ParseArgument(int argc, char* argv[], int& port)
 		device->set_type(type);
 		device->set_block_size(block_size);
 
-		// Either interface, printer or file parameters are supported
-		if (device_factory.GetDefaultParams(type).count("interfaces")) {
-			AddParam(*device, "interfaces", optarg);
-		}
-		else if (device_factory.GetDefaultParams(type).count("cmd")) {
-			string params = optarg;
-			size_t separator_pos = params.find(':');
-			if (separator_pos == string::npos) {
-				AddParam(*device, "cmd", params);
-			}
-			else {
-				AddParam(*device, "cmd", params.substr(0, separator_pos));
-				AddParam(*device, "timeout", params.substr(separator_pos + 1));
-			}
-		}
-		else {
-			AddParam(*device, "file", optarg);
-		}
+		ParseParameters(device, optarg);
 
 		size_t separator_pos = name.find(':');
 		if (separator_pos != string::npos) {

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1298,7 +1298,7 @@ bool ParseArgument(int argc, char* argv[], int& port)
 		device->set_type(type);
 		device->set_block_size(block_size);
 
-		ParseParameters(device, optarg);
+		ParseParameters(*device, optarg);
 
 		size_t separator_pos = name.find(':');
 		if (separator_pos != string::npos) {

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1298,12 +1298,20 @@ bool ParseArgument(int argc, char* argv[], int& port)
 		device->set_type(type);
 		device->set_block_size(block_size);
 
-		// Either interface or file parameters are supported
+		// Either interface, printer or file parameters are supported
 		if (device_factory.GetDefaultParams(type).count("interfaces")) {
 			AddParam(*device, "interfaces", optarg);
 		}
 		else if (device_factory.GetDefaultParams(type).count("printer")) {
-			AddParam(*device, "printer", optarg);
+			string params = optarg;
+			size_t separator_pos = params.find(':');
+			if (separator_pos == string::npos) {
+				AddParam(*device, "printer", params);
+			}
+			else {
+				AddParam(*device, "printer", params.substr(0, separator_pos));
+				AddParam(*device, "timeout", params.substr(separator_pos + 1));
+			}
 		}
 		else {
 			AddParam(*device, "file", optarg);

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -50,6 +50,8 @@ using namespace protobuf_util;
 #define UnitNum	SASIDEV::UnitMax	// Number of units around controller
 #define FPRT(fp, ...) fprintf(fp, __VA_ARGS__ )
 
+#define COMPONENT_SEPARATOR ':'
+
 //---------------------------------------------------------------------------
 //
 //	Variable declarations
@@ -1084,7 +1086,7 @@ bool ProcessCmd(const CommandContext& context, const PbCommand& command)
 
 bool ProcessId(const string id_spec, PbDeviceType type, int& id, int& unit)
 {
-	size_t separator_pos = id_spec.find(':');
+	size_t separator_pos = id_spec.find(COMPONENT_SEPARATOR);
 	if (separator_pos == string::npos) {
 		int max_id = type == SAHD ? 16 : 8;
 
@@ -1300,11 +1302,11 @@ bool ParseArgument(int argc, char* argv[], int& port)
 
 		ParseParameters(*device, optarg);
 
-		size_t separator_pos = name.find(':');
+		size_t separator_pos = name.find(COMPONENT_SEPARATOR);
 		if (separator_pos != string::npos) {
 			device->set_vendor(name.substr(0, separator_pos));
 			name = name.substr(separator_pos + 1);
-			separator_pos = name.find(':');
+			separator_pos = name.find(COMPONENT_SEPARATOR);
 			if (separator_pos != string::npos) {
 				device->set_product(name.substr(0, separator_pos));
 				device->set_revision(name.substr(separator_pos + 1));

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1719,7 +1719,7 @@ int main(int argc, char* argv[])
 				continue;
 			}
 
-			// Extract initiator ID
+			// Extract the SCSI initiator ID
 			int tmp = data - (1 << i);
 			if (tmp) {
 				initiator_id = 0;

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -107,7 +107,7 @@ void Banner(int argc, char* argv[])
 		FPRT(stdout," FILE is disk image file.\n\n");
 		FPRT(stdout,"Usage: %s [-HDn FILE] ...\n\n", argv[0]);
 		FPRT(stdout," n is X68000 SASI HD number(0-15).\n");
-		FPRT(stdout," FILE is disk image file, \"daynaport\", \"bridge\" or \"services\".\n\n");
+		FPRT(stdout," FILE is disk image file, \"daynaport\", \"bridge\", \"printer\" or \"services\".\n\n");
 		FPRT(stdout," Image type is detected based on file extension.\n");
 		FPRT(stdout,"  hdf : SASI HD image (XM6 SASI HD image)\n");
 		FPRT(stdout,"  hds : SCSI HD image (Non-removable generic SCSI HD image)\n");

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -1302,14 +1302,14 @@ bool ParseArgument(int argc, char* argv[], int& port)
 		if (device_factory.GetDefaultParams(type).count("interfaces")) {
 			AddParam(*device, "interfaces", optarg);
 		}
-		else if (device_factory.GetDefaultParams(type).count("printer")) {
+		else if (device_factory.GetDefaultParams(type).count("cmd")) {
 			string params = optarg;
 			size_t separator_pos = params.find(':');
 			if (separator_pos == string::npos) {
-				AddParam(*device, "printer", params);
+				AddParam(*device, "cmd", params);
 			}
 			else {
-				AddParam(*device, "printer", params.substr(0, separator_pos));
+				AddParam(*device, "cmd", params.substr(0, separator_pos));
 				AddParam(*device, "timeout", params.substr(separator_pos + 1));
 			}
 		}

--- a/src/raspberrypi/rascsi_interface.proto
+++ b/src/raspberrypi/rascsi_interface.proto
@@ -39,9 +39,11 @@ enum PbOperation {
     NO_OPERATION = 0;
 
     // Attach devices and return the new device list (PbDevicesInfo)
-    // Parameters (mutually exclusive):
+    // Parameters (depending on the device type):
     //   "file": The filename relative to the default image folder
-    //   "interfaces": A prioritized comma-separated list of interfaces to create a network bridge for.
+    //   "interfaces": A prioritized comma-separated list of interfaces to create a network bridge for
+    //   "cmd": The command to be used for printing
+    //   "timeout": The timeout for printer reservations in seconds
     ATTACH = 1;
 
     // Detach a device and return the new device list (PbDevicesInfo)

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -383,7 +383,7 @@ int main(int argc, char* argv[])
 		exit(EXIT_SUCCESS);
 	}
 
-	ParseParameters(device, param);
+	ParseParameters(*device, param);
 
 	RasctlCommands rasctl_commands(command, hostname, port, token, locale);
 

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -392,10 +392,10 @@ int main(int argc, char* argv[])
 
 		size_t separator_pos = param.find(COMPONENT_SEPARATOR);
 		if (separator_pos == string::npos) {
-			AddParam(*device, "printer", param);
+			AddParam(*device, "cmd", param);
 		}
 		else {
-			AddParam(*device, "printer", param.substr(0, separator_pos));
+			AddParam(*device, "cmd", param.substr(0, separator_pos));
 			AddParam(*device, "timeout", param.substr(separator_pos + 1));
 		}
 	}

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <list>
 
-// Separator for the INQUIRY name components
+// Separator for the INQUIRY name components and for compound parameters
 #define COMPONENT_SEPARATOR ':'
 
 using namespace std;
@@ -384,10 +384,20 @@ int main(int argc, char* argv[])
 	}
 
 	if (!param.empty()) {
-		// Only one of these parameters will be used, depending on the device type
+		// Only one set of these parameters will be used by rascsi, depending on the device type
+
 		AddParam(*device, "interfaces", param);
+
 		AddParam(*device, "file", param);
-		AddParam(*device, "printer", param);
+
+		size_t separator_pos = param.find(COMPONENT_SEPARATOR);
+		if (separator_pos == string::npos) {
+			AddParam(*device, "printer", param);
+		}
+		else {
+			AddParam(*device, "printer", param.substr(0, separator_pos));
+			AddParam(*device, "timeout", param.substr(separator_pos + 1));
+		}
 	}
 
 	RasctlCommands rasctl_commands(command, hostname, port, token, locale);

--- a/src/raspberrypi/rasctl.cpp
+++ b/src/raspberrypi/rasctl.cpp
@@ -383,22 +383,7 @@ int main(int argc, char* argv[])
 		exit(EXIT_SUCCESS);
 	}
 
-	if (!param.empty()) {
-		// Only one set of these parameters will be used by rascsi, depending on the device type
-
-		AddParam(*device, "interfaces", param);
-
-		AddParam(*device, "file", param);
-
-		size_t separator_pos = param.find(COMPONENT_SEPARATOR);
-		if (separator_pos == string::npos) {
-			AddParam(*device, "cmd", param);
-		}
-		else {
-			AddParam(*device, "cmd", param.substr(0, separator_pos));
-			AddParam(*device, "timeout", param.substr(separator_pos + 1));
-		}
-	}
+	ParseParameters(device, param);
 
 	RasctlCommands rasctl_commands(command, hostname, port, token, locale);
 

--- a/src/raspberrypi/rasctl_display.cpp
+++ b/src/raspberrypi/rasctl_display.cpp
@@ -79,7 +79,7 @@ void RasctlDisplay::DisplayDeviceInfo(const PbDevice& pb_device)
 	bool isFirst = true;
 	for (const auto& param : pb_device.params()) {
 		if (!isFirst) {
-			cout << "  ";
+			cout << ":";
 		}
 		isFirst = false;
 		cout << param.first << "=" << param.second;

--- a/src/raspberrypi/rasctl_display.cpp
+++ b/src/raspberrypi/rasctl_display.cpp
@@ -76,8 +76,9 @@ void RasctlDisplay::DisplayDeviceInfo(const PbDevice& pb_device)
 		cout << "  ";
 	}
 
+	map<string, string> params = { pb_device.params().begin(), pb_device.params().end() };
 	bool isFirst = true;
-	for (const auto& param : pb_device.params()) {
+	for (const auto& param : params) {
 		if (!isFirst) {
 			cout << ":";
 		}

--- a/src/raspberrypi/rasctl_display.cpp
+++ b/src/raspberrypi/rasctl_display.cpp
@@ -76,6 +76,7 @@ void RasctlDisplay::DisplayDeviceInfo(const PbDevice& pb_device)
 		cout << "  ";
 	}
 
+	// Creates a sorted map
 	map<string, string> params = { pb_device.params().begin(), pb_device.params().end() };
 	bool isFirst = true;
 	for (const auto& param : params) {

--- a/src/raspberrypi/rasctl_display.cpp
+++ b/src/raspberrypi/rasctl_display.cpp
@@ -171,7 +171,7 @@ void RasctlDisplay::DisplayDeviceTypesInfo(const PbDeviceTypesInfo& device_types
 			bool isFirst = true;
 			for (const auto& param : params) {
 				if (!isFirst) {
-					cout << ", ";
+					cout << ":";
 				}
 				cout << param.first << "=" << param.second;
 


### PR DESCRIPTION
Printing files via RaSCSI, including optional device reservation, successfully tested with an Atari. Tested with and without reservation, with and without initiator ID.

```
[2022-02-15 11:30:02.437] [trace] Printing file with size of 733184 byte(s)
[2022-02-15 11:30:02.437] [debug] Executing 'lp -oraw /tmp/rascsi_sclp-EndCOC'
```
```
>lpstat -t
scheduler is running
system default destination: LaserJet
device for LaserJet: ipp://lp/ipp
LaserJet accepting requests since Mo 14 Feb 2022 23:46:59 CET
printer LaserJet now printing LaserJet-14.  enabled since Mo 14 Feb 2022 23:46:59 CET
LaserJet-14             root            733184   Mo 14 Feb 2022 23:46:59 CET
```

For implementation and usage details see https://github.com/akuker/RASCSI/issues/664, scsi_printer.cpp and the manpages.