### PR TITLE
Bridge is not yet ready to not subclass Disk

### DIFF
--- a/src/raspberrypi/devices/scsi_host_bridge.cpp
+++ b/src/raspberrypi/devices/scsi_host_bridge.cpp
@@ -24,7 +24,7 @@
 using namespace std;
 using namespace scsi_defs;
 
-SCSIBR::SCSIBR() : PrimaryDevice("SCBR")
+SCSIBR::SCSIBR() : Disk("SCBR")
 {
 	tap = NULL;
 	m_bTapEnable = false;

--- a/src/raspberrypi/devices/scsi_host_bridge.h
+++ b/src/raspberrypi/devices/scsi_host_bridge.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "os.h"
-#include "primary_device.h"
+#include "disk.h"
 #include <string>
 
 //===========================================================================
@@ -29,7 +29,7 @@
 class CTapDriver;
 class CFileSys;
 
-class SCSIBR : public PrimaryDevice
+class SCSIBR : public Disk
 {
 
 public:
@@ -48,7 +48,7 @@ public:
 	void SendMessage10(SASIDEV *);
 
 private:
-	typedef PrimaryDevice super;
+	typedef Disk super;
 
 	Dispatcher<SCSIBR, SASIDEV> dispatcher;
 


### PR DESCRIPTION
It turned out that - due to some casts :-( - Bridge still requires to subclass Disk, even though it is not a disk.