### PR TITLE
Inquire the backend for device capabilities instead of Web UI assumptions

### DIFF
--- a/python/common/src/rascsi/common_settings.py
+++ b/python/common/src/rascsi/common_settings.py
@@ -4,14 +4,8 @@ Module for general settings used in the rascsi module
 
 from os import getcwd
 
-WORK_DIR = getcwd()
-
-REMOVABLE_DEVICE_TYPES = ("SCCD", "SCRM", "SCMO")
-NETWORK_DEVICE_TYPES = ("SCDP", "SCBR")
-SUPPORT_DEVICE_TYPES = ("SCLP", "SCHS")
-
 # There may be a more elegant way to get the HOME dir of the user that installed RaSCSI
-HOME_DIR = "/".join(WORK_DIR.split("/")[0:3])
+HOME_DIR = "/".join(getcwd().split("/")[0:3])
 CFG_DIR = f"{HOME_DIR}/.config/rascsi"
 CONFIG_FILE_SUFFIX = "json"
 

--- a/python/common/src/rascsi/ractl_cmds.py
+++ b/python/common/src/rascsi/ractl_cmds.py
@@ -137,12 +137,17 @@ class RaCtlCmds:
         result = proto.PbResult()
         result.ParseFromString(data)
         device_types = {}
-        import logging
         for device in result.device_types_info.properties:
+            supports_file = device.properties.supports_file
             params = {}
             for key, value in device.properties.default_params.items():
                 params[key] = value
-            device_types[proto.PbDeviceType.Name(device.type)] = params
+            block_sizes = device.properties.block_sizes
+            device_types[proto.PbDeviceType.Name(device.type)] = {
+                    "supports_file": supports_file,
+                    "params": params,
+                    "block_sizes": block_sizes,
+                    }
         return {"status": result.status, "device_types": device_types}
 
     def get_image_files_info(self):

--- a/python/common/src/rascsi/ractl_cmds.py
+++ b/python/common/src/rascsi/ractl_cmds.py
@@ -150,7 +150,8 @@ class RaCtlCmds:
 
     def get_removable_device_types(self):
         """
-        Returns a (list) of (str) of four letter device acronyms that are of the removable type
+        Returns a (list) of (str) of four letter device acronyms
+        that are of the removable type.
         """
         device_types = self.get_device_types()
         removable_device_types = []
@@ -159,28 +160,29 @@ class RaCtlCmds:
                 removable_device_types.append(device)
         return removable_device_types
 
-    def get_image_device_types(self):
+    def get_disk_device_types(self):
         """
-        Returns a (list) of (str) of four letter device acronyms that take image files as arguments
+        Returns a (list) of (str) of four letter device acronyms 
+        that take image files as arguments.
         """
         device_types = self.get_device_types()
-        image_device_types = []
+        disk_device_types = []
         for device, value in device_types["device_types"].items():
             if value["supports_file"]:
-                image_device_types.append(device)
-        return image_device_types
+                disk_device_types.append(device)
+        return disk_device_types
 
-    def get_support_device_types(self):
+    def get_peripheral_device_types(self):
         """
         Returns a (list) of (str) of four letter device acronyms
-        that don't take image files as arguments
+        that don't take image files as arguments.
         """
         device_types = self.get_device_types()
-        image_device_types = self.get_image_device_types()
-        support_device_types = [
+        image_device_types = self.get_disk_device_types()
+        peripheral_device_types = [
                 x for x in device_types["device_types"] if x not in image_device_types
                 ]
-        return support_device_types
+        return peripheral_device_types
 
     def get_image_files_info(self):
         """

--- a/python/oled/src/rascsi_oled_monitor.py
+++ b/python/oled/src/rascsi_oled_monitor.py
@@ -43,12 +43,6 @@ from pi_cmds import get_ip_and_host
 from rascsi.ractl_cmds import RaCtlCmds
 from rascsi.socket_cmds import SocketCmds
 
-from rascsi.common_settings import (
-    REMOVABLE_DEVICE_TYPES,
-    NETWORK_DEVICE_TYPES,
-    SUPPORT_DEVICE_TYPES,
-)
-
 parser = argparse.ArgumentParser(description="RaSCSI OLED Monitor script")
 parser.add_argument(
     "--rotation",
@@ -166,7 +160,8 @@ LINE_SPACING = 8
 FONT = ImageFont.truetype('resources/type_writer.ttf', FONT_SIZE)
 
 IP_ADDR, HOSTNAME = get_ip_and_host()
-
+REMOVABLE_DEVICE_TYPES = ractl_cmd.get_removable_device_types()
+SUPPORT_DEVICE_TYPES = ractl_cmd.get_support_device_types()
 
 def formatted_output():
     """
@@ -188,11 +183,12 @@ def formatted_output():
                 else:
                     output.append(f"{line['id']} {line['device_type'][2:4]} {line['status']}")
             # Special handling of devices that don't use image files
-            elif line["device_type"] in (NETWORK_DEVICE_TYPES):
-                output.append(f"{line['id']} {line['device_type'][2:4]} {line['vendor']} "
-                              f"{line['product']}")
             elif line["device_type"] in (SUPPORT_DEVICE_TYPES):
-                output.append(f"{line['id']} {line['device_type'][2:4]} {line['product']}")
+                if line["vendor"] == "RaSCSI":
+                    output.append(f"{line['id']} {line['device_type'][2:4]} {line['product']}")
+                else:
+                    output.append(f"{line['id']} {line['device_type'][2:4]} {line['vendor']} "
+                                  f"{line['product']}")
             # Print only the Vendor/Product info if it's not generic RaSCSI
             elif line["vendor"] not in "RaSCSI":
                 output.append(f"{line['id']} {line['device_type'][2:4]} {line['file']} "

--- a/python/web/src/device_utils.py
+++ b/python/web/src/device_utils.py
@@ -52,33 +52,32 @@ def sort_and_format_devices(devices):
     return formatted_devices
 
 
-def extend_device_names(device_types):
+def map_device_types_and_names(device_types):
     """
-    Takes a (list) of (str) device_types with the four letter device acronyms
+    Takes a (dict) corresponding to the data structure returned by RaCtlCmds.get_device_types()
     Returns a (dict) of device_type:device_name mappings of localized device names
     """
-    mapped_device_types = {}
-    for device_type in device_types:
-        if device_type == "SAHD":
+    for key, value in device_types.items():
+        if key == "SAHD":
             device_name = _("SASI Hard Disk")
-        elif device_type == "SCHD":
+        elif key == "SCHD":
             device_name = _("SCSI Hard Disk")
-        elif device_type == "SCRM":
+        elif key == "SCRM":
             device_name = _("Removable Disk")
-        elif device_type == "SCMO":
+        elif key == "SCMO":
             device_name = _("Magneto-Optical")
-        elif device_type == "SCCD":
+        elif key == "SCCD":
             device_name = _("CD / DVD")
-        elif device_type == "SCBR":
+        elif key == "SCBR":
             device_name = _("X68000 Host Bridge")
-        elif device_type == "SCDP":
+        elif key == "SCDP":
             device_name = _("DaynaPORT SCSI/Link")
-        elif device_type == "SCLP":
+        elif key == "SCLP":
             device_name = _("Printer")
-        elif device_type == "SCHS":
+        elif key == "SCHS":
             device_name = _("Host Services")
         else:
-            device_name = _("Unknown Device")
-        mapped_device_types[device_type] = device_name
+            device_name = key
+        device_types[key]["name"] = device_name
 
-    return mapped_device_types
+    return device_types

--- a/python/web/src/device_utils.py
+++ b/python/web/src/device_utils.py
@@ -58,26 +58,33 @@ def map_device_types_and_names(device_types):
     Returns a (dict) of device_type:device_name mappings of localized device names
     """
     for key, value in device_types.items():
-        if key == "SAHD":
-            device_name = _("SASI Hard Disk")
-        elif key == "SCHD":
-            device_name = _("SCSI Hard Disk")
-        elif key == "SCRM":
-            device_name = _("Removable Disk")
-        elif key == "SCMO":
-            device_name = _("Magneto-Optical")
-        elif key == "SCCD":
-            device_name = _("CD / DVD")
-        elif key == "SCBR":
-            device_name = _("X68000 Host Bridge")
-        elif key == "SCDP":
-            device_name = _("DaynaPORT SCSI/Link")
-        elif key == "SCLP":
-            device_name = _("Printer")
-        elif key == "SCHS":
-            device_name = _("Host Services")
-        else:
-            device_name = key
-        device_types[key]["name"] = device_name
+        device_types[key]["name"] = get_device_name(key)
 
     return device_types
+
+
+def get_device_name(device_type):
+    """
+    Takes a four letter device acronym (str) device_type.
+    Returns the human-readable name for the device type.
+    """
+    if device_type == "SAHD":
+        return _("SASI Hard Disk")
+    elif device_type == "SCHD":
+        return _("SCSI Hard Disk")
+    elif device_type == "SCRM":
+        return _("Removable Disk")
+    elif device_type == "SCMO":
+        return _("Magneto-Optical")
+    elif device_type == "SCCD":
+        return _("CD / DVD")
+    elif device_type == "SCBR":
+        return _("X68000 Host Bridge")
+    elif device_type == "SCDP":
+        return _("DaynaPORT SCSI/Link")
+    elif device_type == "SCLP":
+        return _("Printer")
+    elif device_type == "SCHS":
+        return _("Host Services")
+    else:
+        return device_type

--- a/python/web/src/templates/drives.html
+++ b/python/web/src/templates/drives.html
@@ -15,7 +15,7 @@
     <td><b>{{ _("Ref.") }}</b></td>
     <td><b>{{ _("Action") }}</b></td>
 </tr>
-{% for hd in hd_conf %}
+{% for hd in hd_conf|sort(attribute='name') %}
 <tr>
     <td style="text-align:center">{{ hd.name }}</td>
     <td style="text-align:center">{{ hd.size_mb }}</td>
@@ -59,7 +59,7 @@
     <td><b>{{ _("Ref.") }}</b></td>
     <td><b>{{ _("Action") }}</b></td>
 </tr>
-{% for cd in cd_conf %}
+{% for cd in cd_conf|sort(attribute='name') %}
 <tr>
     <td style="text-align:center">{{ cd.name }}</td>
     <td style="text-align:center">{{ cd.size_mb }}</td>
@@ -79,9 +79,9 @@
         <input type="hidden" name="block_size" value="{{ cd.block_size }}">
         <label for="file_name">{{ _("Create for:") }}</label>
     <select type="select" name="file_name">
-        {% for f in files %}
-    {% if f["name"].lower().endswith(cdrom_file_suffix) %}
-    <option value="{{ f["name"] }}">{{ f["name"].replace(base_dir, '') }}</option>
+        {% for file in files|sort(attribute='name') %}
+    {% if file["name"].lower().endswith(cdrom_file_suffix) %}
+    <option value="{{ file["name"] }}">{{ file["name"].replace(base_dir, '') }}</option>
     {% endif %}
     {% endfor %}
     </select>
@@ -105,7 +105,7 @@
     <td><b>{{ _("Ref.") }}</b></td>
     <td><b>{{ _("Action") }}</b></td>
 </tr>
-{% for rm in rm_conf %}
+{% for rm in rm_conf|sort(attribute='name') %}
 <tr>
     <td style="text-align:center">{{ rm.name }}</td>
     <td style="text-align:center">{{ rm.size_mb }}</td>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -15,7 +15,7 @@
 <p><form action="/config/load" method="post">
     <select name="name" required="" width="14">
         {% if config_files %}
-        {% for config in config_files %}
+        {% for config in config_files|sort %}
         <option value="{{ config }}">
             {{ config.replace(".json", '') }}
         </option>
@@ -166,7 +166,7 @@
             <td>{{ _("Size") }}</td>
             <td>{{ _("Actions") }}</td>
         </tr>
-        {% for file in files %}
+        {% for file in files|sort(attribute='name') %}
         <tr>
             {% if file["prop"] %}
             <td>
@@ -320,7 +320,7 @@
         <td>{{ _("Type") }}</td>
         <td>{{ _("Actions") }}</td>
     </tr>
-    {% for type in SUPPORT_DEVICE_TYPES %}
+    {% for type in SUPPORT_DEVICE_TYPES|sort %}
     <tr>
         <td>
             <div>{{ device_types[type]["name"] }}</div>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -155,7 +155,7 @@
         <li>{{ _("Manage image files in the active RaSCSI image directory: <tt>%(directory)s</tt> with a scan depth of %(scan_depth)s.", directory=base_dir, scan_depth=scan_depth) }}</li>
         <li>{{ _("Select a valid SCSI ID and <a href=\"%(url)s\">LUN</a> to attach to. Unless you know what you're doing, always use LUN 0.", url="https://en.wikipedia.org/wiki/Logical_unit_number") }}
         </li>
-        <li>{{ _("If RaSCSI was unable to detect the device type associated with the image, you can choose the type from the dropdown.") }}</li>
+        <li>{{ _("If RaSCSI was unable to detect the media type associated with the image, you get to choose the type from the dropdown.") }}</li>
     </ul>
 </details>
 
@@ -264,10 +264,10 @@
                     {% else %}
                         <select name="type">
                         <option selected disabled value="">
-                        {{ _("Select device type") }}
+                        {{ _("Select media type") }}
                         </option>
                         {% for key, value in device_types.items() %}
-                        {% if key in IMAGE_DEVICE_TYPES %}
+                        {% if key in DISK_DEVICE_TYPES %}
                         <option value="{{ key }}">
                             {{ value["name"] }}
                         </option>
@@ -298,7 +298,7 @@
 <hr/>
 <details>
     <summary class="heading">
-        {{ _("Attach Support Device") }}
+        {{ _("Attach Peripheral Device") }}
     </summary>
     <ul>
         <li>{{ _("<a href=\"%(url1)s\">DaynaPORT SCSI/Link</a> and <a href=\"%(url2)s\">X68000 Host Bridge</a> are network devices.", url1="https://github.com/akuker/RASCSI/wiki/Dayna-Port-SCSI-Link", url2="https://github.com/akuker/RASCSI/wiki/X68000#Host_File_System_driver") }}
@@ -317,10 +317,10 @@
 </details>
 <table border="black" cellpadding="3">
     <tr style="font-weight: bold;">
-        <td>{{ _("Type") }}</td>
-        <td>{{ _("Actions") }}</td>
+        <td>{{ _("Peripheral") }}</td>
+        <td>{{ _("Parameters and Actions") }}</td>
     </tr>
-    {% for type in SUPPORT_DEVICE_TYPES %}
+    {% for type in PERIPHERAL_DEVICE_TYPES %}
     <tr>
         <td>
             <div>{{ device_types[type]["name"] }}</div>
@@ -331,7 +331,7 @@
                 {% for key, value in device_types[type]["params"].items() %}
                 <label for="{{ key }}">{{ key }}:</label>
                 {% if value.isnumeric() %}
-                <input name="{{ key }}" type="number" size="{{ value|length }}" placeholder="{{ value }}">
+                <input name="{{ key }}" type="number" size="{{ value|length }}" value="{{ value }}">
                 {% elif key == "interface" %}
                 <select name="interface">
                 {% for if in netinfo["ifs"] %}

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -267,7 +267,7 @@
                         {{ _("Select device type") }}
                         </option>
                         {% for key, value in device_types.items() %}
-                        {% if key not in (NETWORK_DEVICE_TYPES + SUPPORT_DEVICE_TYPES) %}
+                        {% if key in IMAGE_DEVICE_TYPES %}
                         <option value="{{ key }}">
                             {{ value }}
                         </option>
@@ -320,7 +320,7 @@
         <td>{{ _("Type") }}</td>
         <td>{{ _("Actions") }}</td>
     </tr>
-    {% for type in (NETWORK_DEVICE_TYPES + SUPPORT_DEVICE_TYPES) %}
+    {% for type in SUPPORT_DEVICE_TYPES %}
     <tr>
         <td>
             <div>{{ device_types[type] }}</div>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -328,7 +328,7 @@
         <td>
             <form action="/scsi/attach_device" method="post">
                 <input name="type" type="hidden" value="{{ type }}">
-                {% for key, value in device_params[type].items() %}
+                {% for key, value in device_params[type]["params"].items() %}
                 <label for="{{ key }}">{{ key }}:</label>
                 {% if value.isnumeric() %}
                 <input name="{{ key }}" type="number" size="{{ value|length }}" placeholder="{{ value }}">

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -164,7 +164,7 @@
         <tr style="font-weight: bold;">
             <td>{{ _("File") }}</td>
             <td>{{ _("Size") }}</td>
-            <td>{{ _("Actions") }}</td>
+            <td>{{ _("Parameters and Actions") }}</td>
         </tr>
         {% for file in files|sort(attribute='name') %}
         <tr>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -320,7 +320,7 @@
         <td>{{ _("Type") }}</td>
         <td>{{ _("Actions") }}</td>
     </tr>
-    {% for type in SUPPORT_DEVICE_TYPES|sort %}
+    {% for type in SUPPORT_DEVICE_TYPES %}
     <tr>
         <td>
             <div>{{ device_types[type]["name"] }}</div>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -269,7 +269,7 @@
                         {% for key, value in device_types.items() %}
                         {% if key in IMAGE_DEVICE_TYPES %}
                         <option value="{{ key }}">
-                            {{ value }}
+                            {{ value["name"] }}
                         </option>
                         {% endif %}
                         {% endfor %}
@@ -323,12 +323,12 @@
     {% for type in SUPPORT_DEVICE_TYPES %}
     <tr>
         <td>
-            <div>{{ device_types[type] }}</div>
+            <div>{{ device_types[type]["name"] }}</div>
         </td>
         <td>
             <form action="/scsi/attach_device" method="post">
                 <input name="type" type="hidden" value="{{ type }}">
-                {% for key, value in device_params[type]["params"].items() %}
+                {% for key, value in device_types[type]["params"].items() %}
                 <label for="{{ key }}">{{ key }}:</label>
                 {% if value.isnumeric() %}
                 <input name="{{ key }}" type="number" size="{{ value|length }}" placeholder="{{ value }}">

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -181,8 +181,8 @@ def index():
         ARCHIVE_FILE_SUFFIX=ARCHIVE_FILE_SUFFIX,
         PROPERTIES_SUFFIX=PROPERTIES_SUFFIX,
         REMOVABLE_DEVICE_TYPES=ractl.get_removable_device_types(),
-        IMAGE_DEVICE_TYPES=ractl.get_image_device_types(),
-        SUPPORT_DEVICE_TYPES=ractl.get_support_device_types(),
+        DISK_DEVICE_TYPES=ractl.get_disk_device_types(),
+        PERIPHERAL_DEVICE_TYPES=ractl.get_peripheral_device_types(),
     )
 
 
@@ -481,7 +481,7 @@ def log_level():
 @login_required
 def attach_device():
     """
-    Attaches a support device that doesn't take an image file as argument
+    Attaches a peripheral device that doesn't take an image file as argument
     """
     params = {}
     for item in request.form:

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -35,7 +35,7 @@ from pi_cmds import (
 from device_utils import (
     sort_and_format_devices,
     get_valid_scsi_ids,
-    extend_device_names,
+    map_device_types_and_names,
 )
 from return_code_mapper import ReturnCodeMapper
 
@@ -110,16 +110,14 @@ def index():
     server_info = ractl.get_server_info()
     disk = disk_space()
     devices = ractl.list_devices()
-    device_types = ractl.get_device_types()
+    device_types = map_device_types_and_names(ractl.get_device_types()["device_types"])
     image_files = file_cmds.list_images()
     config_files = file_cmds.list_config_files()
-
-    mapped_device_types = extend_device_names(device_types["device_types"].keys())
 
     extended_image_files = []
     for image in image_files["files"]:
         if image["detected_type"] != "UNDEFINED":
-            image["detected_type_name"] = mapped_device_types[image["detected_type"]]
+            image["detected_type_name"] = device_types[image["detected_type"]]["name"]
         extended_image_files.append(image)
 
     sorted_image_files = sorted(extended_image_files, key=lambda x: x["name"].lower())
@@ -176,8 +174,7 @@ def index():
         log_levels=server_info["log_levels"],
         current_log_level=server_info["current_log_level"],
         netinfo=ractl.get_network_info(),
-        device_types=mapped_device_types,
-        device_params=device_types["device_types"],
+        device_types=device_types,
         free_disk=int(disk["free"] / 1024 / 1024),
         valid_file_suffix=valid_file_suffix,
         cdrom_file_suffix=tuple(server_info["sccd"]),

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -579,8 +579,8 @@ def attach_image():
     if process["status"]:
         flash(_((
                 "Attached %(file_name)s as %(device_type)s to "
-                "SCSI ID %(id_number)s LUN %(unit_number)s",
-                )
+                "SCSI ID %(id_number)s LUN %(unit_number)s"
+                ),
             file_name=file_name,
             device_type=get_device_name(device_type),
             id_number=scsi_id,

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -575,15 +575,10 @@ def attach_image():
 
     kwargs = {"unit": int(unit), "params": {"file": file_name}}
 
-    # The most common block size is 512 bytes
-    expected_block_size = 512
-
-    if device_type != "":
+    if device_type:
         kwargs["device_type"] = device_type
-        if device_type == "SCCD":
-            expected_block_size = 2048
-        elif device_type == "SAHD":
-            expected_block_size = 256
+        device_types = ractl.get_device_types()
+        expected_block_size = min(device_types["device_types"][device_type]["block_sizes"])
 
     # Attempt to load the device properties file:
     # same file name with PROPERTIES_SUFFIX appended

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -234,10 +234,12 @@ def drive_list():
     else:
         username = None
 
+    server_info = ractl.get_server_info()
+
     return render_template(
         "drives.html",
         files=file_cmds.list_images()["files"],
-        base_dir=ractl.get_server_info()["image_dir"],
+        base_dir=server_info["image_dir"],
         hd_conf=hd_conf,
         cd_conf=cd_conf,
         rm_conf=rm_conf,

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -36,6 +36,7 @@ from device_utils import (
     sort_and_format_devices,
     get_valid_scsi_ids,
     map_device_types_and_names,
+    get_device_name,
 )
 from return_code_mapper import ReturnCodeMapper
 
@@ -527,11 +528,8 @@ def attach_device():
     process = ReturnCodeMapper.add_msg(process)
     if process["status"]:
         flash(_(
-            (
-                "Attached device of type %(device_type)s "
-                "to SCSI ID %(id_number)s LUN %(unit_number)s"
-            ),
-            device_type=device_type,
+            "Attached %(device_type)s to SCSI ID %(id_number)s LUN %(unit_number)s",
+            device_type=get_device_name(device_type),
             id_number=scsi_id,
             unit_number=unit,
             ))
@@ -579,8 +577,15 @@ def attach_image():
     process = ractl.attach_device(scsi_id, **kwargs)
     process = ReturnCodeMapper.add_msg(process)
     if process["status"]:
-        flash(_("Attached %(file_name)s to SCSI ID %(id_number)s LUN %(unit_number)s",
-            file_name=file_name, id_number=scsi_id, unit_number=unit))
+        flash(_((
+                "Attached %(file_name)s as %(device_type)s to "
+                "SCSI ID %(id_number)s LUN %(unit_number)s",
+                )
+            file_name=file_name,
+            device_type=get_device_name(device_type),
+            id_number=scsi_id,
+            unit_number=unit,
+            ))
         if int(file_size) % int(expected_block_size):
             flash(_("The image file size %(file_size)s bytes is not a multiple of "
                   u"%(block_size)s. RaSCSI will ignore the trailing data. "

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -53,9 +53,6 @@ from rascsi.common_settings import (
     CFG_DIR,
     CONFIG_FILE_SUFFIX,
     PROPERTIES_SUFFIX,
-    REMOVABLE_DEVICE_TYPES,
-    NETWORK_DEVICE_TYPES,
-    SUPPORT_DEVICE_TYPES,
     RESERVATIONS,
 )
 from rascsi.ractl_cmds import RaCtlCmds
@@ -190,9 +187,9 @@ def index():
         auth_active=auth_active()["status"],
         ARCHIVE_FILE_SUFFIX=ARCHIVE_FILE_SUFFIX,
         PROPERTIES_SUFFIX=PROPERTIES_SUFFIX,
-        REMOVABLE_DEVICE_TYPES=REMOVABLE_DEVICE_TYPES,
-        NETWORK_DEVICE_TYPES=NETWORK_DEVICE_TYPES,
-        SUPPORT_DEVICE_TYPES=SUPPORT_DEVICE_TYPES,
+        REMOVABLE_DEVICE_TYPES=ractl.get_removable_device_types(),
+        IMAGE_DEVICE_TYPES=ractl.get_image_device_types(),
+        SUPPORT_DEVICE_TYPES=ractl.get_support_device_types(),
     )
 
 


### PR DESCRIPTION
- Introduce RaCtlCmds class methods for getting lists of device types, and their capabilities, instead of hard coded constants in common_settings.py
- Use device capabilities logic across the Web Interface and OLED script, removing hard coded assumptions
- Introduce a get_device_name() method for mapping human readable device names, and use it in the Web Interface for device attachment messages
- Use jinja2 sort filters instead of python logic
- Refactoring