### PR TITLE
Use the word Release in the context of making a SCSI ID available

### DIFF
--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -130,9 +130,9 @@
             <td class="inactive">{{ RESERVATIONS[device.id] }}</td>
             <td class="inactive"></td>
             <td class="inactive">
-                <form action="/scsi/unreserve" method="post">
+                <form action="/scsi/release" method="post">
                     <input name="scsi_id" type="hidden" value="{{ device.id }}">
-                    <input type="submit" value="{{ _("Unreserve") }}">
+                    <input type="submit" value="{{ _("Release") }}">
                 </form>
             </td>
             {% endif %}

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -712,11 +712,11 @@ def reserve_id():
     flash(process["msg"], "error")
     return redirect(url_for("index"))
 
-@APP.route("/scsi/unreserve", methods=["POST"])
+@APP.route("/scsi/release", methods=["POST"])
 @login_required
-def unreserve_id():
+def release_id():
     """
-    Removes the reservation of a SCSI ID as well as the memo for the reservation
+    Releases the reservation of a SCSI ID as well as the memo for the reservation
     """
     scsi_id = request.form.get("scsi_id")
     reserved_ids = ractl.get_reserved_ids()["ids"]


### PR DESCRIPTION
"Unreserve" is an [incorrect use of the English word](https://www.merriam-webster.com/dictionary/unreserve) in this context. Using the word "Release" instead.