### PR TITLE
Added Pi reboot support to host services

### DIFF
--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -164,15 +164,22 @@ void SCSIDEV::BusFree()
 
 		// When the bus is free RaSCSI or the Pi may be shut down
 		switch(shutdown_mode) {
-		case RASCSI:
+		case STOP_RASCSI:
 			LOGINFO("RaSCSI shutdown requested");
 			exit(0);
 			break;
 
-		case PI:
+		case STOP_PI:
 			LOGINFO("Raspberry Pi shutdown requested");
 			if (system("init 0") == -1) {
 				LOGERROR("Raspberry Pi shutdown failed: %s", strerror(errno));
+			}
+			break;
+
+		case RESTART_PI:
+			LOGINFO("Raspberry Pi restart requested");
+			if (system("init 6") == -1) {
+				LOGERROR("Raspberry Pi restart failed: %s", strerror(errno));
 			}
 			break;
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -29,8 +29,9 @@ public:
 
 	enum rascsi_shutdown_mode {
 		NONE,
-		RASCSI,
-		PI
+		STOP_RASCSI,
+		STOP_PI,
+		RESTART_PI
 	};
 
 	// Internal data definition


### PR DESCRIPTION
For consistency reasons START/STOP UNIT also support rebooting the Pi, just as this is supported by the SHUTDOWN operation of the protobuf interface.