### PR TITLE
8bit encoder detection + debounced button detection, numpy removal

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -992,8 +992,8 @@ function installRaScsiCtrlBoard() {
     updateRaScsiGit
 
     sudo apt-get update && sudo apt-get install libjpeg-dev libpng-dev libopenjp2-7-dev i2c-tools raspi-config -y </dev/null
-    # install numpy via apt to avoid compilation
-    sudo apt-get install python3-numpy python3-cbor2 -y </dev/null
+    # install python packages through apt that need compilation
+    sudo apt-get install python3-cbor2 -y </dev/null
 
     # enable i2c
     if [[ $(grep -c "^dtparam=i2c_arm=on" /boot/config.txt) -ge 1 ]]; then

--- a/python/ctrlboard/README.md
+++ b/python/ctrlboard/README.md
@@ -47,6 +47,7 @@ the raspberry pi model and enable transitions only for the following pi models:
 The model detection can be overriden by adding a --transitions parameter to start.sh.
 
 ## Credits
+
 ### DejaVuSansMono-Bold.ttf
 * Source: https://dejavu-fonts.github.io
 * Distributed under DejaVu Fonts Lience (see DejaVu Fonts License.txt for full text)

--- a/python/ctrlboard/requirements.txt
+++ b/python/ctrlboard/requirements.txt
@@ -7,5 +7,4 @@ RPi.GPIO==0.7.0
 protobuf==3.19.3
 unidecode==1.3.2
 smbus==1.1.post2
-# installed via apt to avoid lengthy compilation
-#numpy==1.21.5
+

--- a/python/ctrlboard/src/ctrlboard_hw/encoder.py
+++ b/python/ctrlboard/src/ctrlboard_hw/encoder.py
@@ -10,57 +10,36 @@ class Encoder:
         self.enc_a = enc_a
         self.enc_b = enc_b
         self.pos = 0
-        self.state = 0b0011
+        self.state = 0b00000000
         self.direction = 0
 
     def update(self):
         """Updates the internal attributes wrt. to the encoder position and direction."""
-        self.update2()
-
-    def update2(self):
-        """Primary method for detecting the direction"""
         value_enc_a = self.enc_a.state_interrupt
         value_enc_b = self.enc_b.state_interrupt
 
         self.direction = 0
-        state = self.state & 0b0011
+        state = self.state & 0b00111111
 
         if value_enc_a:
-            state |= 0b0100
+            state |= 0b01000000
         if value_enc_b:
-            state |= 0b1000
+            state |= 0b10000000
 
-        if state == 0b1011:
+        # clockwise pattern detection
+        if (state == 0b11010010 or state == 0b11001000 or state == 0b11011000 or
+                state == 0b11010001 or state == 0b11011011 or state == 0b11100000 or
+                state == 0b11001011):
             self.pos += 1
             self.direction = 1
-
-        if state == 0b0111:
+            self.state = 0b00000000
+            return
+        # counter-clockwise pattern detection
+        elif (state == 0b11000100 or state == 0b11100100 or state == 0b11100001 or
+              state == 0b11000111 or state == 0b11100111):
             self.pos -= 1
             self.direction = -1
+            self.state = 0b00000000
+            return
 
         self.state = state >> 2
-
-        self.enc_a.state_interrupt = True
-        self.enc_b.state_interrupt = True
-
-    def update1(self):
-        """Secondary, less well working method to detect the direction"""
-        if self.enc_a.state_interrupt is True and self.enc_b.state_interrupt is True:
-            return
-
-        if self.enc_a.state_interrupt is False and self.enc_b.state_interrupt is False:
-            self.enc_a.state_interrupt = True
-            self.enc_b.state_interrupt = True
-            return
-
-        self.direction = 0
-
-        if self.enc_a.state_interrupt is False:
-            self.pos += 1
-            self.direction = 1
-        elif self.enc_a.state_interrupt is True:
-            self.pos -= 1
-            self.direction = -1
-
-        self.enc_a.state_interrupt = True
-        self.enc_b.state_interrupt = True

--- a/python/ctrlboard/src/ctrlboard_hw/hardware_button.py
+++ b/python/ctrlboard/src/ctrlboard_hw/hardware_button.py
@@ -11,6 +11,7 @@ class HardwareButton:
         self.state = True
         self.state_interrupt = True
         self.name = "n/a"
+        self.last_press = None
 
     def read(self):
         """Reads the configured port of the i2c multiplexer"""


### PR DESCRIPTION
According to my tests, this rewritten rotary encoder detection works quite a bit better than before, especially with different encoder models. The old one worked fine with my bourns encoder, but jumped around with the cheap chinese encoders I had. I have also added a debounce timer for the button presses as it started to jump around a bit with the restructuring done in this change. Very fast movements still do not always get detected, but I think this is due to missing events due to i2c + multiplexer. Also, I have removed numpy. It didn't seem to make any difference any more.