### PR TITLE
SASI FORMAT opcode fix, SASI segfault fix, added SASI INQUIRY/READ CAPACITY, 512 bytes per sector SASI drives

### DIFF
--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -361,7 +361,6 @@ void SASIDEV::Execute()
 	// Discard pending sense data from the previous command if the current command is not REQUEST SENSE
 	if ((SASIDEV::sasi_command)ctrl.cmd[0] != SASIDEV::eCmdRequestSense) {
 		ctrl.status = 0;
-		ctrl.device->SetStatusCode(0);
 	}
 
 	// Process by command
@@ -436,18 +435,14 @@ void SASIDEV::Execute()
 			break;
 	}
 
-	// Unsupported command
 	LOGTRACE("%s ID %d received unsupported command: $%02X", __PRETTY_FUNCTION__, GetSCSIID(), (BYTE)ctrl.cmd[0]);
 
-	// Logical Unit
 	DWORD lun = GetEffectiveLun();
 	if (ctrl.unit[lun]) {
-		// Command processing on drive
 		ctrl.unit[lun]->SetStatusCode(STATUS_INVALIDCMD);
 	}
 
-	// Failure (Error)
-	Error();
+	Error(sense_key::ILLEGAL_REQUEST, asc::INVALID_LUN);
 }
 
 //---------------------------------------------------------------------------

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -1279,6 +1279,6 @@ void SASIDEV::FlushUnit()
 
 int SASIDEV::GetEffectiveLun() const
 {
-	return ctrl.lun != -1 ? ctrl.lun : (ctrl.cmd[1] >> 5) & 0x07;
+	return (ctrl.cmd[1] >> 5) & 0x01;
 }
 

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -407,6 +407,11 @@ void SASIDEV::Execute()
 			((Disk *)ctrl.device)->Seek(this);
 			return;
 
+		case SASIDEV::eCmdInquiry:
+			LOGTRACE( "%s INQUIRY Command", __PRETTY_FUNCTION__);
+			((Disk *)ctrl.device)->Inquiry(this);
+			return;
+
 		// ASSIGN (SASI only)
 		// This doesn't exist in the SASI Spec, but was in the original RaSCSI code.
 		// leaving it here for now....

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -355,6 +355,8 @@ void SASIDEV::Execute()
 	ctrl.blocks = 1;
 	ctrl.execstart = SysTimer::GetTimerLow();
 
+	ctrl.device = ctrl.unit[GetEffectiveLun()];
+
 	// Discard pending sense data from the previous command if the current command is not REQUEST SENSE
 	if ((SASIDEV::sasi_command)ctrl.cmd[0] != SASIDEV::eCmdRequestSense) {
 		ctrl.status = 0;

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -647,11 +647,8 @@ void SASIDEV::Error(sense_key sense_key, asc asc, status status)
 		return;
 	}
 
-	// Logical Unit
-	DWORD lun = GetEffectiveLun();
-
 	// Set status and message
-	ctrl.status = (lun << 5) | status;
+	ctrl.status = (GetEffectiveLun() << 5) | status;
 
 	// status phase
 	Status();
@@ -1085,6 +1082,6 @@ void SASIDEV::FlushUnit()
 
 int SASIDEV::GetEffectiveLun() const
 {
-	return (ctrl.cmd[1] >> 5) & 0x01;
+	return (ctrl.cmd[1] >> 5) & 0x07;
 }
 

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -437,12 +437,9 @@ void SASIDEV::Execute()
 
 	LOGTRACE("%s ID %d received unsupported command: $%02X", __PRETTY_FUNCTION__, GetSCSIID(), (BYTE)ctrl.cmd[0]);
 
-	DWORD lun = GetEffectiveLun();
-	if (ctrl.unit[lun]) {
-		ctrl.unit[lun]->SetStatusCode(STATUS_INVALIDCMD);
-	}
+	ctrl.device->SetStatusCode(STATUS_INVALIDCMD);
 
-	Error(sense_key::ILLEGAL_REQUEST, asc::INVALID_LUN);
+	Error(sense_key::ILLEGAL_REQUEST, asc::INVALID_COMMAND_OPERATION_CODE);
 }
 
 //---------------------------------------------------------------------------

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -355,7 +355,14 @@ void SASIDEV::Execute()
 	ctrl.blocks = 1;
 	ctrl.execstart = SysTimer::GetTimerLow();
 
-	ctrl.device = ctrl.unit[GetEffectiveLun()];
+	int lun = GetEffectiveLun();
+	if (!ctrl.unit[lun]) {
+		ctrl.device->SetStatusCode(STATUS_INVALIDLUN);
+		Error(sense_key::ILLEGAL_REQUEST, asc::INVALID_LUN);
+		return;
+	}
+
+	ctrl.device = ctrl.unit[lun];
 	ctrl.device->SetCtrl(&ctrl);
 
 	// Discard pending sense data from the previous command if the current command is not REQUEST SENSE

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -356,6 +356,7 @@ void SASIDEV::Execute()
 	ctrl.execstart = SysTimer::GetTimerLow();
 
 	ctrl.device = ctrl.unit[GetEffectiveLun()];
+	ctrl.device->SetCtrl(&ctrl);
 
 	// Discard pending sense data from the previous command if the current command is not REQUEST SENSE
 	if ((SASIDEV::sasi_command)ctrl.cmd[0] != SASIDEV::eCmdRequestSense) {

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -388,6 +388,7 @@ void SASIDEV::Execute()
 			return;
 
 		// FORMAT (the old RaSCSI code used 0x06 as opcode, which is not compliant with the SASI specification)
+		// The FORMAT command of RaSCSI does not do anything but just returns a GOOD status
 		case SASIDEV::eCmdFormat:
 		case SASIDEV::eCmdFormatLegacy:
 			LOGTRACE( "%s FORMAT UNIT Command", __PRETTY_FUNCTION__);

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -381,8 +381,9 @@ void SASIDEV::Execute()
 			CmdRequestSense();
 			return;
 
-		// FORMAT
+		// FORMAT (the old RaSCSI code used 0x06 as opcode, which is not compliant with the SASI specification)
 		case SASIDEV::eCmdFormat:
+		case SASIDEV::eCmdFormatLegacy:
 			CmdFormat();
 			return;
 

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -1082,7 +1082,6 @@ void SASIDEV::FlushUnit()
 
 int SASIDEV::GetEffectiveLun() const
 {
-	// RaSCSI only supports a single SASI LUN
-	return (ctrl.cmd[1] >> 5) & 0x01;
+	return (ctrl.cmd[1] >> 5) & 0x07;
 }
 

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -408,7 +408,7 @@ void SASIDEV::Execute()
 			return;
 
 		// ASSIGN (SASI only)
-		// This doesn't exist in the SCSI Spec, but was in the original RaSCSI code.
+		// This doesn't exist in the SASI Spec, but was in the original RaSCSI code.
 		// leaving it here for now....
 		case SASIDEV::eCmdSasiCmdAssign:
 			CmdAssign();
@@ -425,7 +425,7 @@ void SASIDEV::Execute()
 			return;
 
 		// SPECIFY (SASI only)
-		// This doesn't exist in the SCSI Spec, but was in the original RaSCSI code.
+		// This doesn't exist in the SASI Spec, but was in the original RaSCSI code.
 		// leaving it here for now....
 		case SASIDEV::eCmdInvalid:
 			CmdSpecify();

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -1082,6 +1082,7 @@ void SASIDEV::FlushUnit()
 
 int SASIDEV::GetEffectiveLun() const
 {
-	return (ctrl.cmd[1] >> 5) & 0x07;
+	// RaSCSI only supports a single SASI LUN
+	return (ctrl.cmd[1] >> 5) & 0x01;
 }
 

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -394,6 +394,11 @@ void SASIDEV::Execute()
 			((Disk *)ctrl.device)->FormatUnit(this);
 			return;
 
+		case SASIDEV::eCmdReadCapacity:
+			LOGTRACE( "%s READ CAPACITY Command", __PRETTY_FUNCTION__);
+			((Disk *)ctrl.device)->ReadCapacity10(this);
+			return;
+
 		case SASIDEV::eCmdReassign:
 			LOGTRACE( "%s REASSIGN BLOCKS Command", __PRETTY_FUNCTION__);
 			((Disk *)ctrl.device)->ReassignBlocks(this);

--- a/src/raspberrypi/controllers/sasidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/sasidev_ctrl.cpp
@@ -309,7 +309,7 @@ void SASIDEV::Command()
 		ctrl.blocks = 1;
 
 		// If no byte can be received move to the status phase
-		int count = ctrl.bus->CommandHandShake(ctrl.buffer);
+		int count = ctrl.bus->CommandHandShake(ctrl.buffer, IsSASI());
 		if (!count) {
 			Error();
 			return;

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -36,7 +36,7 @@ private:
 		eCmdTestUnitReady = 0x00,
 		eCmdRezero =  0x01,
 		eCmdRequestSense = 0x03,
-		eCmdFormat = 0x06,
+		eCmdFormat = 0x04,
 		eCmdReassign = 0x07,
 		eCmdRead6 = 0x08,
 		eCmdWrite6 = 0x0A,

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -138,8 +138,7 @@ public:
 	void MsgIn();							// Message in phase
 	void DataOut();						// Data out phase
 
-	// Get LUN based on IDENTIFY message, with LUN from the CDB as fallback
-	int GetEffectiveLun() const;
+	virtual int GetEffectiveLun() const;
 
 	virtual void Error(scsi_defs::sense_key sense_key = scsi_defs::sense_key::NO_SENSE,
 			scsi_defs::asc = scsi_defs::asc::NO_ADDITIONAL_SENSE_INFORMATION,

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -152,16 +152,6 @@ protected:
 	virtual void Execute();					// Execution phase
 
 	// Commands
-	void CmdTestUnitReady();					// TEST UNIT READY command
-	void CmdRezero();						// REZERO UNIT command
-	void CmdRequestSense();					// REQUEST SENSE command
-	void CmdFormat();						// FORMAT command
-	void CmdReassignBlocks();						// REASSIGN BLOCKS command
-	void CmdReserveUnit();						// RESERVE UNIT command
-	void CmdReleaseUnit();						// RELEASE UNIT command
-	void CmdRead6();						// READ(6) command
-	void CmdWrite6();						// WRITE(6) command
-	void CmdSeek6();						// SEEK(6) command
 	void CmdAssign();						// ASSIGN command
 	void CmdSpecify();						// SPECIFY command
 

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -43,6 +43,7 @@ private:
 		eCmdWrite6 = 0x0A,
 		eCmdSeek6 = 0x0B,
 		eCmdSetMcastAddr  = 0x0D,    // DaynaPort specific command
+		eCmdInquiry = 0x12,
 		eCmdModeSelect6 = 0x15,
 		eCmdReserve6 = 0x16,
 		eCmdRelease6 = 0x17,

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -37,6 +37,7 @@ private:
 		eCmdRezero =  0x01,
 		eCmdRequestSense = 0x03,
 		eCmdFormat = 0x04,
+		eCmdFormatLegacy = 0x06,
 		eCmdReassign = 0x07,
 		eCmdRead6 = 0x08,
 		eCmdWrite6 = 0x0A,

--- a/src/raspberrypi/controllers/sasidev_ctrl.h
+++ b/src/raspberrypi/controllers/sasidev_ctrl.h
@@ -37,6 +37,7 @@ private:
 		eCmdRezero =  0x01,
 		eCmdRequestSense = 0x03,
 		eCmdFormat = 0x04,
+		eCmdReadCapacity = 0x05,
 		eCmdFormatLegacy = 0x06,
 		eCmdReassign = 0x07,
 		eCmdRead6 = 0x08,

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -274,7 +274,7 @@ void SCSIDEV::Execute()
 
 	int lun = GetEffectiveLun();
 	if (!ctrl.unit[lun]) {
-		if ((scsi_command)ctrl.cmd[0] != eCmdInquiry &&
+		if ((scsi_command)ctrl.cmd[0] != scsi_command::eCmdInquiry &&
 				(scsi_command)ctrl.cmd[0] != scsi_command::eCmdRequestSense) {
 			LOGDEBUG("Invalid LUN %d for ID %d", lun, GetSCSIID());
 

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -911,7 +911,7 @@ bool SCSIDEV::XferOut(bool cont)
 	return false;
 }
 
-int SASIDEV::GetEffectiveLun() const
+int SCSIDEV::GetEffectiveLun() const
 {
 	return ctrl.lun != -1 ? ctrl.lun : (ctrl.cmd[1] >> 5) & 0x07;
 }

--- a/src/raspberrypi/controllers/scsidev_ctrl.cpp
+++ b/src/raspberrypi/controllers/scsidev_ctrl.cpp
@@ -911,3 +911,8 @@ bool SCSIDEV::XferOut(bool cont)
 	return false;
 }
 
+int SASIDEV::GetEffectiveLun() const
+{
+	return ctrl.lun != -1 ? ctrl.lun : (ctrl.cmd[1] >> 5) & 0x07;
+}
+

--- a/src/raspberrypi/controllers/scsidev_ctrl.h
+++ b/src/raspberrypi/controllers/scsidev_ctrl.h
@@ -62,6 +62,9 @@ public:
 
 	void Receive() override;
 
+	// Get LUN based on IDENTIFY message, with LUN from the CDB as fallback
+	int GetEffectiveLun() const;
+
 	bool IsSASI() const override { return false; }
 	bool IsSCSI() const override { return true; }
 

--- a/src/raspberrypi/devices/device_factory.cpp
+++ b/src/raspberrypi/devices/device_factory.cpp
@@ -25,7 +25,7 @@ using namespace rascsi_interface;
 
 DeviceFactory::DeviceFactory()
 {
-	sector_sizes[SAHD] = { 256, 1024 };
+	sector_sizes[SAHD] = { 256, 512, 1024 };
 	sector_sizes[SCHD] = { 512, 1024, 2048, 4096 };
 	sector_sizes[SCRM] = { 512, 1024, 2048, 4096 };
 	sector_sizes[SCMO] = { 512, 1024, 2048, 4096 };

--- a/src/raspberrypi/devices/disk.h
+++ b/src/raspberrypi/devices/disk.h
@@ -96,7 +96,7 @@ private:
 	void Verify16(SASIDEV *);
 	void Seek(SASIDEV *);
 	void Seek10(SASIDEV *);
-	void ReadCapacity10(SASIDEV *) override;
+	virtual void ReadCapacity10(SASIDEV *) override;
 	void ReadCapacity16(SASIDEV *) override;
 	void Reserve(SASIDEV *);
 	void Release(SASIDEV *);

--- a/src/raspberrypi/devices/disk.h
+++ b/src/raspberrypi/devices/disk.h
@@ -71,6 +71,8 @@ public:
 	bool Eject(bool) override;
 
 private:
+	friend class SASIDEV;
+
 	typedef ModePageDevice super;
 
 	// Commands covered by the SCSI specification (see https://www.t10.org/drafts.htm)

--- a/src/raspberrypi/devices/primary_device.cpp
+++ b/src/raspberrypi/devices/primary_device.cpp
@@ -128,8 +128,6 @@ void PrimaryDevice::RequestSense(SASIDEV *controller)
     memcpy(ctrl->buffer, buf.data(), allocation_length);
     ctrl->length = allocation_length;
 
-    LOGTRACE("%s Status $%02X, Sense Key $%02X, ASC $%02X",__PRETTY_FUNCTION__, ctrl->status, ctrl->buffer[2], ctrl->buffer[12]);
-
     controller->DataIn();
 }
 
@@ -204,6 +202,8 @@ vector<BYTE> PrimaryDevice::RequestSense(int)
 	buf[7] = 10;
 	buf[12] = GetStatusCode() >> 8;
 	buf[13] = GetStatusCode();
+
+	LOGTRACE("%s Status $%02X, Sense Key $%02X, ASC $%02X",__PRETTY_FUNCTION__, ctrl->status, ctrl->buffer[2], ctrl->buffer[12]);
 
 	return buf;
 }

--- a/src/raspberrypi/devices/primary_device.h
+++ b/src/raspberrypi/devices/primary_device.h
@@ -30,6 +30,7 @@ public:
 
 	void TestUnitReady(SASIDEV *);
 	void RequestSense(SASIDEV *);
+	virtual void Inquiry(SASIDEV *);
 
 	void SetCtrl(SASIDEV::ctrl_t *ctrl) { this->ctrl = ctrl; }
 
@@ -49,6 +50,5 @@ private:
 
 	Dispatcher<PrimaryDevice, SASIDEV> dispatcher;
 
-	void Inquiry(SASIDEV *);
 	void ReportLuns(SASIDEV *);
 };

--- a/src/raspberrypi/devices/sasihd.cpp
+++ b/src/raspberrypi/devices/sasihd.cpp
@@ -96,5 +96,7 @@ vector<BYTE> SASIHD::RequestSense(int allocation_length)
 	buf[0] = (BYTE)(GetStatusCode() >> 16);
 	buf[1] = (BYTE)(GetLun() << 5);
 
+	LOGTRACE("%s Status $%02X",__PRETTY_FUNCTION__, GetStatusCode());
+
 	return buf;
 }

--- a/src/raspberrypi/devices/sasihd.cpp
+++ b/src/raspberrypi/devices/sasihd.cpp
@@ -83,8 +83,9 @@ void SASIHD::Open(const Filepath& path)
 
 vector<BYTE> SASIHD::Inquiry() const
 {
-	assert(false);
-	return vector<BYTE>(0);
+	// Byte 0 = 0: Direct access device
+
+	return vector<BYTE>(2);
 }
 
 vector<BYTE> SASIHD::RequestSense(int allocation_length)

--- a/src/raspberrypi/devices/sasihd.cpp
+++ b/src/raspberrypi/devices/sasihd.cpp
@@ -97,7 +97,7 @@ vector<BYTE> SASIHD::RequestSense(int allocation_length)
 	buf[0] = (BYTE)(GetStatusCode() >> 16);
 	buf[1] = (BYTE)(GetLun() << 5);
 
-	LOGTRACE("%s Status $%02X",__PRETTY_FUNCTION__, GetStatusCode());
+	LOGTRACE("%s Status $%02X",__PRETTY_FUNCTION__, buf[0]);
 
 	return buf;
 }

--- a/src/raspberrypi/devices/sasihd.cpp
+++ b/src/raspberrypi/devices/sasihd.cpp
@@ -53,6 +53,11 @@ void SASIHD::Open(const Filepath& path)
 	SetSectorSizeInBytes(GetConfiguredSectorSize() ? GetConfiguredSectorSize() : 256, true);
 	SetBlockCount((DWORD)(size >> GetSectorSizeShiftCount()));
 
+	// SASI only supports READ/WRITE(6), limiting the block count to 2^21
+	if (GetBlockCount() > 2097152) {
+		throw io_exception("SASI drives are limited to 2097152 blocks");
+	}
+
 	#if defined(REMOVE_FIXED_SASIHD_SIZE)
 	// Effective size must be a multiple of the sector size
 	size = (size / GetSectorSizeInBytes()) * GetSectorSizeInBytes();

--- a/src/raspberrypi/devices/sasihd.cpp
+++ b/src/raspberrypi/devices/sasihd.cpp
@@ -101,3 +101,25 @@ vector<BYTE> SASIHD::RequestSense(int allocation_length)
 
 	return buf;
 }
+
+void SASIHD::ReadCapacity10(SASIDEV *controller)
+{
+	BYTE *buf = ctrl->buffer;
+
+	// Create end of logical block address (disk.blocks-1)
+	uint32_t blocks = disk.blocks - 1;
+	buf[0] = (BYTE)(blocks >> 24);
+	buf[1] = (BYTE)(blocks >> 16);
+	buf[2] = (BYTE)(blocks >> 8);
+	buf[3] = (BYTE)blocks;
+
+	// Create block length (1 << disk.size)
+	uint32_t length = 1 << disk.size;
+	buf[4] = (BYTE)(length >> 8);
+	buf[5] = (BYTE)length;
+
+	// the size
+	ctrl->length = 6;
+
+	controller->DataIn();
+}

--- a/src/raspberrypi/devices/sasihd.h
+++ b/src/raspberrypi/devices/sasihd.h
@@ -35,4 +35,5 @@ public:
 
 	vector<BYTE> RequestSense(int) override;
 	vector<BYTE> Inquiry() const override;
+	virtual void ReadCapacity10(SASIDEV *) override;
 };

--- a/src/raspberrypi/gpiobus.cpp
+++ b/src/raspberrypi/gpiobus.cpp
@@ -817,7 +817,7 @@ BOOL GPIOBUS::GetDP()
 //	Receive command handshake
 //
 //---------------------------------------------------------------------------
-int GPIOBUS::CommandHandShake(BYTE *buf)
+int GPIOBUS::CommandHandShake(BYTE *buf, bool is_sasi)
 {
 	int count;
 
@@ -869,7 +869,7 @@ int GPIOBUS::CommandHandShake(BYTE *buf)
 	// semantics. I fact, these semantics have become a standard in the Atari world.
 
 	// RaSCSI becomes ICD compatible by ignoring the prepended $1F byte before processing the CDB.
-	if (*buf == 0x1F) {
+	if (!is_sasi && *buf == 0x1F) {
 		SetSignal(PIN_REQ, ON);
 
 		ret = WaitSignal(PIN_ACK, TRUE);

--- a/src/raspberrypi/gpiobus.cpp
+++ b/src/raspberrypi/gpiobus.cpp
@@ -1592,7 +1592,7 @@ int GPIOBUS::GetCommandByteCount(BYTE opcode) {
 	else if (opcode == 0xA0) {
 		return 12;
 	}
-	else if (opcode >= 0x20 && opcode <= 0x7D) {
+	else if (opcode == 0x05 || (opcode >= 0x20 && opcode <= 0x7D)) {
 		return 10;
 	} else {
 		return 6;

--- a/src/raspberrypi/gpiobus.h
+++ b/src/raspberrypi/gpiobus.h
@@ -565,7 +565,7 @@ public:
 										// Set DAT signal
 	BOOL GetDP() override;
 										// Get Data parity signal
-	int CommandHandShake(BYTE *buf) override;
+	int CommandHandShake(BYTE *buf, bool) override;
 										// Command receive handshake
 	int ReceiveHandShake(BYTE *buf, int count) override;
 										// Data receive handshake

--- a/src/raspberrypi/scsi.h
+++ b/src/raspberrypi/scsi.h
@@ -131,7 +131,8 @@ namespace scsi_defs {
 		SPC_2 = 4,
 		SPC_3 = 5,
 		SPC_4 = 6,
-		SPC_5 = 7
+		SPC_5 = 7,
+		SPC_6 = 8
 	};
 
 	enum device_type : int {

--- a/src/raspberrypi/scsi.h
+++ b/src/raspberrypi/scsi.h
@@ -98,7 +98,7 @@ public:
 	virtual BOOL GetDP() = 0;			// Get parity signal
 
 	virtual DWORD Aquire() = 0;
-	virtual int CommandHandShake(BYTE *buf) = 0;
+	virtual int CommandHandShake(BYTE *buf, bool) = 0;
 	virtual int ReceiveHandShake(BYTE *buf, int count) = 0;
 	virtual int SendHandShake(BYTE *buf, int count, int delay_after_bytes) = 0;
 


### PR DESCRIPTION
Summary of SASI changes:

- Fixed two segfaults
- Added SASI INQUIRY and READ CAPACITY
- Support for 512 bytes per sector
- Removed duplicate code
- ICD compatiblity is now only supported for SCSI but not for SASI drives. ICD compatibility means full SCSI command set, which contradicts SASI

My Atari can now boot from a SASI drive, and can correctly read data and execute programs loaded from the drive. I cannot test the SASI error handling with my setup because RaSCSI appears to implement an old SASI flavor of REQUEST SENSE, where the error status is encoded differently than with newer SASI standards, where errors are reported very similar to SCSI. From the logfile the error handling appears to be correct.