### PR TITLE
Ignore unknown parameters and log a warning

### DIFF
--- a/src/raspberrypi/devices/device.cpp
+++ b/src/raspberrypi/devices/device.cpp
@@ -131,7 +131,7 @@ void Device::SetParams(const unordered_map<string, string>& params)
 			this->params[param.first] = param.second;
 		}
 		else {
-			LOGWARN(string("Ignored unknown parameter '" + param.first + "'").c_str());
+			LOGWARN("%s", string("Ignored unknown parameter '" + param.first + "'").c_str());
 		}
 	}
 }

--- a/src/raspberrypi/devices/device.cpp
+++ b/src/raspberrypi/devices/device.cpp
@@ -126,7 +126,12 @@ void Device::SetParams(const unordered_map<string, string>& params)
 	this->params = GetDefaultParams();
 
 	for (const auto& param : params) {
-		this->params[param.first] = param.second;
+		if (this->params.find(param.first) != this->params.end()) {
+			this->params[param.first] = param.second;
+		}
+		else {
+			LOGWARN(string("Ignored unknown parameter '" + param.first + "'").c_str());
+		}
 	}
 }
 

--- a/src/raspberrypi/devices/device.cpp
+++ b/src/raspberrypi/devices/device.cpp
@@ -126,6 +126,7 @@ void Device::SetParams(const unordered_map<string, string>& params)
 	this->params = GetDefaultParams();
 
 	for (const auto& param : params) {
+		// It is assumed that there are default parameters for all supported parameters
 		if (this->params.find(param.first) != this->params.end()) {
 			this->params[param.first] = param.second;
 		}


### PR DESCRIPTION
Instead of silently ignoring unknown parameters (and storing them internally without using them) they are now ignored and a warning is logged.
This improves backward and forward compatibility.