### PR TITLE
Updated MODE SENSE error handling in case of an overflow

### DIFF
--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -459,6 +459,11 @@ int Disk::ModeSense6(const DWORD *cdb, BYTE *buf)
 	}
 	size += pages_size;
 
+	if (size > 256) {
+		SetStatusCode(STATUS_INVALIDPRM);
+		return 0;
+	}
+
 	// Do not return more than ALLOCATION LENGTH bytes
 	if (size > length) {
 		size = length;
@@ -540,6 +545,11 @@ int Disk::ModeSense10(const DWORD *cdb, BYTE *buf, int max_length)
 		return 0;
 	}
 	size += pages_size;
+
+	if (size > 65536) {
+		SetStatusCode(STATUS_INVALIDPRM);
+		return 0;
+	}
 
 	// Do not return more than ALLOCATION LENGTH bytes
 	if (size > length) {

--- a/src/raspberrypi/devices/disk.cpp
+++ b/src/raspberrypi/devices/disk.cpp
@@ -459,7 +459,7 @@ int Disk::ModeSense6(const DWORD *cdb, BYTE *buf)
 	}
 	size += pages_size;
 
-	if (size > 256) {
+	if (size > 255) {
 		SetStatusCode(STATUS_INVALIDPRM);
 		return 0;
 	}
@@ -546,7 +546,7 @@ int Disk::ModeSense10(const DWORD *cdb, BYTE *buf, int max_length)
 	}
 	size += pages_size;
 
-	if (size > 65536) {
+	if (size > 65535) {
 		SetStatusCode(STATUS_INVALIDPRM);
 		return 0;
 	}


### PR DESCRIPTION
This change updates the error handling The SCSI-2 specification says:

If the mode parameter list exceeds 256 bytes for a MODE SENSE(6) command or 65536 bytes for a MODE SENSE(10) command, the target shall return CHECK CONDITION status and the sense key shall be set to ILLEGAL REQUEST and the additional sense code set to INVALID FIELD IN CDB.

Elsewhere the specification says that the number of returned bytes can never be more than ALLOCATION_LENGTH, because that is the amount of memory the initiator has reserved. Effectively this means that the limit is not 256 or 65536, resp., but 255 or 65535. This PR checks against the latter.