### PR TITLE
Add RASCSI host and port arguments to web/start.sh

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -1272,7 +1272,7 @@ function runChoice() {
               preparePythonCommon
               installRaScsiWebInterface
               echo "Configuring RaSCSI Web Interface stand-alone - Complete!"
-              echo "Launch the Web Interface with the 'start.sh' script. To use a custom port for the web server: 'start.sh --port=8081"
+              echo "Launch the Web Interface with the 'start.sh' script. To use a custom port for the web server: 'start.sh --web-port=8081"
           ;;
           12)
               echo "Enabling authentication for the RaSCSI Web Interface"

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -1031,7 +1031,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--rascsi-port",
-        type=str,
+        type=int,
         default=6868,
         action="store",
         help="RaSCSI port. Default: 6868",

--- a/python/web/start.sh
+++ b/python/web/start.sh
@@ -90,16 +90,16 @@ while [ "$1" != "" ]; do
     PARAM=$(echo "$1" | awk -F= '{print $1}')
     VALUE=$(echo "$1" | awk -F= '{print $2}')
     case $PARAM in
-    -p | --port)
+    -p | --web-port)
         ARG_PORT="--port $VALUE"
         ;;
     -P | --password)
         ARG_PASSWORD="--password $VALUE"
         ;;
-    --rascsi-host)
+    -h | --rascsi-host)
         ARG_RASCSI_HOST="--rascsi-host $VALUE"
         ;;
-    --rascsi-port)
+    -o | --rascsi-port)
         ARG_RASCSI_PORT="--rascsi-port $VALUE"
         ;;
     *)

--- a/python/web/start.sh
+++ b/python/web/start.sh
@@ -90,16 +90,22 @@ while [ "$1" != "" ]; do
     PARAM=$(echo "$1" | awk -F= '{print $1}')
     VALUE=$(echo "$1" | awk -F= '{print $2}')
     case $PARAM in
-	-p | --port)
-	    PORT="--port $VALUE"
-	    ;;
-	-P | --password)
-	    PASSWORD="--password $VALUE"
-	    ;;
-        *)
-            echo "ERROR: unknown parameter \"$PARAM\""
-            exit 1
-            ;;
+    -p | --port)
+        ARG_PORT="--port $VALUE"
+        ;;
+    -P | --password)
+        ARG_PASSWORD="--password $VALUE"
+        ;;
+    --rascsi-host)
+        ARG_RASCSI_HOST="--rascsi-host $VALUE"
+        ;;
+    --rascsi-port)
+        ARG_RASCSI_PORT="--rascsi-port $VALUE"
+        ;;
+    *)
+        echo "ERROR: unknown parameter \"$PARAM\""
+        exit 1
+        ;;
     esac
     shift
 done
@@ -108,4 +114,4 @@ PYTHON_COMMON_PATH=$(dirname $PWD)/common/src
 echo "Starting web server for RaSCSI Web Interface..."
 export PYTHONPATH=$PWD/src:${PYTHON_COMMON_PATH}
 cd src
-python3 web.py ${PORT} ${PASSWORD}
+python3 web.py ${ARG_PORT} ${ARG_PASSWORD} ${ARG_RASCSI_HOST} ${ARG_RASCSI_PORT}


### PR DESCRIPTION
Allows web/start.sh to accept `--rascsi-host` and `--rascsi-port` arguments, which are then passed through to web.py.

Fixes an issue where web.py errors when the `--rascsi-port` argument is specified.