### PR TITLE
Rebrand to RaSCSI Reloaded in key places in the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# What is RaSCSI?
-RaSCSI is a virtual SCSI device emulator that runs on a Raspberry Pi. It runs in userspace, and can emulate several SCSI devices at one time. There is a control interface to attach / detach drives during runtime, as well as insert and eject removable media. This project is aimed at users of vintage Macintosh and Atari computers and more (see [compatibility list](https://github.com/akuker/RASCSI/wiki/Compatibility)) from the 1980's and 1990's.
+# What is RaSCSI Reloaded?
+RaSCSI Reloaded is a virtual SCSI device emulator that runs on a Raspberry Pi. It runs in userspace, and can emulate several SCSI devices at one time. There is a control interface to attach / detach drives during runtime, as well as insert and eject removable media. This project is aimed at users of vintage Macintosh and Atari computers and more (see [compatibility list](https://github.com/akuker/RASCSI/wiki/Compatibility)) from the 1980's and 1990's.
 
 Please check out the full story with much more detail on the [wiki](https://github.com/akuker/RASCSI/wiki)!
 
 # How do I contribute?
-RaSCSI is using the <a href="https://datasift.github.io/gitflow/IntroducingGitFlow.html">Gitflow Workflow</a>. A quick overview:
+RaSCSI Reloaded is using the <a href="https://datasift.github.io/gitflow/IntroducingGitFlow.html">Gitflow Workflow</a>. A quick overview:
 
 - The *master* branch should always reflect the contents of the last stable release
 - The *develop* branch should contain the latest tested & approved updates. Pull requests should be used to merge changes into develop.

--- a/python/web/src/templates/base.html
+++ b/python/web/src/templates/base.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>{{ _("RaSCSI Control Page") }} [{{ host }}]</title>
+    <title>{{ _("RaSCSI Reloaded Control Page") }} [{{ host }}]</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <link rel="apple-touch-icon" sizes="57x57" href="/pwa/apple-icon-57x57.png">
@@ -64,7 +64,7 @@
         <tr align="center">
             <td>
                 <a href="http://github.com/akuker/RASCSI" target="_blank">
-                    <h1>{{ _("RaSCSI Control Page") }}</h1>
+                    <h1>{{ _("RaSCSI Reloaded Control Page") }}</h1>
                 </a>
             </td>
         </tr>
@@ -89,7 +89,7 @@
         {% block content %}{% endblock content %}
     </div>
     <div class="footer">
-        <center><tt>{{ _("RaSCSI version: ") }}<strong>{{ version }} <a href="https://github.com/akuker/RASCSI/commit/{{ running_env['git'] }}" target="_blank">{{ running_env["git"][:7] }}</a></strong></tt></center>
+        <center><tt>{{ _("RaSCSI Reloaded version: ") }}<strong>{{ version }} <a href="https://github.com/akuker/RASCSI/commit/{{ running_env['git'] }}" target="_blank">{{ running_env["git"][:7] }}</a></strong></tt></center>
         <center><tt>{{ _("Pi environment: ") }}{{ running_env["env"] }}</tt></center>
     </div>
 </div>

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -91,14 +91,14 @@ void KillHandler(int sig)
 //---------------------------------------------------------------------------
 void Banner(int argc, char* argv[])
 {
-	FPRT(stdout,"SCSI Target Emulator RaSCSI(*^..^*) ");
+	FPRT(stdout,"SCSI Target Emulator RaSCSI Reloaded ");
 	FPRT(stdout,"version %s (%s, %s)\n",
 		rascsi_get_version_string(),
 		__DATE__,
 		__TIME__);
 	FPRT(stdout,"Powered by XM6 TypeG Technology / ");
 	FPRT(stdout,"Copyright (C) 2016-2020 GIMONS\n");
-	FPRT(stdout,"Copyright (C) 2020-2022 Contributors to the RaSCSI project\n");
+	FPRT(stdout,"Copyright (C) 2020-2022 Contributors to the RaSCSI Reloaded project\n");
 	FPRT(stdout,"Connect type : %s\n", CONNECT_DESC);
 
 	if ((argc > 1 && strcmp(argv[1], "-h") == 0) ||


### PR DESCRIPTION
Note that there are about another million uses of the word "RaSCSI", but for all intents and purposes I think we can treat those as effectively an abbreviation of RaSCSI Reloaded.