### PR TITLE
Add support for --log-level argument to web UI + log format update

### DIFF
--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -2,6 +2,7 @@
 Module for the Flask app rendering and endpoints
 """
 
+import sys
 import logging
 import argparse
 from pathlib import Path
@@ -1028,14 +1029,23 @@ if __name__ == "__main__":
         default="localhost",
         action="store",
         help="RaSCSI host. Default: localhost",
-    )
+        )
     parser.add_argument(
         "--rascsi-port",
         type=int,
         default=6868,
         action="store",
         help="RaSCSI port. Default: 6868",
-    )
+        )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="warning",
+        action="store",
+        help="Log level for Web UI. Default: warning",
+        choices=["debug", "info", "warning", "error", "critical"],
+        )
+
     arguments = parser.parse_args()
     APP.config["TOKEN"] = arguments.password
 
@@ -1046,6 +1056,10 @@ if __name__ == "__main__":
 
     if Path(f"{CFG_DIR}/{DEFAULT_CONFIG}").is_file():
         file_cmd.read_config(DEFAULT_CONFIG)
+
+    logging.basicConfig(stream=sys.stdout,
+                        format="%(asctime)s %(levelname)s %(filename)s:%(lineno)s %(message)s",
+                        level=arguments.log_level.upper())
 
     print("Serving rascsi-web...")
     bjoern.run(APP, "0.0.0.0", arguments.port)

--- a/python/web/start.sh
+++ b/python/web/start.sh
@@ -102,6 +102,9 @@ while [ "$1" != "" ]; do
     -o | --rascsi-port)
         ARG_RASCSI_PORT="--rascsi-port $VALUE"
         ;;
+    -l | --log-level)
+        ARG_LOG_LEVEL="--log-level $VALUE"
+        ;;
     *)
         echo "ERROR: unknown parameter \"$PARAM\""
         exit 1
@@ -114,4 +117,4 @@ PYTHON_COMMON_PATH=$(dirname $PWD)/common/src
 echo "Starting web server for RaSCSI Web Interface..."
 export PYTHONPATH=$PWD/src:${PYTHON_COMMON_PATH}
 cd src
-python3 web.py ${ARG_PORT} ${ARG_PASSWORD} ${ARG_RASCSI_HOST} ${ARG_RASCSI_PORT}
+python3 web.py ${ARG_PORT} ${ARG_PASSWORD} ${ARG_RASCSI_HOST} ${ARG_RASCSI_PORT} ${ARG_LOG_LEVEL}


### PR DESCRIPTION
The web UI runs with its log level set to `WARNING` by default.

I was unable to find a way to change the log level without making a code change.

This change allows the log level to be set from the command line, and adds useful information to aid with troubleshooting.

Log format:

```
timestamp level file:line message
```

Example output:

```
2022-08-01 00:12:54,209 WARNING file_cmds.py:109 /home/pi/images/image_with_properties_test.zip is an invalid zip file
2022-08-01 00:12:54,219 WARNING file_cmds.py:109 /home/pi/images/RaSCSI-Boot-8.hda_.zip is an invalid zip file
2022-08-01 00:12:54,232 WARNING sys_cmds.py:96 Executed shell command: brctl show
2022-08-01 00:12:54,232 WARNING sys_cmds.py:97 Got error: brctl: No such operation show
```