### PR TITLE
Add HTTPS support to web UI

### DIFF
--- a/python/web/service-infra/nginx-default.conf
+++ b/python/web/service-infra/nginx-default.conf
@@ -3,6 +3,16 @@
 server {
     listen [::]:80 default_server;
     listen 80 default_server;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    ssl_certificate /etc/ssl/certs/rascsi-web.crt;
+    ssl_certificate_key /etc/ssl/private/rascsi-web.key;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:MozSSL:10m;
+    ssl_session_tickets off;
+    ssl_protocols TLSv1.3;
+    ssl_prefer_server_ciphers off;
 
     location / {
         proxy_pass http://127.0.0.1:8080;


### PR DESCRIPTION
Enables HTTPS for Nginx and generates a self-signed certificate via `easyinstall.sh`.

The configuration is intended for browsers which support modern encryption. See https://caniuse.com/tls1-3 for specifics.

Users accessing the web UI from legacy devices/browsers can continue to use the HTTP service.

To my knowledge, a self-signed certificate is the simplest option for local network usage. There are a couple of approaches to getting a CA issued certificate, but setup is non-trivial for the average user. In any case, advanced users can install their own certificate in `/etc/ssl/certs` and the upgrade process will not overwrite them.

The configuration parameters are based on Mozilla's [SSL Configuration Generator](https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=modern&openssl=1.1.1k&hsts=false&ocsp=false&guideline=5.6) tool.

This PR addresses issue https://github.com/akuker/RASCSI/issues/489.

Raising as draft to allow for early feedback and additional testing.