### PR TITLE
Enhancements to ReturnCodeMapper

### DIFF
--- a/python/web/src/return_code_mapper.py
+++ b/python/web/src/return_code_mapper.py
@@ -9,25 +9,35 @@ class ReturnCodeMapper:
     """Class for mapping between rascsi return codes and translated strings"""
 
     MESSAGES = {
-        ReturnCodes.DELETEFILE_SUCCESS: _("File deleted: %(file_path)s"),
-        ReturnCodes.DELETEFILE_FILE_NOT_FOUND: _("File to delete not found: %(file_path)s"),
-        ReturnCodes.RENAMEFILE_SUCCESS: _("File moved to: %(target_path)s"),
-        ReturnCodes.RENAMEFILE_UNABLE_TO_MOVE: _("Unable to move file to: %(target_path)s"),
-        ReturnCodes.DOWNLOADFILETOISO_SUCCESS: _("Created CD-ROM ISO image with "
-                                                 "arguments \"%(value)s\""),
-        ReturnCodes.DOWNLOADTODIR_SUCCESS: _("%(file_name)s downloaded to %(save_dir)s"),
-        ReturnCodes.WRITEFILE_SUCCESS: _("File created: %(target_path)s"),
-        ReturnCodes.WRITEFILE_COULD_NOT_WRITE: _("Could not create file: %(target_path)s"),
-        ReturnCodes.READCONFIG_SUCCESS: _("Loaded configurations from: %(file_name)s"),
-        ReturnCodes.READCONFIG_COULD_NOT_READ: _("Could not read configuration "
-                                                 "file: %(file_name)s"),
-        ReturnCodes.READCONFIG_INVALID_CONFIG_FILE_FORMAT: _("Invalid configuration file format"),
-        ReturnCodes.READDRIVEPROPS_SUCCESS: _("Read properties from file: %(file_path)s"),
-        ReturnCodes.READDRIVEPROPS_COULD_NOT_READ: _("Could not read properties from "
-                                                     "file: %(file_path)s"),
-        ReturnCodes.ATTACHIMAGE_COULD_NOT_ATTACH: _("Cannot insert an image for %(device_type)s "
-                                                    "into a %(current_device_type)s device"),
-    }
+        ReturnCodes.DELETEFILE_SUCCESS:
+            _("File deleted: %(file_path)s"),
+        ReturnCodes.DELETEFILE_FILE_NOT_FOUND:
+            _("File to delete not found: %(file_path)s"),
+        ReturnCodes.RENAMEFILE_SUCCESS:
+            _("File moved to: %(target_path)s"),
+        ReturnCodes.RENAMEFILE_UNABLE_TO_MOVE:
+            _("Unable to move file to: %(target_path)s"),
+        ReturnCodes.DOWNLOADFILETOISO_SUCCESS:
+            _("Created CD-ROM ISO image with arguments \"%(value)s\""),
+        ReturnCodes.DOWNLOADTODIR_SUCCESS:
+            _("%(file_name)s downloaded to %(save_dir)s"),
+        ReturnCodes.WRITEFILE_SUCCESS:
+            _("File created: %(target_path)s"),
+        ReturnCodes.WRITEFILE_COULD_NOT_WRITE:
+            _("Could not create file: %(target_path)s"),
+        ReturnCodes.READCONFIG_SUCCESS:
+            _("Loaded configurations from: %(file_name)s"),
+        ReturnCodes.READCONFIG_COULD_NOT_READ:
+            _("Could not read configuration file: %(file_name)s"),
+        ReturnCodes.READCONFIG_INVALID_CONFIG_FILE_FORMAT:
+            _("Invalid configuration file format"),
+        ReturnCodes.READDRIVEPROPS_SUCCESS:
+            _("Read properties from file: %(file_path)s"),
+        ReturnCodes.READDRIVEPROPS_COULD_NOT_READ:
+            _("Could not read properties from file: %(file_path)s"),
+        ReturnCodes.ATTACHIMAGE_COULD_NOT_ATTACH:
+            _("Cannot insert an image for %(device_type)s into a %(current_device_type)s device"),
+        }
 
     @staticmethod
     def add_msg(payload):
@@ -36,10 +46,14 @@ class ReturnCodeMapper:
         if "return_code" not in payload:
             return payload
 
-        parameters = payload["parameters"]
+        parameters = payload.get("parameters")
 
-        payload["msg"] = lazy_gettext(
+        if parameters:
+            payload["msg"] = lazy_gettext(
                 ReturnCodeMapper.MESSAGES[payload["return_code"]],
                 **parameters,
                 )
+        else:
+            payload["msg"] = lazy_gettext(ReturnCodeMapper.MESSAGES[payload["return_code"]])
+
         return payload


### PR DESCRIPTION
This change set was originally on another branch, but I ended up not needing to use `ReturnCodeMapper`.

* Fixes error preventing use of payloads without parameters
* ~~Removes redundant calls to `_` (`gettext`) wrapping message strings~~
* Formatting to avoid wrapping of message strings (subjective: readability improvement)