### PR TITLE
Fix Python 3.7 compatibility (#800)

### DIFF
--- a/python/common/src/util/unarchiver.py
+++ b/python/common/src/util/unarchiver.py
@@ -79,7 +79,8 @@ def extract_archive(file_path, **kwargs):
             extracted_members = []
 
             for line in lines[1:-1]:
-                if line_matches := match(unar_file_extracted, line):
+                line_matches = match(unar_file_extracted, line)
+                if line_matches:
                     matches = line_matches.groupdict()
                     member = {
                         "name": str(pathlib.PurePath(matches["path"]).name),
@@ -90,7 +91,11 @@ def extract_archive(file_path, **kwargs):
                         "absolute_path": str(pathlib.PurePath(tmp_dir).joinpath(matches["path"])),
                         }
 
-                    member_types = matches.get("types", "").removeprefix(", ").split(", ")
+                    member_types = matches.get("types", "")
+                    if member_types.startswith(", "):
+                        member_types = member_types[2:].split(", ")
+                    else:
+                        member_types = member_types.split(", ")
 
                     if "dir" in member_types:
                         member["is_dir"] = True


### PR DESCRIPTION
Python 3.7 compatibility is required to support Debian Buster installations.

Replaces use of walrus operator (Python 3.8) and removeprefix (Python 3.9), which were introduced in #789.