### PR TITLE
handle the return value of write()

### DIFF
--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -257,9 +257,9 @@ bool SCSIPrinter::WriteBytes(BYTE *buf, uint32_t length)
 
 	LOGTRACE("Appending %d byte(s) to printer output file", length);
 
-	write(fd, buf, length);
+	uint32_t num_written = write(fd, buf, length);
 
-	return true;
+	return (num_written == length);
 }
 
 bool SCSIPrinter::CheckReservation(SCSIDEV *controller)


### PR DESCRIPTION
With this change, I was able to build and run the `feature_google_test` tests on Ubuntu 22.

@uweseimet - would you be able to look at this? I don't have a way to test the printer functionality currently. But, it looks like a pretty benign change.