### PR TITLE
Python updates following SASI removal

### DIFF
--- a/python/common/src/rascsi/ractl_cmds.py
+++ b/python/common/src/rascsi/ractl_cmds.py
@@ -48,7 +48,6 @@ class RaCtlCmds:
 
         # Creates lists of file endings recognized by RaSCSI
         mappings = result.server_info.mapping_info.mapping
-        sahd = []
         schd = []
         scrm = []
         scmo = []

--- a/python/ctrlboard/src/ctrlboard_event_handler/ctrlboard_menu_update_event_handler.py
+++ b/python/ctrlboard/src/ctrlboard_event_handler/ctrlboard_menu_update_event_handler.py
@@ -247,7 +247,7 @@ class CtrlBoardMenuUpdateEventHandler(Observer):
 
         device_type = device_info["device_list"][0]["device_type"]
         image = device_info["device_list"][0]["image"]
-        if device_type in ("SAHD", "SCHD", "SCBR", "SCDP", "SCLP", "SCHS"):
+        if device_type in ("SCHD", "SCBR", "SCDP", "SCLP", "SCHS"):
             result = self.ractl_cmd.detach_by_id(scsi_id)
             if result["status"] is True:
                 self.show_id_action_message(scsi_id, "detached")

--- a/python/web/src/translations/es/LC_MESSAGES/messages.po
+++ b/python/web/src/translations/es/LC_MESSAGES/messages.po
@@ -1282,10 +1282,10 @@ msgstr "Apagar la Raspberry Pi"
 #~ msgstr "Liberar la reserva"
 
 #~ msgid ""
-#~ "Types: SAHD = SASI HDD | SCHD = SCSI HDD | SCRM = Removable | SCMO = Magneto-"
+#~ "Types: SCHD = SCSI HDD | SCRM = Removable | SCMO = Magneto-"
 #~ "Optical | SCCD = CD-ROM | SCBR = Host Bridge | SCDP = DaynaPORT"
 #~ msgstr ""
-#~ "Tipos: SAHD = SASI HDD | SCHD = SCSI HDD | SCRM = extraíble | SCMO = magneto-"
+#~ "Tipos: SCHD = SCSI HDD | SCRM = extraíble | SCMO = magneto-"
 #~ "optico | SCCD = CD-ROM | SCBR = Host Bridge | SCDP = DaynaPORT"
 
 #~ msgid "Attach Ethernet Adapter"

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -134,7 +134,6 @@ def index():
     formatted_devices = sort_and_format_devices(devices["device_list"])
 
     valid_image_suffixes = "." + ", .".join(
-        server_info["sahd"] +
         server_info["schd"] +
         server_info["scrm"] +
         server_info["scmo"] +


### PR DESCRIPTION
Fix for `server_info["sahd"]` causing KeyError exception when accessing the web UI.

Removed other references to SAHD.

@rdmark If you search for (case-insensitive) 'SASI' there seems to be some translations which mention it. I think these need cleaning up, but I'm not entirely sure how to test those changes?