### PR TITLE
Rename the Host Bridge INQUIRY product to RASCSI BRIDGE

### DIFF
--- a/src/raspberrypi/devices/device_factory.cpp
+++ b/src/raspberrypi/devices/device_factory.cpp
@@ -202,7 +202,7 @@ PrimaryDevice *DeviceFactory::CreateDevice(PbDeviceType type, const string& file
 
 	case SCBR:
 		device = make_unique<SCSIBR>();
-		device->SetProduct("SCSI HOST BRIDGE");
+		device->SetProduct("RASCSI BRIDGE");
 		device->SupportsParams(true);
 		device->SetDefaultParams(default_params[SCBR]);
 		break;

--- a/src/raspberrypi/test/device_factory_test.cpp
+++ b/src/raspberrypi/test/device_factory_test.cpp
@@ -235,7 +235,7 @@ TEST(DeviceFactoryTest, SCBR_Device_Defaults)
 	EXPECT_FALSE(device->IsStopped());
 
 	EXPECT_EQ("RaSCSI", device->GetVendor());
-	EXPECT_EQ("SCSI HOST BRIDGE", device->GetProduct());
+	EXPECT_EQ("RASCSI BRIDGE", device->GetProduct());
 	EXPECT_EQ(string(rascsi_get_version_string()).substr(0, 2) + string(rascsi_get_version_string()).substr(3, 2),
 			device->GetRevision());
 


### PR DESCRIPTION
The Human OS RASETHER.SYS driver expects the Host Bridge to have the product name of RASCSI BRIDGE.