### PR TITLE
Fix corruption in manpage; remove sasidump references

### DIFF
--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -106,6 +106,6 @@ In case the fallocate command is available a much faster alternative to the dd c
    fallocate -l 104857600 /path/to/newimage.hda
 
 .SH SEE ALSO
-rasctl(1), scsimon(1), rasdump(1), sasidump(1)
+rasctl(1), scsimon(1), rasdump(1)
  
 Full documentation is available at: <https://www.github.com/akuker/RASCSI/wiki/>

--- a/doc/rascsi.1
+++ b/doc/rascsi.1
@@ -3,13 +3,13 @@
 rascsi \- Emulates SCSI devices using the Raspberry Pi GPIO pins
 .SH SYNOPSIS
 .B rascsi
-[\fB\-F\f® \fIFOLDER\fR]
-[\fB\-L\f® \fILOG_LEVEL\fR]
-[\fB\-P\f® \fIACCESS_TOKEN_FILE\fR]
+[\fB\-F\fR \fIFOLDER\fR]
+[\fB\-L\fR \fILOG_LEVEL\fR]
+[\fB\-P\fR \fIACCESS_TOKEN_FILE\fR]
 [\fB\-R\fR \fISCAN_DEPTH\fR]
 [\fB\-h\fR]
 [\fB\-n\fR \fIVENDOR:PRODUCT:REVISION\fR]
-[\fB\-p\f® \fIPORT\fR]
+[\fB\-p\fR \fIPORT\fR]
 [\fB\-r\fR \fIRESERVED_IDS\fR]
 [\fB\-n\fR \fITYPE\fR]
 [\fB\-v\fR]

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -108,7 +108,7 @@ EXAMPLES
           fallocate -l 104857600 /path/to/newimage.hda
 
 SEE ALSO
-       rasctl(1), scsimon(1), rasdump(1), sasidump(1)
+       rasctl(1), scsimon(1), rasdump(1)
 
        Full documentation is available at: <https://www.github.com/akuker/RASCSI/wiki/>
 

--- a/doc/rascsi_man_page.txt
+++ b/doc/rascsi_man_page.txt
@@ -8,8 +8,8 @@ NAME
        rascsi - Emulates SCSI devices using the Raspberry Pi GPIO pins
 
 SYNOPSIS
-       rascsi [-F[u00AE] FOLDER] [-L[u00AE] LOG_LEVEL] [-P[u00AE] ACCESS_TOKEN_FILE] [-R SCAN_DEPTH] [-h] [-n VENDOR:PRODUCT:REVI‐
-       SION] [-p[u00AE] PORT] [-r RESERVED_IDS] [-n TYPE] [-v] [-z LOCALE] [-IDn:[u] FILE] [-HDn[:u] FILE]...
+       rascsi  [-F  FOLDER]  [-L LOG_LEVEL] [-P ACCESS_TOKEN_FILE] [-R SCAN_DEPTH] [-h] [-n VENDOR:PRODUCT:REVISION] [-p PORT] [-r
+       RESERVED_IDS] [-n TYPE] [-v] [-z LOCALE] [-IDn:[u] FILE] [-HDn[:u] FILE]...
 
 DESCRIPTION
        rascsi emulates SCSI devices using the Raspberry Pi GPIO pins.

--- a/doc/rasctl.1
+++ b/doc/rasctl.1
@@ -174,6 +174,6 @@ Request the RaSCSI process to attach a disk (assumed) to SCSI ID 0 with the cont
    rasctl -i 0 -f HDIIMAGE0.HDS
 
 .SH SEE ALSO
-rascsi(1), scsimon(1), rasdump(1), sasidump(1)
+rascsi(1), scsimon(1), rasdump(1)
 
 Full documentation is available at: <https://www.github.com/akuker/RASCSI/wiki/>

--- a/doc/rasctl_man_page.txt
+++ b/doc/rasctl_man_page.txt
@@ -143,7 +143,7 @@ EXAMPLES
           rasctl -i 0 -f HDIIMAGE0.HDS
 
 SEE ALSO
-       rascsi(1), scsimon(1), rasdump(1), sasidump(1)
+       rascsi(1), scsimon(1), rasdump(1)
 
        Full documentation is available at: <https://www.github.com/akuker/RASCSI/wiki/>
 

--- a/doc/scsimon.1
+++ b/doc/scsimon.1
@@ -22,6 +22,6 @@ Launch scsimon to capture all SCSI traffic available to the RaSCSI hardware:
    scsimon
 
 .SH SEE ALSO
-rasctl(1), rascsi(1), rasdump(1), sasidump(1)
+rasctl(1), rascsi(1), rasdump(1)
  
 Full documentation is available at: <https://www.github.com/akuker/RASCSI/wiki/>

--- a/doc/scsimon_man_page.txt
+++ b/doc/scsimon_man_page.txt
@@ -29,7 +29,7 @@ EXAMPLES
           scsimon
 
 SEE ALSO
-       rasctl(1), rascsi(1), rasdump(1), sasidump(1)
+       rasctl(1), rascsi(1), rasdump(1)
 
        Full documentation is available at: <https://www.github.com/akuker/RASCSI/wiki/>
 


### PR DESCRIPTION
An unexpected ® symbol in rascsi.1

Seems to have been introduced with https://github.com/akuker/RASCSI/commit/eeef537bc082b1a2c1e75633e08098196abdcdee