### PR TITLE
Remove redundant help text, table columns and parameters from the Web UI

### DIFF
--- a/python/web/src/templates/drives.html
+++ b/python/web/src/templates/drives.html
@@ -27,8 +27,6 @@
     <td>
     <form action="/drive/create" method="post">
         <input type="hidden" name="drive_name" value="{{ hd.name }}">
-        <label for="size_{{ hd.name }}">{{ _("Size:") }}</label>
-        <input type="number" name="size" id="size_{{ hd.name }}" min="512" max="274877906944" step="512" value="{{ hd.size }}">{{ _("B") }}
         <label for="file_name_{{ hd.name }}">{{ _("Save as:") }}</label>
         <input type="text" name="file_name" id="file_name_{{ hd.name }}" value="{{ hd.secure_name }}" required />.{{ hd.file_type }}
     <input type="submit" value="{{ _("Create") }}" />
@@ -104,8 +102,6 @@
     <td>
     <form action="/drive/create" method="post">
         <input type="hidden" name="drive_name" value="{{ rm.name }}">
-        <label for="size_{{ rm.name }}">{{ _("Size:") }}</label>
-        <input type="number" name="size" id="size_{{ rm.name }}" min="512" max="274877906944" step="512" value="{{ rm.size }}">{{ _("B") }}
         <label for="file_name_{{ rm.name }}">{{ _("Save as:") }}</label>
         <input type="text" name="file_name" id="file_name_{{ rm.name }}" value="{{ rm.secure_name }}" required />.{{ rm.file_type }}
         <input type="submit" value="{{ _("Create") }}" />

--- a/python/web/src/templates/drives.html
+++ b/python/web/src/templates/drives.html
@@ -47,7 +47,6 @@
 <tbody>
 <tr>
     <th scope="col">{{ _("Name") }}</th>
-    <th scope="col">{{ _("Size (MiB)") }}</th>
     <th scope="col">{{ _("Description") }}</th>
     <th scope="col">{{ _("Action") }}</th>
 </tr>
@@ -60,7 +59,6 @@
         {{ cd.name }}
         {% endif %}
     </td>
-    <td align="center">{{ cd.size_mb }}</td>
     <td>{{ cd.description }}</td>
     <td>
     <form action="/drive/cdrom" method="post">

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -340,9 +340,7 @@
         {{ _("Attach Peripheral Device") }}
     </summary>
     <ul>
-        <li>{{ _("Before using a networking device, it is recommended to run easyinstall.sh from the command line to configure your Raspberry Pi.") }}
         </li>
-        <ul>
         {% if bridge_configured %}
         <li>{{ _("The <tt>rascsi_bridge</tt> network bridge is active and ready to be used by an emulated network adapter!") }}</li>
         {% else %}
@@ -350,7 +348,6 @@
         {% endif %}
         <li>{{ _("To browse the modern web, install a vintage web proxy such as <a href=\"%(url)s\" target=\"_blank\">Macproxy</a>.", url="https://github.com/akuker/RASCSI/wiki/Vintage-Web-Proxy#macproxy") }}</li>
         </li>
-        </ul>
         <li>{{ _("Read more about <a href=\"%(url)s\" target=\"_blank\">supported device types</a> on the wiki.", url="https://github.com/akuker/RASCSI/wiki/Supported-Device-Types") }}
         </li>
     </ul>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -348,7 +348,6 @@
         {% else %}
         <li>{{ _("Please configure the <tt>rascsi_bridge</tt> network bridge before attaching an emulated network adapter!") }}</li>
         {% endif %}
-        <li>{{ _("If you have a DHCP setup, choose only the interface you have configured the bridge with. You can ignore the inet field when attaching.") }}</li>
         <li>{{ _("To browse the modern web, install a vintage web proxy such as <a href=\"%(url)s\" target=\"_blank\">Macproxy</a>.", url="https://github.com/akuker/RASCSI/wiki/Vintage-Web-Proxy#macproxy") }}</li>
         </li>
         </ul>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -673,7 +673,6 @@
         {{ _("Raspberry Pi Operations") }}
     </summary>
     <ul>
-        <li>{{ _("Reboot or shut down the Raspberry Pi that RaSCSI is running on.") }}</li>
         <li>{{ _("IMPORTANT: Always shut down the Pi before turning off the power. Failing to do so may lead to data loss.") }}</li>
     </ul>
 </details>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -6,7 +6,6 @@
         {{ _("Current RaSCSI Configuration") }}
     </summary>
     <ul>
-        <li>{{ _("Displays the currently attached devices for each available SCSI ID.") }}</li>
         <li>{{ _("Save and load device configurations, stored as json files in <tt>%(config_dir)s</tt>", config_dir=CFG_DIR) }}</li>
         <li>{{ _("To have a particular device configuration load when RaSCSI starts, save it as <em>default</em>.") }}</li>
     </ul>
@@ -175,7 +174,6 @@
         <li>{{ _("Manage image files in the active RaSCSI image directory: <tt>%(directory)s</tt> with a scan depth of %(scan_depth)s.", directory=env["image_dir"], scan_depth=scan_depth) }}</li>
         <li>{{ _("Select a valid SCSI ID and <a href=\"%(url)s\" target=\"_blank\">LUN</a> to attach to. Unless you know what you're doing, always use LUN 0.", url="https://en.wikipedia.org/wiki/Logical_unit_number") }}
         </li>
-        <li>{{ _("If RaSCSI was unable to detect the media type associated with the image, you get to choose the type from the dropdown.") }}</li>
         <li>
             {{ _("Recognized image file types:") }}
             {% set comma = joiner(", ") %}
@@ -495,7 +493,6 @@
         {{ _("Download File from the Web") }}
     </summary>
     <ul>
-        <li>{{ _("Choose the desination directory and download a file from the Web to your Raspberry Pi.") }}</li>
         <li>{{ _("Install <a href=\"%(url)s\" target=\"_blank\">Netatalk</a> to use the AFP File Server.", url="https://github.com/akuker/RASCSI/wiki/AFP-File-Sharing") }}</li>
     </ul>
 </details>
@@ -597,17 +594,6 @@
     <input type="submit" value="{{ _("Create") }}">
 </form>
 
-<hr/>
-
-<details>
-    <summary class="heading">
-        {{ _("Create Named Drive") }}
-    </summary>
-    <ul>
-        <li>{{ _("Create pairs of images and properties files from a list of real-life drives.") }}</li>
-        <li>{{ _("This will make RaSCSI use certain vendor strings and block sizes that may improve compatibility with certain systems.") }}</li>
-    </ul>
-</details>
 <p><a href="/drive/list">{{ _("Create a named disk image that mimics real-life drives") }}</a></p>
 
 <hr/>
@@ -617,10 +603,11 @@
         {{ _("Logging") }}
     </summary>
     <ul>
-        <li>{{ _("Fetch a certain number of lines of system logs with the given scope.") }}</li>
+        <li>{{ _("The current dropdown selection indicates the active log level.") }}</li>
     </ul>
 </details>
 
+<div>
 <form action="/logs/show" method="post">
     <label for="log_lines">{{ _("Log Lines:") }}</label>
     <input name="lines" id="log_lines" type="number" value="200" min="0" max="99999" step="100">
@@ -644,19 +631,9 @@
     </select>
     <input type="submit" value="{{ _("Show Logs") }}">
 </form>
+</div>
 
-<hr/>
-
-<details>
-    <summary class="heading">
-        {{ _("Server Log Level") }}
-    </summary>
-    <ul>
-        <li>{{ _("Change the log level of the RaSCSI backend process.") }}</li>
-        <li>{{ _("The current dropdown selection indicates the active log level.") }}</li>
-    </ul>
-</details>
-
+<div>
 <form action="/logs/level" method="post">
     <label for="log_level">{{ _("Log Level:") }}</label>
     <select name="level" id="log_level">
@@ -668,6 +645,7 @@
     </select>
     <input type="submit" value="{{ _("Set Log Level") }}">
 </form>
+</div>
 
 <hr/>
 

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -358,7 +358,6 @@ def drive_create():
     Creates the image and properties file pair
     """
     drive_name = request.form.get("drive_name")
-    size = request.form.get("size")
     file_name = request.form.get("file_name")
 
     properties = get_properties_by_drive_name(
@@ -367,7 +366,11 @@ def drive_create():
         )
 
     # Creating the image file
-    process = file_cmd.create_new_image(file_name, properties["file_type"], size)
+    process = file_cmd.create_new_image(
+        file_name,
+        properties["file_type"],
+        properties["size"],
+        )
     if not process["status"]:
         return response(error=True, message=process["msg"])
 

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -217,6 +217,7 @@ def get_properties_by_drive_name(drives, drive_name):
         "product": drive_props["product"],
         "revision": drive_props["revision"],
         "block_size": drive_props["block_size"],
+        "size": drive_props["size"],
         }
 
 def auth_active(group):


### PR DESCRIPTION
- Remove the Size option from the Drives page, since we offer custom sizes with Drive profiles now in the Create Image form
- Fetch size from drive props data structure rather than the web form
- Remove a range of redundant / obvious help text to reduce UI clutter and emphasize the important help text
- Remove the Size column from the CD-ROM drives table since it's always N/A
- Merge the two Logging related sections, and the two Create Image related sections (semantically associated)