### PR TITLE
Fix logging for Data Out phase, fixed offset

### DIFF
--- a/src/raspberrypi/controllers/scsi_controller.cpp
+++ b/src/raspberrypi/controllers/scsi_controller.cpp
@@ -776,6 +776,16 @@ void ScsiController::DataOutNonBlockOriented()
 	assert(IsDataOut());
 
 	switch (GetOpcode()) {
+		// TODO Check why these cases are needed
+		case scsi_command::eCmdWrite6:
+		case scsi_command::eCmdWrite10:
+		case scsi_command::eCmdWrite16:
+		case scsi_command::eCmdWriteLong10:
+		case scsi_command::eCmdWriteLong16:
+		case scsi_command::eCmdVerify10:
+		case scsi_command::eCmdVerify16:
+			break;
+
 		case scsi_command::eCmdModeSelect6:
 		case scsi_command::eCmdModeSelect10: {
 				// TODO Try to get rid of this cast

--- a/src/raspberrypi/devices/host_services.cpp
+++ b/src/raspberrypi/devices/host_services.cpp
@@ -36,6 +36,9 @@ HostServices::HostServices(int lun, const ControllerManager& manager)
 {
 	dispatcher.Add(scsi_command::eCmdTestUnitReady, "TestUnitReady", &HostServices::TestUnitReady);
 	dispatcher.Add(scsi_command::eCmdStartStop, "StartStopUnit", &HostServices::StartStopUnit);
+
+	SetReady(true);
+	SetReset(false);
 }
 
 bool HostServices::Dispatch(scsi_command cmd)

--- a/src/raspberrypi/devices/scsi_daynaport.cpp
+++ b/src/raspberrypi/devices/scsi_daynaport.cpp
@@ -358,7 +358,7 @@ void SCSIDaynaPort::Write6()
 		ctrl->length = GetInt16(ctrl->cmd, 3);
 	}
 	else if (data_format == 0x80) {
-		ctrl->length = GetInt16(ctrl->cmd, 3 + 8);
+		ctrl->length = GetInt16(ctrl->cmd, 3) + 8;
 	}
 	else {
 		LOGWARN("%s Unknown data format $%02X", __PRETTY_FUNCTION__, data_format)
@@ -366,7 +366,7 @@ void SCSIDaynaPort::Write6()
 	LOGTRACE("%s length: $%04X (%d) format: $%02X", __PRETTY_FUNCTION__, ctrl->length, ctrl->length, data_format)
 
 	if (ctrl->length <= 0) {
-		throw scsi_exception();
+		throw scsi_exception(sense_key::ILLEGAL_REQUEST, asc::INVALID_FIELD_IN_CDB);
 	}
 
 	// Set next block

--- a/src/raspberrypi/devices/scsi_printer.cpp
+++ b/src/raspberrypi/devices/scsi_printer.cpp
@@ -60,6 +60,9 @@ SCSIPrinter::SCSIPrinter(int lun) : PrimaryDevice("SCLP", lun)
 	dispatcher.Add(scsi_command::eCmdSynchronizeBuffer, "SynchronizeBuffer", &SCSIPrinter::SynchronizeBuffer);
 	dispatcher.Add(scsi_command::eCmdSendDiag, "SendDiagnostic", &SCSIPrinter::SendDiagnostic);
 	dispatcher.Add(scsi_command::eCmdStartStop, "StopPrint", &SCSIPrinter::StopPrint);
+
+	SetReady(true);
+	SetReset(false);
 }
 
 SCSIPrinter::~SCSIPrinter()


### PR DESCRIPTION
This change reverts a previous change related to logging an unexpected Data Out phase. It's not clear why the re-added cases are needed, but for now (with this PR) the logging behavior is like it was before (i.e. with release 22.08.1 and older).
A wrong offset (caused by a typo) is also fixed.