### PR TITLE
Web UI: Change locale fallback message log level to 'info'

### DIFF
--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -150,7 +150,7 @@ def get_locale():
         language = session["language"]
     except KeyError:
         language = ""
-        logging.warning("The default locale could not be detected. Falling back to English.")
+        logging.info("The default locale could not be detected. Falling back to English.")
     if language:
         return language
     # Hardcoded fallback to "en" when the user agent does not send an accept-language header


### PR DESCRIPTION
The locale fallback log message is triggered for every integration test that's run. Let's change it to info, since it's not really a source of worry anyways. Not all user agents pass on locale information.