### PR TITLE
Web UI: More file path sanitation, better network bridge warnings, each endpoint return one message

### DIFF
--- a/python/common/src/rascsi/file_cmds.py
+++ b/python/common/src/rascsi/file_cmds.py
@@ -392,7 +392,7 @@ class FileCmds:
             else:
                 logging.info(
                     "%s is a zipfile! Will attempt to unzip and store the resulting files.",
-                    str(tmp_full_path),
+                    tmp_full_path,
                     )
                 unzip_proc = asyncio.run(self.run_async("unzip", [
                     "-d",
@@ -403,7 +403,7 @@ class FileCmds:
                 if not unzip_proc["returncode"]:
                     logging.info(
                         "%s was successfully unzipped. Deleting the zipfile.",
-                        str(tmp_full_path),
+                        tmp_full_path,
                         )
                     tmp_full_path.unlink(True)
 

--- a/python/common/src/rascsi/file_cmds.py
+++ b/python/common/src/rascsi/file_cmds.py
@@ -2,9 +2,9 @@
 Module for methods reading from and writing to the file system
 """
 
-import os
 import logging
 import asyncio
+from os import path, walk
 from functools import lru_cache
 from pathlib import PurePath, Path
 from zipfile import ZipFile, is_zipfile
@@ -54,14 +54,14 @@ class FileCmds:
         index 0 is (str) file name and index 1 is (int) size in bytes
         """
         files_list = []
-        for path, _dirs, files in os.walk(dir_path):
+        for file_path, _dirs, files in walk(dir_path):
             # Only list selected file types
             files = [f for f in files if f.lower().endswith(file_types)]
             files_list.extend(
                 [
                     (
                         file,
-                        os.path.getsize(os.path.join(path, file))
+                        path.getsize(path.join(file_path, file))
                     )
                     for file in files
                 ]
@@ -75,7 +75,7 @@ class FileCmds:
         Returns a (list) of (str) files_list
         """
         files_list = []
-        for _root, _dirs, files in os.walk(CFG_DIR):
+        for _root, _dirs, files in walk(CFG_DIR):
             for file in files:
                 if file.endswith("." + CONFIG_FILE_SUFFIX):
                     files_list.append(file)

--- a/python/common/src/rascsi/file_cmds.py
+++ b/python/common/src/rascsi/file_cmds.py
@@ -430,7 +430,7 @@ class FileCmds:
             "status": True,
             "return_code": ReturnCodes.DOWNLOADFILETOISO_SUCCESS,
             "parameters": parameters,
-            "file_name": str(iso_filename),
+            "file_name": iso_filename.name,
         }
 
     # noinspection PyMethodMayBeStatic

--- a/python/common/src/rascsi/file_cmds.py
+++ b/python/common/src/rascsi/file_cmds.py
@@ -376,10 +376,10 @@ class FileCmds:
 
         file_name = PurePath(url).name
         tmp_ts = int(time())
-        tmp_dir = "/tmp/" + str(tmp_ts) + "/"
+        tmp_dir = Path("/tmp") / str(tmp_ts)
         os.mkdir(tmp_dir)
-        tmp_full_path = tmp_dir + file_name
-        iso_filename = f"{server_info['image_dir']}/{file_name}.iso"
+        tmp_full_path = tmp_dir / file_name
+        iso_filename = Path(server_info['image_dir']) / f"{file_name}.iso"
 
         req_proc = self.download_to_dir(quote(url, safe=URL_SAFE), tmp_dir, file_name)
 
@@ -387,25 +387,25 @@ class FileCmds:
             return {"status": False, "msg": req_proc["msg"]}
 
         if is_zipfile(tmp_full_path):
-            if "XtraStuf.mac" in str(ZipFile(tmp_full_path).namelist()):
+            if "XtraStuf.mac" in str(ZipFile(str(tmp_full_path)).namelist()):
                 logging.info("MacZip file format detected. Will not unzip to retain resource fork.")
             else:
                 logging.info(
                     "%s is a zipfile! Will attempt to unzip and store the resulting files.",
-                    tmp_full_path,
+                    str(tmp_full_path),
                     )
                 unzip_proc = asyncio.run(self.run_async("unzip", [
                     "-d",
-                    tmp_dir,
+                    str(tmp_dir),
                     "-n",
-                    tmp_full_path,
+                    str(tmp_full_path),
                     ]))
                 if not unzip_proc["returncode"]:
                     logging.info(
                         "%s was successfully unzipped. Deleting the zipfile.",
-                        tmp_full_path,
+                        str(tmp_full_path),
                         )
-                    self.delete_file(Path(tmp_full_path))
+                    self.delete_file(tmp_full_path)
 
         try:
             run(
@@ -413,8 +413,8 @@ class FileCmds:
                     "genisoimage",
                     *iso_args,
                     "-o",
-                    iso_filename,
-                    tmp_dir,
+                    str(iso_filename),
+                    str(tmp_dir),
                 ],
                 capture_output=True,
                 check=True,
@@ -430,7 +430,7 @@ class FileCmds:
             "status": True,
             "return_code": ReturnCodes.DOWNLOADFILETOISO_SUCCESS,
             "parameters": parameters,
-            "file_name": iso_filename,
+            "file_name": str(iso_filename),
         }
 
     # noinspection PyMethodMayBeStatic

--- a/python/common/src/rascsi/file_cmds.py
+++ b/python/common/src/rascsi/file_cmds.py
@@ -377,7 +377,7 @@ class FileCmds:
         file_name = PurePath(url).name
         tmp_ts = int(time())
         tmp_dir = Path("/tmp") / str(tmp_ts)
-        os.mkdir(tmp_dir)
+        tmp_dir.mkdir()
         tmp_full_path = tmp_dir / file_name
         iso_filename = Path(server_info['image_dir']) / f"{file_name}.iso"
 
@@ -405,7 +405,7 @@ class FileCmds:
                         "%s was successfully unzipped. Deleting the zipfile.",
                         str(tmp_full_path),
                         )
-                    self.delete_file(tmp_full_path)
+                    tmp_full_path.unlink(True)
 
         try:
             run(

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -35,7 +35,7 @@
 <p>
 <form action="/config/save" method="post">
     <label for="config_save_name">{{ _("File name") }}</label>
-    <input name="name" id="config_save_name" placeholder="default" size="20">
+    <input name="name" id="config_save_name" value="default" size="20">
     .{{ CONFIG_FILE_SUFFIX }}
     <input type="submit" value="{{ _("Save") }}">
 </form>

--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -522,22 +522,22 @@
     <input name="url" id="iso_url" required="" type="url">
     <label for="iso_type">{{ _("Type:") }}</label>
     <select name="type" id="iso_type">
-        <option value="-hfs">
+        <option value="HFS">
             HFS
         </option>
-        <option value="-iso-level 1">
+        <option value="ISO-9660 Level 1">
             ISO-9660 Level 1
         </option>
-        <option value="-iso-level 2">
+        <option value="ISO-9660 Level 2">
             ISO-9660 Level 2
         </option>
-        <option value="-iso-level 3">
+        <option value="ISO-9660 Level 3">
             ISO-9660 Level 3
         </option>
-        <option value="-J">
+        <option value="Joliet">
             Joliet
         </option>
-        <option value="-r">
+        <option value="Rock Ridge">
             Rock Ridge
         </option>
     </select>

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -794,7 +794,25 @@ def download_to_iso():
     """
     scsi_id = request.form.get("scsi_id")
     url = request.form.get("url")
-    iso_args = request.form.get("type").split()
+    iso_type = request.form.get("type")
+
+    if iso_type == "HFS":
+        iso_args = ["-hfs"]
+    elif iso_type == "ISO-9660 Level 1":
+        iso_args = ["-iso-level", "1"]
+    elif iso_type == "ISO-9660 Level 2":
+        iso_args = ["-iso-level", "2"]
+    elif iso_type == "ISO-9660 Level 3":
+        iso_args = ["-iso-level", "3"]
+    elif iso_type == "Joliet":
+        iso_args = ["-J"]
+    elif iso_type == "Rock Ridge":
+        iso_args = ["-r"]
+    else:
+        return response(
+            error=True,
+            message=_("%(iso_type)s is not a valid CD-ROM format.", iso_type=iso_type)
+        )
 
     process = file_cmd.download_file_to_iso(url, *iso_args)
     process = ReturnCodeMapper.add_msg(process)
@@ -816,10 +834,10 @@ def download_to_iso():
     if process_attach["status"]:
         return response(
             message=_(
-                "CD-ROM image %(file_name)s created with argument \"%(args)s\" "
+                "CD-ROM image %(file_name)s with type %(iso_type)s was created "
                 "and attached to SCSI ID %(id_number)s",
                 file_name=process["file_name"],
-                args=" ".join(iso_args),
+                iso_type=iso_type,
                 id_number=scsi_id,
             ),
         )
@@ -827,8 +845,10 @@ def download_to_iso():
     return response(
         error=True,
         message=_(
-            "CD-ROM image %(file_name)s was created, but could not be attached: %(error)s",
+            "CD-ROM image %(file_name)s with type %(iso_type)s was created "
+            "but could not be attached: %(error)s",
             file_name=process["file_name"],
+            iso_type=iso_type,
             error=process_attach["msg"],
         ),
     )

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -336,7 +336,7 @@ def drive_create():
     Creates the image and properties file pair
     """
     drive_name = request.form.get("drive_name")
-    file_name = request.form.get("file_name")
+    file_name = Path(request.form.get("file_name")).name
 
     properties = get_properties_by_drive_name(
         APP.config["RASCSI_DRIVE_PROPERTIES"],
@@ -374,7 +374,7 @@ def drive_cdrom():
     Creates a properties file for a CD-ROM image
     """
     drive_name = request.form.get("drive_name")
-    file_name = request.form.get("file_name")
+    file_name = Path(request.form.get("file_name")).name
 
     # Creating the drive properties file
     file_name = f"{file_name}.{PROPERTIES_SUFFIX}"
@@ -396,8 +396,7 @@ def config_save():
     """
     Saves a config file to disk
     """
-    file_name = request.form.get("name") or "default"
-    file_name = f"{file_name}.{CONFIG_FILE_SUFFIX}"
+    file_name = Path(request.form.get("name") + f".{CONFIG_FILE_SUFFIX}").name
 
     process = file_cmd.write_config(file_name)
     process = ReturnCodeMapper.add_msg(process)
@@ -413,7 +412,7 @@ def config_load():
     """
     Loads a config file from disk
     """
-    file_name = request.form.get("name")
+    file_name = Path(request.form.get("name")).name
 
     if "load" in request.form:
         process = file_cmd.read_config(file_name)

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -579,17 +579,10 @@ def attach_device():
             if param:
                 params.update({item.replace(PARAM_PREFIX, ""): param})
 
-    error_url = "https://github.com/akuker/RASCSI/wiki/Dayna-Port-SCSI-Link"
-    error_msg = _("Please follow the instructions at %(url)s", url=error_url)
-
     if "interface" in params.keys():
         bridge_status = is_bridge_configured(params["interface"])
         if not bridge_status["status"]:
-            # TODO: Refactor the return messages into one string
-            return response(error=True, message=[
-                (bridge_status["msg"], "error"),
-                (error_msg, "error")
-            ])
+            return response(error=True, message=bridge_status["msg"])
 
     kwargs = {
             "unit": int(unit),

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -790,7 +790,7 @@ def shutdown():
 @login_required
 def download_to_iso():
     """
-    Downloads a file and creates a CD-ROM image with the specified file system and he file
+    Downloads a file and creates a CD-ROM image with the specified file system and the file
     """
     scsi_id = request.form.get("scsi_id")
     url = request.form.get("url")

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -1082,9 +1082,9 @@ def extract_image():
         for properties_file in extract_result["properties_files_moved"]:
             if properties_file["status"]:
                 logging.info(
-                        "Properties file %(file_name)s moved to %(directory)s",
-                        file_name=properties_file["name"],
-                        directory=CFG_DIR,
+                        "Properties file %s moved to %s",
+                        properties_file["name"],
+                        CFG_DIR,
                         )
             else:
                 logging.warning(

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -911,7 +911,7 @@ def create_file():
     if file_name.is_absolute() or ".." in str(file_name):
         file_name = file_name.name
 
-    full_file_name = f"{str(file_name)}.{file_type}"
+    full_file_name = f"{file_name}.{file_type}"
     process = file_cmd.create_new_image(str(file_name), file_type, size)
     if not process["status"]:
         return response(error=True, message=process["msg"])
@@ -970,7 +970,7 @@ def delete():
         (_("Image file deleted: %(file_name)s", file_name=str(file_name)), "success")]
 
     # Delete the drive properties file, if it exists
-    prop_file_path = Path(CFG_DIR) / f"{str(file_name)}.{PROPERTIES_SUFFIX}"
+    prop_file_path = Path(CFG_DIR) / f"{file_name}.{PROPERTIES_SUFFIX}"
     if prop_file_path.is_file():
         process = file_cmd.delete_file(prop_file_path)
         process = ReturnCodeMapper.add_msg(process)
@@ -1003,8 +1003,8 @@ def rename():
         (_("Image file renamed to: %(file_name)s", file_name=str(new_file_name)), "success")]
 
     # Rename the drive properties file, if it exists
-    prop_file_path = Path(CFG_DIR) / f"{str(file_name)}.{PROPERTIES_SUFFIX}"
-    new_prop_file_path = Path(CFG_DIR) / f"{str(new_file_name)}.{PROPERTIES_SUFFIX}"
+    prop_file_path = Path(CFG_DIR) / f"{file_name}.{PROPERTIES_SUFFIX}"
+    new_prop_file_path = Path(CFG_DIR) / f"{new_file_name}.{PROPERTIES_SUFFIX}"
     if prop_file_path.is_file():
         process = file_cmd.rename_file(prop_file_path, new_prop_file_path)
         process = ReturnCodeMapper.add_msg(process)
@@ -1037,8 +1037,8 @@ def copy():
         (_("Copy of image file saved as: %(file_name)s", file_name=str(new_file_name)), "success")]
 
     # Create a copy of the drive properties file, if it exists
-    prop_file_path = Path(CFG_DIR) / f"{str(file_name)}.{PROPERTIES_SUFFIX}"
-    new_prop_file_path = Path(CFG_DIR) / f"{str(new_file_name)}.{PROPERTIES_SUFFIX}"
+    prop_file_path = Path(CFG_DIR) / f"{file_name}.{PROPERTIES_SUFFIX}"
+    new_prop_file_path = Path(CFG_DIR) / f"{new_file_name}.{PROPERTIES_SUFFIX}"
     if prop_file_path.is_file():
         process = file_cmd.copy_file(prop_file_path, new_prop_file_path)
         process = ReturnCodeMapper.add_msg(process)

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -816,8 +816,10 @@ def download_to_iso():
     if process_attach["status"]:
         return response(
             message=_(
-                "CD-ROM image %(file_name)s created and attached to SCSI ID %(id_number)s",
+                "CD-ROM image %(file_name)s created with argument \"%(args)s\" "
+                "and attached to SCSI ID %(id_number)s",
                 file_name=process["file_name"],
+                args=" ".join(iso_args),
                 id_number=scsi_id,
             ),
         )
@@ -915,12 +917,14 @@ def create_file():
             message=_(
                 "Image file with properties created: %(file_name)s",
                 file_name=full_file_name,
-            )
+            ),
+            image=full_file_name,
         )
 
     return response(
         status_code=201,
-        message=_("Image file created: %(file_name)s", file_name=full_file_name)
+        message=_("Image file created: %(file_name)s", file_name=full_file_name),
+        image=full_file_name,
     )
 
 

--- a/python/web/src/web_utils.py
+++ b/python/web/src/web_utils.py
@@ -264,6 +264,21 @@ def is_bridge_configured(interface):
     return {"status": True, "msg": ""}
 
 
+def is_safe_path(file_name):
+    """
+    Takes (Path) file_name with the path to a file on the file system
+    Returns True if the path is safe
+    Returns False if the path is either absolute, or tries to traverse the file system
+    """
+    if file_name.is_absolute() or ".." in str(file_name):
+        return {
+            "status": False,
+            "msg": _("%(file_name)s is not a valid path", file_name=file_name),
+        }
+
+    return {"status": True, "msg": ""}
+
+
 def upload_with_dropzonejs(image_dir):
     """
     Takes (str) image_dir which is the path to the image dir to store files.

--- a/python/web/tests/api/test_files.py
+++ b/python/web/tests/api/test_files.py
@@ -24,7 +24,6 @@ def test_create_file(http_client, list_files, delete_file):
     )
 
     response_data = response.json()
-    print(str(response_data))
 
     assert response.status_code == 201
     assert response_data["status"] == STATUS_SUCCESS
@@ -52,7 +51,6 @@ def test_create_file_with_properties(http_client, list_files, delete_file):
     )
 
     response_data = response.json()
-    print(str(response_data))
 
     assert response.status_code == 201
     assert response_data["status"] == STATUS_SUCCESS

--- a/python/web/tests/api/test_files.py
+++ b/python/web/tests/api/test_files.py
@@ -20,16 +20,45 @@ def test_create_file(http_client, list_files, delete_file):
             "file_name": file_prefix,
             "type": "hds",
             "size": 1,
-            "drive_name": "DEC RZ22",
         },
     )
 
     response_data = response.json()
+    print(str(response_data))
 
     assert response.status_code == 201
     assert response_data["status"] == STATUS_SUCCESS
     assert response_data["data"]["image"] == file_name
     assert response_data["messages"][0]["message"] == f"Image file created: {file_name}"
+    assert file_name in list_files()
+
+    # Cleanup
+    delete_file(file_name)
+
+
+# route("/files/create", methods=["POST"])
+def test_create_file_with_properties(http_client, list_files, delete_file):
+    file_prefix = str(uuid.uuid4())
+    file_name = f"{file_prefix}.hds"
+
+    response = http_client.post(
+        "/files/create",
+        data={
+            "file_name": file_prefix,
+            "type": "hds",
+            "size": 1,
+            "drive_name": "DEC RZ22",
+        },
+    )
+
+    response_data = response.json()
+    print(str(response_data))
+
+    assert response.status_code == 201
+    assert response_data["status"] == STATUS_SUCCESS
+    assert response_data["data"]["image"] == file_name
+    assert response_data["messages"][0]["message"] == \
+            f"Image file with properties created: {file_name}"
     assert file_name in list_files()
 
     # Cleanup
@@ -258,6 +287,7 @@ def test_download_url_to_iso(
 
     http_path = f"/images/{test_file_name}"
     url = httpserver.url_for(http_path)
+    ISO_TYPE = "-hfs"
 
     with open("tests/assets/test_image.hds", mode="rb") as file:
         test_file_data = file.read()
@@ -271,7 +301,7 @@ def test_download_url_to_iso(
         "/files/download_to_iso",
         data={
             "scsi_id": SCSI_ID,
-            "type": "-hfs",
+            "type": ISO_TYPE,
             "url": url,
         },
     )
@@ -283,10 +313,11 @@ def test_download_url_to_iso(
     assert iso_file_name in list_files()
     assert iso_file_name in list_attached_images()
 
-    m = response_data["messages"]
-    assert m[0]["message"] == 'Created CD-ROM ISO image with arguments "-hfs"'
-    assert m[1]["message"] == f"Saved image as: {env['images_dir']}/{iso_file_name}"
-    assert m[2]["message"] == f"Attached to SCSI ID {SCSI_ID}"
+    assert (
+        response_data["messages"][0]["message"] == \
+            f"CD-ROM image {iso_file_name} created with argument \"{ISO_TYPE}\" "
+            f"and attached to SCSI ID {SCSI_ID}"
+    )
 
     # Cleanup
     detach_devices()

--- a/python/web/tests/api/test_files.py
+++ b/python/web/tests/api/test_files.py
@@ -55,8 +55,10 @@ def test_create_file_with_properties(http_client, list_files, delete_file):
     assert response.status_code == 201
     assert response_data["status"] == STATUS_SUCCESS
     assert response_data["data"]["image"] == file_name
-    assert response_data["messages"][0]["message"] == \
-            f"Image file with properties created: {file_name}"
+    assert (
+        response_data["messages"][0]["message"]
+        == f"Image file with properties created: {file_name}"
+    )
     assert file_name in list_files()
 
     # Cleanup
@@ -312,9 +314,9 @@ def test_download_url_to_iso(
     assert iso_file_name in list_attached_images()
 
     assert (
-        response_data["messages"][0]["message"] == \
-            f"CD-ROM image {iso_file_name} created with argument \"{ISO_TYPE}\" "
-            f"and attached to SCSI ID {SCSI_ID}"
+        response_data["messages"][0]["message"]
+        == f'CD-ROM image {iso_file_name} created with argument "{ISO_TYPE}" '
+        f"and attached to SCSI ID {SCSI_ID}"
     )
 
     # Cleanup

--- a/python/web/tests/api/test_files.py
+++ b/python/web/tests/api/test_files.py
@@ -287,7 +287,7 @@ def test_download_url_to_iso(
 
     http_path = f"/images/{test_file_name}"
     url = httpserver.url_for(http_path)
-    ISO_TYPE = "-hfs"
+    ISO_TYPE = "ISO-9660 Level 1"
 
     with open("tests/assets/test_image.hds", mode="rb") as file:
         test_file_data = file.read()
@@ -315,7 +315,7 @@ def test_download_url_to_iso(
 
     assert (
         response_data["messages"][0]["message"]
-        == f'CD-ROM image {iso_file_name} created with argument "{ISO_TYPE}" '
+        == f"CD-ROM image {iso_file_name} with type {ISO_TYPE} was created "
         f"and attached to SCSI ID {SCSI_ID}"
     )
 

--- a/python/web/tests/api/test_misc.py
+++ b/python/web/tests/api/test_misc.py
@@ -83,7 +83,8 @@ def test_create_image_with_properties_file(http_client, delete_file):
 
     assert response.status_code == 200
     assert response_data["status"] == STATUS_SUCCESS
-    assert response_data["messages"][0]["message"] == f"Image file created: {file_name}"
+    assert response_data["messages"][0]["message"] == \
+            f"Image file with properties created: {file_name}"
 
     # Cleanup
     delete_file(file_name)

--- a/python/web/tests/api/test_misc.py
+++ b/python/web/tests/api/test_misc.py
@@ -83,8 +83,10 @@ def test_create_image_with_properties_file(http_client, delete_file):
 
     assert response.status_code == 200
     assert response_data["status"] == STATUS_SUCCESS
-    assert response_data["messages"][0]["message"] == \
-            f"Image file with properties created: {file_name}"
+    assert (
+        response_data["messages"][0]["message"]
+        == f"Image file with properties created: {file_name}"
+    )
 
     # Cleanup
     delete_file(file_name)


### PR DESCRIPTION
- Sanitize file paths with Path: for flat file structures, always extract Path().name, and for nested file structures either look for absolute paths, or someone trying to use ".." to traverse the dir strucutre.
- Reduce redundancy in network bridge detection method, and return somewhat more informative messages
- Make all endpoints return exactly one message
- Move some warning messages to logging
- Use tempfile for iso generation temp file handling