### PR TITLE
Bump to the latest bjoern/Flask/Jinja2

### DIFF
--- a/python/web/requirements.txt
+++ b/python/web/requirements.txt
@@ -1,9 +1,6 @@
-bjoern==3.1.0
-click==7.1.2
-Flask==2.0.1
-itsdangerous==2.0.1
-Jinja2==3.0.1
-MarkupSafe==2.0.1
+bjoern==3.2.2
+Flask==2.2.2
+Jinja2==3.1.2
 protobuf==3.20.2
 requests==2.26.0
 simplepam==0.1.5


### PR DESCRIPTION
click/itsdangerous/MarkupSafe are implicit dependencies of the above so removing explicit requirements.