### PR TITLE
Restore rascsi help text for hda format; consistently use 'compatible' terminology

### DIFF
--- a/src/raspberrypi/devices/scsihd_nec.cpp
+++ b/src/raspberrypi/devices/scsihd_nec.cpp
@@ -10,7 +10,7 @@
 //	Licensed under the BSD 3-Clause License.
 //	See LICENSE file in the project root folder.
 //
-//	[ SCSI NEC "Genuine" Hard Disk]
+//	[ SCSI NEC Compatible Hard Disk]
 //
 //---------------------------------------------------------------------------
 
@@ -83,7 +83,7 @@ pair<int, int> SCSIHD_NEC::SetParameters(const string& extension, const array<BY
 	int image_size;
 	int sector_size;
 
-	// PC-9801-55 NEC genuine?
+	// PC-9801-55 NEC compatible?
 	if (ext == ".hdn") {
 		// Assuming sector size 512, number of sectors 25, number of heads 8 as default settings
 		image_offset = 0;

--- a/src/raspberrypi/devices/scsihd_nec.h
+++ b/src/raspberrypi/devices/scsihd_nec.h
@@ -10,7 +10,7 @@
 //  	Licensed under the BSD 3-Clause License.
 //  	See LICENSE file in the project root folder.
 //
-//  	[ SCSI NEC "Genuine" Hard Disk]
+//  	[ SCSI NEC Compatible Hard Disk]
 //
 //---------------------------------------------------------------------------
 
@@ -26,7 +26,7 @@ using namespace std;
 
 //===========================================================================
 //
-//	SCSI hard disk (PC-9801-55 NEC genuine / Anex86 / T98Next)
+//	SCSI hard disk (PC-9801-55 NEC compatible / Anex86 / T98Next)
 //
 //===========================================================================
 class SCSIHD_NEC : public SCSIHD //NOSONAR The inheritance hierarchy depth is acceptable in this case

--- a/src/raspberrypi/rascsi.cpp
+++ b/src/raspberrypi/rascsi.cpp
@@ -83,7 +83,8 @@ void Banner(int argc, char* argv[])
 		cout << "  hd1 : SCSI-1 HD image (Non-removable generic SCSI-1 HD image)\n";
 		cout << "  hds : SCSI HD image (Non-removable generic SCSI HD image)\n";
 		cout << "  hdr : SCSI HD image (Removable generic HD image)\n";
-		cout << "  hdn : SCSI HD image (NEC GENUINE)\n";
+		cout << "  hda : SCSI HD image (Apple compatible image)\n";
+		cout << "  hdn : SCSI HD image (NEC compatible image)\n";
 		cout << "  hdi : SCSI HD image (Anex86 HD image)\n";
 		cout << "  nhd : SCSI HD image (T98Next HD image)\n";
 		cout << "  mos : SCSI MO image (MO image)\n";


### PR DESCRIPTION
- The help text for hda fell off in https://github.com/akuker/RASCSI/pull/252 and was never added back after we restored this format
- We've changed "genuine" to "compatible" elsewhere, so making this the consistent terminology.