### PR TITLE
Added missing command mapping for DEVICES_INFO

### DIFF
--- a/cpp/rasctl/rasctl_parser.h
+++ b/cpp/rasctl/rasctl_parser.h
@@ -30,9 +30,10 @@ private:
 	unordered_map<int, PbOperation> operations = {
 			{ 'a', ATTACH },
 			{ 'd', DETACH },
-			{ 'i', INSERT },
 			{ 'e', EJECT },
+			{ 'i', INSERT },
 			{ 'p', PROTECT },
+			{ 's', DEVICES_INFO },
 			{ 'u', UNPROTECT }
 	};
 


### PR DESCRIPTION
```
>rasctl -c s -i 0
  0:0  SCHD  RaSCSI:SCSI HD 121 MiB:2211  1024 bytes per sector  127398912 bytes capacity  /home/us/hatari/test.hds  read-only
```