### PR TITLE
Prevent copying of files in use

### DIFF
--- a/cpp/rascsi/rascsi_image.cpp
+++ b/cpp/rascsi/rascsi_image.cpp
@@ -249,6 +249,12 @@ bool RascsiImage::CopyImage(const CommandContext& context, const PbCommand& comm
     	return context.ReturnStatus(false, "Can't read source image file '" + from + "'");
     }
 
+	const auto [id, lun] = StorageDevice::GetIdsForReservedFile(from);
+	if (id != -1 || lun != -1) {
+		return context.ReturnStatus(false, "Can't copy image file '" + from +
+				"', it is currently being used by device ID " + to_string(id) + ", LUN " + to_string(lun));
+	}
+
 	if (!CreateImageFolder(context, to)) {
 		return false;
 	}


### PR DESCRIPTION
Copying files in use is technically possible but may result in undefined destination file contents because the source file may be in the process of being modified. The fact that the destination file is broken may not be noticed for some time.
In order to prevent any issues copying of files in use should be prevented.