### PR TITLE
Headless bypass for sudo -v in easyinstall

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -132,8 +132,6 @@ function installPackagesStandalone() {
 # cache the pip packages
 function cachePipPackages(){
     pushd $WEB_INSTALL_PATH
-    # Refresh the sudo authentication, which shouldn't trigger another password prompt
-    sudo -v
     sudo pip3 install -r ./requirements.txt
     popd
 }
@@ -145,8 +143,6 @@ function compileRaScsi() {
     echo "Compiling with ${CORES:-1} simultaneous cores..."
     make clean </dev/null
 
-    # Refresh the sudo authentication, which shouldn't trigger another password prompt
-    sudo -v
     make -j "${CORES:-1}" all CONNECT_TYPE="${CONNECT_TYPE:-FULLSPEC}" </dev/null
 }
 

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -616,7 +616,7 @@ function installHfdisk() {
 function fetchHardDiskDrivers() {
     if [ ! -d "$BASE/mac-hard-disk-drivers" ]; then
         cd "$BASE" || exit 1
-        wget -r https://macintoshgarden.org/sites/macintoshgarden.org/files/apps/mac-hard-disk-drivers.zip
+        wget -r https://www.dropbox.com/s/gcs4v5pcmk7rxtb/mac-hard-disk-drivers.zip?dl=0
         unzip -d mac-hard-disk-drivers mac-hard-disk-drivers.zip
         rm mac-hard-disk-drivers.zip
     fi

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -78,6 +78,10 @@ function initialChecks() {
 
 # checks that the current user has sudoers privileges
 function sudoCheck() {
+    if [[ $HEADLESS ]]; then
+        echo "Skipping password check in headless mode"
+        return 0
+    fi
     echo "Input your password to allow this script to make the above changes."
     sudo -v
 }
@@ -614,9 +618,9 @@ function installHfdisk() {
 
 # Fetch HFS drivers that the Web Interface uses
 function fetchHardDiskDrivers() {
-    if [ ! -f "$BASE/mac-hard-disk-drivers" ]; then
+    if [ ! -d "$BASE/mac-hard-disk-drivers" ]; then
         cd "$BASE" || exit 1
-        wget https://macintoshgarden.org/sites/macintoshgarden.org/files/apps/mac-hard-disk-drivers.zip
+        wget -r https://macintoshgarden.org/sites/macintoshgarden.org/files/apps/mac-hard-disk-drivers.zip
         unzip -d mac-hard-disk-drivers mac-hard-disk-drivers.zip
         rm mac-hard-disk-drivers.zip
     fi


### PR DESCRIPTION
- Headless bypass for the initial sudo check
- Remove subsequent ```sudo -v``` since I haven't seen them actually make a difference for maintaining the auth state
- Two minor fixes to the Mac Hard Disk Drivers function: Should check for dir, not file; and overwrite zip if it exists
- Change Mac Hard Disk Drivers storage URL to Dropbox