### PR TITLE
Introduce option to use clang++, and option to skip apt packages

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -120,7 +120,8 @@ function installPackages() {
         man2html \
         hfsutils \
         dosfstools \
-        kpartx
+        kpartx \
+        clang
 }
 
 # install Debian packges for RaSCSI standalone
@@ -135,9 +136,8 @@ function installPackagesStandalone() {
         libpcap-dev \
         libprotobuf-dev \
         protobuf-compiler \
-        disktype \
         libgmock-dev \
-        man2html
+        clang
 }
 
 # cache the pip packages

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -46,7 +46,7 @@ logo="""
 echo -e $logo
 }
 
-COMPILER="g++"
+COMPILER="clang++-11"
 CONNECT_TYPE="FULLSPEC"
 CORES=1
 USER=$(whoami)
@@ -121,7 +121,7 @@ function installPackages() {
         hfsutils \
         dosfstools \
         kpartx \
-        clang
+        clang-11
 }
 
 # install Debian packges for RaSCSI standalone
@@ -132,12 +132,13 @@ function installPackagesStandalone() {
     fi
     sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -qq \
         build-essential \
+        git \
         libspdlog-dev \
         libpcap-dev \
         libprotobuf-dev \
         protobuf-compiler \
         libgmock-dev \
-        clang
+        clang-11
 }
 
 # cache the pip packages
@@ -1239,7 +1240,7 @@ function runChoice() {
               createImagesDir
               createCfgDir
               updateRaScsiGit
-              installPackages
+              installPackagesStandalone
               stopRaScsiScreen
               stopRaScsi
               compileRaScsi
@@ -1474,8 +1475,8 @@ while [ "$1" != "" ]; do
         -h | --headless)
             HEADLESS=1
             ;;
-        -l | --with_clang)
-            COMPILER="clang++"
+        -g | --with_gcc)
+            COMPILER="g++"
             ;;
         -s | --skip_packages)
             SKIP_PACKAGES=1

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -151,10 +151,10 @@ function cachePipPackages(){
 function compileRaScsi() {
     cd "$CPP_PATH" || exit 1
 
-    echo "Compiling with $CORES simultaneous cores..."
+    echo "Compiling $CONNECT_TYPE with $COMPILER on $CORES simultaneous cores..."
     make clean </dev/null
 
-    make CXX="$COMPILER" -j "$CORES" all CONNECT_TYPE="$CONNECT_TYPE" </dev/null
+    make CXX="$COMPILER" CONNECT_TYPE="$CONNECT_TYPE" -j "$CORES" all </dev/null
 }
 
 function cleanupOutdatedManPage() {


### PR DESCRIPTION
- Make clang++-11 the default for compiling rascsi
- Add --with_gcc option to use g++ instead
- Add option to skip apt-get package installation (this saves a significant amount of time running the script on a Zero when you already have the required packages installed)
- Add a line to the script menu showing current options
- Surrounding cleanup