### PR TITLE
GitHub Actions: Revert to triggering C++ workflows on push

### DIFF
--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -2,14 +2,10 @@ name: Build ARM binaries
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize]
+  push:
     paths:
       - 'cpp/**'
       - '.github/workflows/build_code.yml'
-  push:
-    branches:
-      - develop
 
 jobs:
   fullspec:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -2,14 +2,10 @@ name: C++ Tests/Analysis
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize]
+  push:
     paths:
       - 'cpp/**'
       - '.github/workflows/cpp.yml'
-  push:
-    branches:
-      - develop
 
 env:
   APT_PACKAGES: libspdlog-dev libpcap-dev libevdev2 libev-dev protobuf-compiler libgtest-dev libgmock-dev


### PR DESCRIPTION
Following feedback:

* All C++ workflows will run on push when a file is modified in the `cpp/**` path
* The web workflow will continue to be triggered by PR events for now