### PR TITLE
Reliability fix for Banana Pi M2+

### DIFF
--- a/cpp/hal/gpiobus_bananam2p.cpp
+++ b/cpp/hal/gpiobus_bananam2p.cpp
@@ -533,6 +533,7 @@ void GPIOBUS_BananaM2p::SetREQ(bool ast)
 uint8_t GPIOBUS_BananaM2p::GetDAT()
 {
     GPIO_FUNCTION_TRACE
+    (void)Acquire();
     // TODO: This is inefficient, but it works...
     uint32_t data =
         ((GetSignal(BPI_PIN_DT0) ? 0x01 : 0x00) << 0) | ((GetSignal(BPI_PIN_DT1) ? 0x01 : 0x00) << 1) |

--- a/cpp/shared/rascsi_version.cpp
+++ b/cpp/shared/rascsi_version.cpp
@@ -14,7 +14,7 @@
 
 // The following should be updated for each release
 const int rascsi_major_version = 22; // Last two digits of year
-const int rascsi_minor_version = 11; // Month
+const int rascsi_minor_version = 12; // Month
 const int rascsi_patch_version = -1;  // Patch number - increment for each update
 
 using namespace std;


### PR DESCRIPTION
I knew it was something simple that I was missing!!! 

With this fix, Banana Pi M2+ seems to be much more stable, but incredibly slow.

![image](https://user-images.githubusercontent.com/34318535/205472170-c7f7259c-6e11-48f9-8750-41103eaf9da4.png)

Performance will be the next step. This PR should at least make the functionality more stable. (probably not perfect, but much much better)