### PR TITLE
Add debug build to github workflows #1012

### DIFF
--- a/.github/workflows/arm_cross_compile.yml
+++ b/.github/workflows/arm_cross_compile.yml
@@ -53,10 +53,10 @@ jobs:
       # supports .ZIP files.
       # This is workaround for https://github.com/actions/upload-artifact/issues/38
       - name: Tar binary output
-        run: tar -czvf rascsi${{ env.debug_flag_filename }}-${{ inputs.connect-type }}.tar.gz ./bin
+        run: tar -czvf ${{ env.debug_flag_filename }}rascsi-${{ inputs.connect-type }}.tar.gz ./bin
 
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
-          name: arm-binaries${{ env.debug_flag_filename }}-${{ inputs.connect-type }}.tar.gz
-          path: cpp/rascsi${{ env.debug_flag_filename }}-${{ inputs.connect-type }}.tar.gz
+          name: ${{ env.debug_flag_filename }}arm-binaries-${{ inputs.connect-type }}.tar.gz
+          path: cpp/${{ env.debug_flag_filename }}rascsi-${{ inputs.connect-type }}.tar.gz

--- a/.github/workflows/arm_cross_compile.yml
+++ b/.github/workflows/arm_cross_compile.yml
@@ -6,8 +6,8 @@ on:
         type: string
       # Debug flag should either be an empty string or "DEBUG=1"
       debug-flag:
-        required: true
-        type: string
+        required: false
+        type: boolean
 
 jobs:
   build_arm:
@@ -39,8 +39,15 @@ jobs:
       - name: Install apt packages
         run: sudo apt-get --yes install ${{ env.APT_ARM_TOOLCHAIN }} ${{ env.APT_LIBRARIES }}
 
+      - name: Build debug strings
+        if: ${{ inputs.debug-flag }}
+        run: |
+          echo "debug_flag_compile=DEBUG\=1" >> $GITHUB_ENV
+          echo "debug_flag_filename=-debug" >> $GITHUB_ENV
+          echo "IM DEBUGGING"
+
       - name: Compile
-        run: make all -j 6 CONNECT_TYPE=${{ inputs.connect-type }} ${{ inputs.debug-flag }} CROSS_COMPILE=arm-linux-gnueabihf-
+        run: make all -j 6 CONNECT_TYPE=${{ inputs.connect-type }} ${{ env.debug_flag_compile }} CROSS_COMPILE=arm-linux-gnueabihf-
 
       # We need to tar the binary outputs to retain the executable
       # file permission. Currently, actions/upload-artifact only
@@ -52,5 +59,5 @@ jobs:
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
-          name: arm-binaries-${{ inputs.connect-type }}.tar.gz
-          path: cpp/rascsi-${{ inputs.connect-type }}.tar.gz
+          name: arm-binaries-${{ inputs.connect-type }}${{ env.debug_flag_filename }}.tar.gz
+          path: cpp/rascsi-${{ inputs.connect-type }}${{ env.debug_flag_filename }}.tar.gz

--- a/.github/workflows/arm_cross_compile.yml
+++ b/.github/workflows/arm_cross_compile.yml
@@ -4,6 +4,10 @@ on:
       connect-type:
         required: true
         type: string
+      debug-flag:
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build_arm:
@@ -36,7 +40,7 @@ jobs:
         run: sudo apt-get --yes install ${{ env.APT_ARM_TOOLCHAIN }} ${{ env.APT_LIBRARIES }}
 
       - name: Compile
-        run: make all -j 6 CONNECT_TYPE=${{ inputs.connect-type }} CROSS_COMPILE=arm-linux-gnueabihf-
+        run: make all -j 6 CONNECT_TYPE=${{ inputs.connect-type }} ${{ inputs.debug-flag }} CROSS_COMPILE=arm-linux-gnueabihf-
 
       # We need to tar the binary outputs to retain the executable
       # file permission. Currently, actions/upload-artifact only

--- a/.github/workflows/arm_cross_compile.yml
+++ b/.github/workflows/arm_cross_compile.yml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ inputs.debug-flag }}
         run: |
           echo "debug_flag_compile=DEBUG\=1" >> $GITHUB_ENV
-          echo "debug_flag_filename=-debug" >> $GITHUB_ENV
+          echo "debug_flag_filename=debug-" >> $GITHUB_ENV
 
       - name: Compile
         run: make all -j 6 CONNECT_TYPE=${{ inputs.connect-type }} ${{ env.debug_flag_compile }} CROSS_COMPILE=arm-linux-gnueabihf-

--- a/.github/workflows/arm_cross_compile.yml
+++ b/.github/workflows/arm_cross_compile.yml
@@ -4,7 +4,7 @@ on:
       connect-type:
         required: true
         type: string
-      # Debug flag should either be an empty string or "DEBUG=1"
+      # Debug flag indicates whether to build a debug build (no optimization, debugger symbols)
       debug-flag:
         required: false
         type: boolean
@@ -44,7 +44,6 @@ jobs:
         run: |
           echo "debug_flag_compile=DEBUG\=1" >> $GITHUB_ENV
           echo "debug_flag_filename=-debug" >> $GITHUB_ENV
-          echo "IM DEBUGGING"
 
       - name: Compile
         run: make all -j 6 CONNECT_TYPE=${{ inputs.connect-type }} ${{ env.debug_flag_compile }} CROSS_COMPILE=arm-linux-gnueabihf-
@@ -54,10 +53,10 @@ jobs:
       # supports .ZIP files.
       # This is workaround for https://github.com/actions/upload-artifact/issues/38
       - name: Tar binary output
-        run: tar -czvf rascsi-${{ inputs.connect-type }}.tar.gz ./bin
+        run: tar -czvf rascsi${{ env.debug_flag_filename }}-${{ inputs.connect-type }}.tar.gz ./bin
 
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
-          name: arm-binaries-${{ inputs.connect-type }}${{ env.debug_flag_filename }}.tar.gz
-          path: cpp/rascsi-${{ inputs.connect-type }}${{ env.debug_flag_filename }}.tar.gz
+          name: arm-binaries${{ env.debug_flag_filename }}-${{ inputs.connect-type }}.tar.gz
+          path: cpp/rascsi${{ env.debug_flag_filename }}-${{ inputs.connect-type }}.tar.gz

--- a/.github/workflows/arm_cross_compile.yml
+++ b/.github/workflows/arm_cross_compile.yml
@@ -4,9 +4,9 @@ on:
       connect-type:
         required: true
         type: string
+      # Debug flag should either be an empty string or "DEBUG=1"
       debug-flag:
         required: false
-        default: ''
         type: string
 
 jobs:

--- a/.github/workflows/arm_cross_compile.yml
+++ b/.github/workflows/arm_cross_compile.yml
@@ -6,7 +6,7 @@ on:
         type: string
       # Debug flag should either be an empty string or "DEBUG=1"
       debug-flag:
-        required: false
+        required: true
         type: string
 
 jobs:

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -10,28 +10,28 @@ on:
 
 jobs:
   fullspec:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "FULLSPEC"
 
   standard:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "STANDARD"
 
   aibom:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "AIBOM"
 
   gamernium:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "GAMERNIUM"
 
   # The fullspec connection board is the most common
   debug-fullspec:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "FULLSPEC"
       debug-flag: true

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -10,31 +10,31 @@ on:
 
 jobs:
   fullspec:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "FULLSPEC"
       debug-flag: ""
 
   standard:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "STANDARD"
       debug-flag: ""
 
   aibom:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "AIBOM"
       debug-flag: ""
 
   gamernium:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "GAMERNIUM"
       debug-flag: ""
 
   debug:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "FULLSPEC"
       debug-flag: "DEBUG=1"

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -33,4 +33,4 @@ jobs:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "FULLSPEC"
-      debug-flag: "DEBUG=1"
+      debug-flag: true

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'cpp/**'
       - '.github/workflows/build_code.yml'
+      - '.github/workflows/arm_cross_compile.yml'
 
 jobs:
   fullspec:

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -29,7 +29,8 @@ jobs:
     with:
       connect-type: "GAMERNIUM"
 
-  debug:
+  # The fullspec connection board is the most common
+  debug-fullspec:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "FULLSPEC"

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -12,21 +12,25 @@ jobs:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "FULLSPEC"
+      debug-flag: ""
 
   standard:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "STANDARD"
+      debug-flag: ""
 
   aibom:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "AIBOM"
+      debug-flag: ""
 
   gamernium:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "GAMERNIUM"
+      debug-flag: ""
 
   debug:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -10,31 +10,31 @@ on:
 
 jobs:
   fullspec:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
     with:
       connect-type: "FULLSPEC"
       debug-flag: ""
 
   standard:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
     with:
       connect-type: "STANDARD"
       debug-flag: ""
 
   aibom:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
     with:
       connect-type: "AIBOM"
       debug-flag: ""
 
   gamernium:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
     with:
       connect-type: "GAMERNIUM"
       debug-flag: ""
 
   debug:
-    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml
     with:
       connect-type: "FULLSPEC"
       debug-flag: "DEBUG=1"

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -13,25 +13,21 @@ jobs:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "FULLSPEC"
-      debug-flag: ""
 
   standard:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "STANDARD"
-      debug-flag: ""
 
   aibom:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "AIBOM"
-      debug-flag: ""
 
   gamernium:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012
     with:
       connect-type: "GAMERNIUM"
-      debug-flag: ""
 
   debug:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@feature_debug_build_1012

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -17,3 +17,19 @@ jobs:
     uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
     with:
       connect-type: "STANDARD"
+
+  aibom:
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
+    with:
+      connect-type: "AIBOM"
+
+  gamernium:
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
+    with:
+      connect-type: "GAMERNIUM"
+
+  debug:
+    uses: akuker/RASCSI/.github/workflows/arm_cross_compile.yml@develop
+    with:
+      connect-type: "FULLSPEC"
+      debug-flag: "DEBUG=1"


### PR DESCRIPTION
Also added gamernium and aibom versions to the github workflows. Since these run in parallel, the actions won't take any longer.

Note that the most recent commit WILL FAIL. build_code.yml specifies the `develop` branch for the job, so this won't work until `arm_cross_compile.yml` is merged.