### PR TITLE
Store the PIP cache in a specific directory  - #1149

### DIFF
--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -153,15 +153,16 @@ function installPackagesWeb() {
 
 # cache the pip packages
 function cachePipPackages(){
-    mkdir -p $HOME/.pip_cache
+    CACHEDIR="$HOME/.cache/piscsi"
+    mkdir -p "$CACHEDIR" || exit 1
     # Note: these need to be installed in source form ONLY. If the binary packages are installed, the architecture
     # is selected based upon the building host architecture, not the target architecture. (so, if you're building
     # a PiSCSI image on x86, pip will download x86 binaries, which aren't usefull on a Raspberry Pi
-    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache setuptools
-    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache wheel
-    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache flit_core
-    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache -r $WEB_INSTALL_PATH/requirements.txt
-    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache -r $CTRLBOARD_INSTALL_PATH/requirements.txt
+    python3 -m pip download --no-binary :all: --destination-directory "$CACHEDIR" setuptools
+    python3 -m pip download --no-binary :all: --destination-directory "$CACHEDIR" wheel
+    python3 -m pip download --no-binary :all: --destination-directory "$CACHEDIR" flit_core
+    python3 -m pip download --no-binary :all: --destination-directory "$CACHEDIR" -r $WEB_INSTALL_PATH/requirements.txt
+    python3 -m pip download --no-binary :all: --destination-directory "$CACHEDIR" -r $CTRLBOARD_INSTALL_PATH/requirements.txt
     # TODO: The OLED requirements.txt includes a circuit python package that doesn't work with non-binary
     # pip3 download
 }

--- a/easyinstall.sh
+++ b/easyinstall.sh
@@ -153,9 +153,17 @@ function installPackagesWeb() {
 
 # cache the pip packages
 function cachePipPackages(){
-    pushd $WEB_INSTALL_PATH
-    sudo pip3 install -r ./requirements.txt
-    popd
+    mkdir -p $HOME/.pip_cache
+    # Note: these need to be installed in source form ONLY. If the binary packages are installed, the architecture
+    # is selected based upon the building host architecture, not the target architecture. (so, if you're building
+    # a PiSCSI image on x86, pip will download x86 binaries, which aren't usefull on a Raspberry Pi
+    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache setuptools
+    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache wheel
+    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache flit_core
+    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache -r $WEB_INSTALL_PATH/requirements.txt
+    python3 -m pip download --no-binary :all: --destination-directory $HOME/.pip_cache -r $CTRLBOARD_INSTALL_PATH/requirements.txt
+    # TODO: The OLED requirements.txt includes a circuit python package that doesn't work with non-binary
+    # pip3 download
 }
 
 # compile the PiSCSI binaries

--- a/python/web/start.sh
+++ b/python/web/start.sh
@@ -59,8 +59,9 @@ if ! test -e venv; then
     echo "Activating venv"
     source venv/bin/activate
     echo "Installing requirements.txt"
-    pip3 install wheel
-    pip3 install -r requirements.txt
+    pip3 install wheel --no-index --find-links=$HOME/.pip_cache
+    # Reference: https://pip.pypa.io/en/latest/user_guide/#installing-from-local-packages
+    pip3 install -r requirements.txt --no-index --find-links=$HOME/.pip_cache
 
     if git rev-parse --is-inside-work-tree &> /dev/null; then
       git rev-parse HEAD > current
@@ -79,7 +80,7 @@ if [[ $? -eq 0 ]]; then
         git rev-parse > current
     elif [ "$(cat current)" != "$(git rev-parse HEAD)" ]; then
         echo "New version detected, updating libraries from requirements.txt"
-        pip3 install -r requirements.txt
+        pip3 install -r requirements.txt --no-index --find-links=$HOME/.pip_cache
         git rev-parse HEAD > current
     fi
 else

--- a/python/web/start.sh
+++ b/python/web/start.sh
@@ -2,6 +2,8 @@
 set -e
 # set -x # Uncomment to Debug
 
+CACHEDIR="$HOME/.cache/piscsi"
+
 cd "$(dirname "$0")"
 # verify packages installed
 ERROR=0
@@ -59,9 +61,9 @@ if ! test -e venv; then
     echo "Activating venv"
     source venv/bin/activate
     echo "Installing requirements.txt"
-    pip3 install wheel --no-index --find-links=$HOME/.pip_cache
+    pip3 install wheel --no-index --find-links="$CACHEDIR"
     # Reference: https://pip.pypa.io/en/latest/user_guide/#installing-from-local-packages
-    pip3 install -r requirements.txt --no-index --find-links=$HOME/.pip_cache
+    pip3 install -r requirements.txt --no-index --find-links="$CACHEDIR"
 
     if git rev-parse --is-inside-work-tree &> /dev/null; then
       git rev-parse HEAD > current
@@ -80,7 +82,7 @@ if [[ $? -eq 0 ]]; then
         git rev-parse > current
     elif [ "$(cat current)" != "$(git rev-parse HEAD)" ]; then
         echo "New version detected, updating libraries from requirements.txt"
-        pip3 install -r requirements.txt --no-index --find-links=$HOME/.pip_cache
+        pip3 install -r requirements.txt --no-index --find-links="$CACHEDIR"
         git rev-parse HEAD > current
     fi
 else


### PR DESCRIPTION
Updated easyinstall to download the SOURCE pip packages to $HOME/.pip_cache. The web startup script was updated to install the packages from this directory