### PR TITLE
Configure Dependabot for multiple ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/python/web"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "python"
+    directory: "/python"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Added support for Docker, GitHub Actions, npm, and Python package ecosystems with weekly update schedules.