### PR TITLE
Revert back to Ubuntu 22.04 for armhf cross-compilation

### DIFF
--- a/.github/workflows/arm_cross_compile.yml
+++ b/.github/workflows/arm_cross_compile.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_arm:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: cpp
@@ -27,11 +27,11 @@ jobs:
       - name: Reconfigure apt for arch amd64
         run: sudo sed -i "s/deb /deb [arch=amd64] /g" /etc/apt/sources.list
 
-      - name: Add armhf repos (noble)
-        run: sudo bash -c "echo \"deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ noble main multiverse restricted universe\" >> /etc/apt/sources.list"
+      - name: Add armhf repos (jammy)
+        run: sudo bash -c "echo \"deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ jammy main multiverse restricted universe\" >> /etc/apt/sources.list"
 
-      - name: Add armhf repos (noble-updates)
-        run: sudo bash -c "echo \"deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ noble-updates main multiverse restricted universe\" >> /etc/apt/sources.list"
+      - name: Add armhf repos (jammy-updates)
+        run: sudo bash -c "echo \"deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main multiverse restricted universe\" >> /etc/apt/sources.list"
 
       - name: Update apt
         run: sudo apt update


### PR DESCRIPTION
Ubuntu 24.04 (Noble Numbat) has unfortunately done away with the 32bit ports including armhf arch, so let's stay on 22.04 until we find a future proof solution (or drop 32bit support)