### PR TITLE
Downgrade protobuf version to 3.20.3

### DIFF
--- a/python/common/requirements.txt
+++ b/python/common/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.7.4
 charset-normalizer==3.3.2
 idna==3.7
-protobuf==6.33.0
+protobuf==3.20.3
 requests==2.32.2
 urllib3==2.2.2
 vcgencmd==0.1.1

--- a/python/ctrlboard/requirements.txt
+++ b/python/ctrlboard/requirements.txt
@@ -1,7 +1,7 @@
 luma.core==2.4.1
 luma.oled==3.8.1
 Pillow==10.3.0
-protobuf==6.33.0
+protobuf==3.20.3
 pyftdi==0.55.0
 pyserial==3.5
 pyusb==1.2.1

--- a/python/oled/requirements.txt
+++ b/python/oled/requirements.txt
@@ -7,7 +7,7 @@ adafruit-circuitpython-typing==1.9.5
 Adafruit-PlatformDetect==3.53.0
 Adafruit-PureIO==1.1.11
 Pillow==10.3.0
-protobuf==6.33.0
+protobuf==3.20.3
 pyftdi==0.55.0
 pyserial==3.5
 pyusb==1.2.1

--- a/python/web/requirements.txt
+++ b/python/web/requirements.txt
@@ -8,7 +8,7 @@ flask-babel==4.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.6
 MarkupSafe==2.1.3
-protobuf==6.33.0
+protobuf==3.20.3
 pytz==2023.3.post1
 requests==2.32.4
 simplepam==0.1.5


### PR DESCRIPTION
Python protobuf 6.x isn't compatible with the protoc version we're currently using for piscsi proper; let's upgrade both together at a later time