### PR TITLE
Migrate from simplepam to python-pam library

### DIFF
--- a/python/web/requirements.txt
+++ b/python/web/requirements.txt
@@ -9,9 +9,10 @@ itsdangerous==2.1.2
 Jinja2==3.1.6
 MarkupSafe==2.1.3
 protobuf==3.20.3
+python-pam==2.0.2
 pytz==2023.3.post1
 requests==2.32.4
-simplepam==0.1.5
+six==1.17.0
 ua-parser==0.16.1
 vcgencmd==0.1.1
 Werkzeug==3.0.6

--- a/python/web/src/web.py
+++ b/python/web/src/web.py
@@ -12,7 +12,7 @@ from os import path
 import bjoern
 
 from piscsi.return_codes import ReturnCodes
-from simplepam import authenticate
+from pam import authenticate
 from flask_babel import Babel, Locale, refresh, _
 from werkzeug.utils import secure_filename
 
@@ -357,7 +357,7 @@ def upload_page():
 @APP.route("/login", methods=["POST"])
 def login():
     """
-    Uses simplepam to authenticate against Linux users
+    Uses PAM to authenticate with system users
     """
     username = request.form["username"]
     password = request.form["password"]


### PR DESCRIPTION
The [simplepam](https://pypi.org/project/simplepam/) library hasn't been updated since 2014, and when you try to install it in our test containers now you get the error:

> ERROR: The tar file (/tmp/pip-unpack-syr6irxo/simplepam-0.1.5.tar.gz) has a file (simplepam-0.1.5/README) trying to install outside target directory (README.md)

This is to move to using the [python-pam](https://pypi.org/project/python-pam/) library instead, which is more actively maintained and less buggy.