### PR TITLE
Update SonarQube job conditions not to run for dependabot

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -51,7 +51,10 @@ jobs:
 
   sonarcloud:
     runs-on: ubuntu-24.04
-    if: github.repository == 'PiSCSI/piscsi'
+    if: >
+      (github.event_name == 'push' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot') || (github.event_name
+      == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && github.actor
+      != 'dependabot')
     env:
       BUILD_WRAPPER_OUT_DIR: "$HOME/.build_wrapper_out"
     steps:


### PR DESCRIPTION
Dependabot won't have the privileges to access the Sonar access token, so these jobs will always fail for their PRs