### PR TITLE
Introduce option to set the minimum execution time of SCSI commands

### DIFF
--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -995,3 +995,5 @@ void ScsiController::Sleep()
 	}
 	execstart = 0;
 }
+
+unsigned int ScsiController::MIN_EXEC_TIME = 50;

--- a/cpp/controllers/scsi_controller.h
+++ b/cpp/controllers/scsi_controller.h
@@ -25,7 +25,9 @@ class PrimaryDevice;
 class ScsiController : public AbstractController
 {
 	// For timing adjustments
-	static const unsigned int MIN_EXEC_TIME = 50;
+public:
+	static unsigned int MIN_EXEC_TIME;
+	static void SetMinExecTime(unsigned int usec) { MIN_EXEC_TIME = usec; }
 
 	// Transfer period factor (limited to 50 x 4 = 200ns)
 	static const int MAX_SYNC_PERIOD = 50;

--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -155,7 +155,7 @@ string Piscsi::ParseArguments(span<char *> args, PbCommand& command, int& port, 
 
 	opterr = 1;
 	int opt;
-	while ((opt = getopt(static_cast<int>(args.size()), args.data(), "-Iib:d:n:p:r:t:z:D:F:L:P:R:C:v")) != -1) {
+	while ((opt = getopt(static_cast<int>(args.size()), args.data(), "-Iib:d:n:p:r:s:t:z:D:F:L:P:R:C:v")) != -1) {
 		switch (opt) {
 			// The two options below are kind of a compound option with two letters
 			case 'i':
@@ -211,6 +211,16 @@ string Piscsi::ParseArguments(span<char *> args, PbCommand& command, int& port, 
 
 			case 'r':
 				reserved_ids = optarg;
+				continue;
+
+			case 's':
+				{
+					int min_exec_time;
+					if (!GetAsUnsignedInt(optarg, min_exec_time)) {
+						throw parser_exception("Invalid command delay " + string(optarg));
+					}
+					ScsiController::SetMinExecTime(min_exec_time);
+				}
 				continue;
 
 			case 't':
@@ -517,6 +527,8 @@ int Piscsi::run(span<char *> args)
 
 		return EXIT_FAILURE;
 	}
+
+	spdlog::info("SCSI command execution time set to " + to_string(ScsiController::MIN_EXEC_TIME) + " microseconds");
 
 	if (const string error = executor->SetReservedIds(reserved_ids); !error.empty()) {
 		cerr << "Error: " << error << endl;

--- a/doc/piscsi.1
+++ b/doc/piscsi.1
@@ -75,6 +75,10 @@ The piscsi server port, default is 6868.
 .TP
 .BR \-r\fI " " \fIRESERVED_IDS
 Comma-separated list of IDs to reserve. Pass an empty list in order to not reserve anything.
+.TP
+.BR \-r\fs " " \fIMICROSECONDS
+Minimum execution time for SCSI commands in microseconds. Default is 50. Higher values may be needed for some older SCSI initiators to work properly.
+.TP
 .BR \-p\fI " " \fITYPE
 The optional case-insensitive device type (SAHD, SCHD, SCRM, SCCD, SCMO, SCBR, SCDP, SCLP, SCHS). If no type is specified for devices that support an image file, piscsi tries to derive the type from the file extension.
 .TP


### PR DESCRIPTION
For the Status, DataIn, and DataOut phases, piscsi has a 50 microsecond sleep implemented, which has proven a stabilizing factor for the bus on most SCSI initiators
    
However, Akai S1100 and other samplers of a similar vintage need a longer sleep time for reliable operation, so a -s option for piscsi has been introduced to set the value to an artbitrary number at runtime