### PR TITLE
create meson build scripts, improve tests and correctness

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -23,7 +23,7 @@ on:
       - 'python/**'
 
 env:
-  APT_PACKAGES: libspdlog-dev libpcap-dev libevdev2 libev-dev protobuf-compiler libgtest-dev libgmock-dev
+  APT_PACKAGES: libspdlog-dev libpcap-dev libevdev2 libev-dev protobuf-compiler libgtest-dev libgmock-dev meson ninja-build
 
 jobs:
   unit_tests:
@@ -48,6 +48,32 @@ jobs:
         with:
           name: piscsi_test_log.txt
           path: cpp/piscsi_test_log.txt
+
+  unit_tests_meson:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install dependencies
+        run: sudo apt-get install ${{ env.APT_PACKAGES }}
+
+      - name: Configure build
+        run: meson setup build
+
+      - name: Build unit tests
+        run: meson compile -C build
+
+      - name: Run unit tests
+        run: meson test -C build
+
+      - name: Upload logs
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: testlog.txt
+          path: build/meson-logs/testlog.txt
 
   sonarcloud:
     runs-on: ubuntu-24.04

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -41,7 +41,7 @@ jobs:
         run: DEBUG=1 make -j $(nproc) test
 
       - name: Run unit tests
-        run: (set -o pipefail && bin/piscsi_test | tee piscsi_test_log.txt)
+        run: (set -o pipefail && GTEST_SHUFFLE=1 bin/piscsi_test | tee piscsi_test_log.txt)
 
       - name: Upload logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -67,7 +67,7 @@ jobs:
         run: meson compile -C build
 
       - name: Run unit tests
-        run: meson test -C build
+        run: GTEST_SHUFFLE=1 meson test -C build
 
       - name: Upload logs
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -11,4 +11,3 @@ piscsi.dat
 obj
 bin
 coverage
-generated

--- a/cpp/devices/ctapdriver.cpp
+++ b/cpp/devices/ctapdriver.cpp
@@ -11,6 +11,7 @@
 
 #include "shared/piscsi_util.h"
 #include "shared/network_util.h"
+#include <fcntl.h>
 #include <unistd.h>
 #include <poll.h>
 #include <arpa/inet.h>

--- a/cpp/devices/scsi_command_util.cpp
+++ b/cpp/devices/scsi_command_util.cpp
@@ -30,23 +30,40 @@ string scsi_command_util::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uin
 		return result;
 	}
 
+	// The parameter list must include a complete MODE SELECT header and be present in the transfer buffer.
+	// SCSI-2 8.2.8 requires PARAMETER LIST LENGTH ERROR for any truncated header, descriptor, or page.
+	const int header_length = cmd == scsi_command::eCmdModeSelect10 ? 8 : 4;
+	if (length < header_length || length > static_cast<int>(buf.size())) {
+		throw scsi_exception(sense_key::illegal_request, asc::parameter_list_length_error);
+	}
+
 	// Skip block descriptors
-	int offset;
-	if (cmd == scsi_command::eCmdModeSelect10) {
-		offset = 8 + GetInt16(buf, 6);
+	const int block_descriptor_length = cmd == scsi_command::eCmdModeSelect10 ? GetInt16(buf, 6) : buf[3];
+	if (block_descriptor_length > length - header_length) {
+		throw scsi_exception(sense_key::illegal_request, asc::parameter_list_length_error);
 	}
-	else {
-		offset = 4 + buf[3];
-	}
+
+	int offset = header_length + block_descriptor_length;
 	length -= offset;
 
 	bool has_valid_page_code = false;
 
 	// Parse the pages
 	while (length > 0) {
+		// A mode page header must not be truncated.
+		if (length < 2) {
+			throw scsi_exception(sense_key::illegal_request, asc::parameter_list_length_error);
+		}
+
+		const int size = buf[offset + 1] + 2;
+		if (size > length) {
+			throw scsi_exception(sense_key::illegal_request, asc::parameter_list_length_error);
+		}
+
 		// Format device page
 		if (const int page = buf[offset]; page == 0x03) {
-			if (length < 14) {
+			// The sector size field is at offset 12 in the page and occupies two bytes.
+			if (size < 14) {
 				throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_parameter_list);
 			}
 
@@ -69,8 +86,6 @@ string scsi_command_util::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uin
 		}
 
 		// Advance to the next page
-		const int size = buf[offset + 1] + 2;
-
 		length -= size;
 		offset += size;
 	}

--- a/cpp/devices/scsi_command_util.cpp
+++ b/cpp/devices/scsi_command_util.cpp
@@ -62,11 +62,13 @@ string scsi_command_util::ModeSelect(scsi_command cmd, cdb_t cdb, span<const uin
 
 		// Format device page
 		if (const int page = buf[offset]; page == 0x03) {
-			// The sector size field is at offset 12 in the page and occupies two bytes.
-			if (size < 14) {
+			// MODE SELECT must use the page length advertised by MODE SENSE.
+			constexpr int format_device_page_length = 24;
+			if (size != format_device_page_length) {
 				throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_parameter_list);
 			}
 
+			// The sector size field is at offset 12 in the page and occupies two bytes.
 			// With this page the sector size for a subsequent FORMAT can be selected, but only very few
 			// drives support this, e.g FUJITSU M2624S
 			// We are fine as long as the current sector size remains unchanged

--- a/cpp/generated/.gitignore
+++ b/cpp/generated/.gitignore
@@ -1,0 +1,3 @@
+piscsi_interface.pb.h
+piscsi_interface.pb.cc
+piscsi_interface.pb.cpp

--- a/cpp/generated/meson.build
+++ b/cpp/generated/meson.build
@@ -1,0 +1,13 @@
+piscsi_interface_src = custom_target(
+    'piscsi_interface_proto',
+    input : meson.project_source_root() / 'cpp' / 'piscsi_interface.proto',
+    output : ['piscsi_interface.pb.cc', 'piscsi_interface.pb.h'],
+    command : [
+        protoc, 
+        '--cpp_out=@BUILD_ROOT@/cpp/generated', 
+        '--proto_path=' + meson.project_source_root() / 'cpp',
+        '@INPUT@'
+    ],
+    build_by_default : true,
+    install : false
+)

--- a/cpp/generated/meson.build
+++ b/cpp/generated/meson.build
@@ -1,11 +1,11 @@
 piscsi_interface_src = custom_target(
     'piscsi_interface_proto',
-    input : meson.project_source_root() / 'cpp' / 'piscsi_interface.proto',
+    input : meson.project_source_root() / 'proto' / 'piscsi_interface.proto',
     output : ['piscsi_interface.pb.cc', 'piscsi_interface.pb.h'],
     command : [
         protoc, 
         '--cpp_out=@BUILD_ROOT@/cpp/generated', 
-        '--proto_path=' + meson.project_source_root() / 'cpp',
+        '--proto_path=' + meson.project_source_root() / 'proto',
         '@INPUT@'
     ],
     build_by_default : true,

--- a/cpp/hal/gpiobus_raspberry.cpp
+++ b/cpp/hal/gpiobus_raspberry.cpp
@@ -19,6 +19,7 @@
 #include "hal/gpiobus_raspberry.h"
 #include "hal/gpiobus.h"
 #include "hal/systimer.h"
+#include <fcntl.h>
 #include <map>
 #include <cstring>
 #ifdef __linux__

--- a/cpp/hal/gpiobus_raspberry.cpp
+++ b/cpp/hal/gpiobus_raspberry.cpp
@@ -67,7 +67,7 @@ bool GPIOBUS_Raspberry::Init(mode_e mode)
 {
     GPIOBUS::Init(mode);
 
-#if defined(__x86_64__) || defined(__X86__)
+#if !defined(__linux__) || defined(__x86_64__) || defined(__X86__)
     (void)baseaddr;
     level = new uint32_t();
     return true;
@@ -278,7 +278,7 @@ bool GPIOBUS_Raspberry::Init(mode_e mode)
 
 void GPIOBUS_Raspberry::Cleanup()
 {
-#if defined(__x86_64__) || defined(__X86__)
+#if !defined(__linux__) || defined(__x86_64__) || defined(__X86__)
     return;
 #else
     // Release SEL signal interrupt
@@ -312,7 +312,7 @@ void GPIOBUS_Raspberry::Cleanup()
 
 void GPIOBUS_Raspberry::Reset()
 {
-#if defined(__x86_64__) || defined(__X86__)
+#if !defined(__linux__) || defined(__x86_64__) || defined(__X86__)
     return;
 #else
     int i;

--- a/cpp/hal/gpiobus_virtual.cpp
+++ b/cpp/hal/gpiobus_virtual.cpp
@@ -13,6 +13,7 @@
 #include "hal/systimer.h"
 #include "hal/log.h"
 #include <cstddef>
+#include <fcntl.h>
 #include <map>
 #include <memory>
 #include <string.h>
@@ -556,4 +557,3 @@ uint32_t GPIOBUS_Virtual::Acquire()
 #endif
     return signal_value;
 }
-

--- a/cpp/hal/sbc_version.cpp
+++ b/cpp/hal/sbc_version.cpp
@@ -79,7 +79,7 @@ void SBC_Version::Init()
     ifstream input_stream(SBC_Version::m_device_tree_model_path);
 
     if (input_stream.fail()) {
-#if defined(__x86_64__) || defined(__X86__)
+#if !defined(__linux__) || defined(__x86_64__) || defined(__X86__)
         // We expect this to fail on x86
     	spdlog::warn("Detected " + GetAsString());
         sbc_version = sbc_version_type::sbc_unknown;

--- a/cpp/hal/systimer_raspberry.cpp
+++ b/cpp/hal/systimer_raspberry.cpp
@@ -36,6 +36,10 @@ using namespace std;
 //---------------------------------------------------------------------------
 void SysTimer_Raspberry::Init()
 {
+#if !defined(__linux__)
+    // The Raspberry Pi timer is accessed through Linux device files and is not available on development hosts.
+    return;
+#else
     // Get the base address
     const auto baseaddr = SBC_Version::GetPeripheralAddress();
 
@@ -81,6 +85,7 @@ void SysTimer_Raspberry::Init()
         corefreq = maxclock[6] / 1000000;
         close(vcio_fd);
     }
+#endif
 }
 
 //---------------------------------------------------------------------------

--- a/cpp/hal/systimer_raspberry.cpp
+++ b/cpp/hal/systimer_raspberry.cpp
@@ -13,6 +13,7 @@
 
 #include "hal/systimer_raspberry.h"
 #include <spdlog/spdlog.h>
+#include <fcntl.h>
 #include <memory>
 #include <sys/ioctl.h>
 #include <sys/mman.h>

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -1,0 +1,180 @@
+controllers_src = [
+    'controllers/abstract_controller.cpp',
+    'controllers/controller_manager.cpp',
+    'controllers/phase_handler.cpp',
+    'controllers/scsi_controller.cpp',
+]
+devices_src = [
+    'devices/cd_track.cpp',
+    'devices/ctapdriver.cpp',
+    'devices/device_factory.cpp',
+    'devices/device_logger.cpp',
+    'devices/device.cpp',
+    'devices/disk_cache.cpp',
+    'devices/disk_track.cpp',
+    'devices/disk.cpp',
+    'devices/host_services.cpp',
+    'devices/mode_page_device.cpp',
+    'devices/primary_device.cpp',
+    'devices/scsi_command_util.cpp',
+    'devices/scsi_daynaport.cpp',
+    'devices/scsi_printer.cpp',
+    'devices/scsi_streamer.cpp',
+    'devices/scsicd.cpp',
+    'devices/scsihd_nec.cpp',
+    'devices/scsihd.cpp',
+    'devices/scsimo.cpp',
+    'devices/storage_device.cpp',
+]
+hal_src = [
+    'hal/bus.cpp',
+    'hal/data_sample.cpp',
+    'hal/gpiobus_factory.cpp',
+    'hal/gpiobus_raspberry.cpp',
+    'hal/gpiobus_virtual.cpp',
+    'hal/gpiobus.cpp',
+    'hal/sbc_version.cpp',
+    'hal/systimer_raspberry.cpp',
+    'hal/systimer.cpp',
+]
+piscsi_core_src = [
+    'piscsi/command_context.cpp',
+    'piscsi/localizer.cpp',
+    'piscsi/piscsi_core.cpp',
+    'piscsi/piscsi_executor.cpp',
+    'piscsi/piscsi_image.cpp',
+    'piscsi/piscsi_response.cpp',
+    'piscsi/piscsi_service.cpp',
+] + controllers_src + devices_src + hal_src
+piscsi_src = [
+    'piscsi/piscsi.cpp',
+]
+scsictl_core_src = [
+    'scsictl/scsictl_commands.cpp',
+    'scsictl/scsictl_core.cpp',
+    'scsictl/scsictl_display.cpp',
+    'scsictl/scsictl_parser.cpp',
+]
+scsictl_src = [
+    'scsictl/scsictl.cpp',
+]
+scsidump_core_src = [
+    'scsidump/scsidump_core.cpp',
+]
+scsidump_src = [
+    'scsidump/scsidump.cpp',
+] + scsidump_core_src + hal_src
+scsiloop_src = [
+    'scsiloop/scsiloop.cpp',
+    'scsiloop/scsiloop_core.cpp',
+    'scsiloop/scsiloop_cout.cpp',
+    'scsiloop/scsiloop_gpio.cpp',
+    'scsiloop/scsiloop_timer.cpp',
+] + hal_src
+scsimon_src = [
+    'scsimon/scsimon.cpp',
+    'scsimon/sm_core.cpp',
+    'scsimon/sm_html_report.cpp',
+    'scsimon/sm_json_report.cpp',
+    'scsimon/sm_vcd_report.cpp',
+] + hal_src
+shared_src = [
+    'shared/network_util.cpp',
+    'shared/piscsi_util.cpp',
+    'shared/piscsi_version.cpp',
+]
+protobuf_src = [
+    'shared/protobuf_util.cpp',
+]
+test_src = [
+    'test/abstract_controller_test.cpp',
+    'test/bus_test.cpp',
+    'test/command_context_test.cpp',
+    'test/controller_manager_test.cpp',
+    'test/ctapdriver_test.cpp',
+    'test/device_factory_test.cpp',
+    'test/device_test.cpp',
+    'test/disk_test.cpp',
+    'test/gpiobus_raspberry_test.cpp',
+    'test/host_services_test.cpp',
+    'test/linux_os_stubs.cpp',
+    'test/localizer_test.cpp',
+    'test/mode_page_device_test.cpp',
+    'test/network_util_test.cpp',
+    'test/phase_handler_test.cpp',
+    'test/piscsi_exceptions_test.cpp',
+    'test/piscsi_executor_test.cpp',
+    'test/piscsi_image_test.cpp',
+    'test/piscsi_response_test.cpp',
+    'test/piscsi_service_test.cpp',
+    'test/piscsi_util_test.cpp',
+    'test/primary_device_test.cpp',
+    'test/protobuf_util_test.cpp',
+    'test/scsi_command_util_test.cpp',
+    'test/scsi_controller_test.cpp',
+    'test/scsi_daynaport_test.cpp',
+    'test/scsi_printer_test.cpp',
+    'test/scsicd_test.cpp',
+    'test/scsictl_commands_test.cpp',
+    'test/scsictl_display_test.cpp',
+    'test/scsictl_parser_test.cpp',
+    'test/scsidump_test.cpp',
+    'test/scsihd_nec_test.cpp',
+    'test/scsihd_test.cpp',
+    'test/scsimo_test.cpp',
+    'test/storage_device_test.cpp',
+    'test/test_setup.cpp',
+    'test/test_shared.cpp',
+] + scsidump_core_src
+
+subdir('generated')
+
+if to_build.contains('piscsi')
+    piscsi_bin = executable('piscsi',
+        piscsi_core_src + piscsi_src + shared_src + protobuf_src + piscsi_interface_src[0],
+        dependencies : [pthread_dep, pcap_dep, protobuf_dep],
+        install : true,
+    )
+endif
+
+if to_build.contains('scsictl')
+    scsictl_bin = executable('scsictl',
+        scsictl_core_src + scsictl_src + shared_src + protobuf_src + piscsi_interface_src[0],
+        dependencies : [pthread_dep, protobuf_dep],
+        install : true,
+    )
+endif
+
+if to_build.contains('scsimon')
+    scsimon_bin = executable('scsimon',
+        scsimon_src + shared_src,
+        dependencies : [pthread_dep],
+        install : true,
+    )
+endif
+
+if to_build.contains('scsiloop')
+    scsiloop_bin = executable('scsiloop',
+        scsiloop_src + shared_src,
+        dependencies : [pthread_dep],
+        install : true,
+    )
+endif
+
+if connect_type == 'FULLSPEC' and to_build.contains('scsidump')
+    scsidump_bin = executable('scsidump',
+        scsidump_src + shared_src,
+        dependencies : [pthread_dep],
+        install : true,
+    )
+endif
+
+if gtest_dep.found() and gmock_dep.found() and to_build.contains('test')
+    test_bin = executable('piscsi_test',
+        piscsi_core_src + scsictl_core_src + test_src + shared_src + protobuf_src + piscsi_interface_src[0],
+        dependencies : [pthread_dep, pcap_dep, protobuf_dep, gtest_dep, gmock_dep],
+        link_args : ['-Wl,--wrap=fopen64'],
+        install : false
+    )
+    test('unit', test_bin)
+endif

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -185,5 +185,5 @@ if gtest_dep.found() and gmock_dep.found() and to_build.contains('test')
         link_args : test_link_args,
         install : false
     )
-    test('unit', test_bin)
+    test('unit', test_bin, protocol : 'gtest')
 endif

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -95,9 +95,7 @@ test_src = [
     'test/device_factory_test.cpp',
     'test/device_test.cpp',
     'test/disk_test.cpp',
-    'test/gpiobus_raspberry_test.cpp',
     'test/host_services_test.cpp',
-    'test/linux_os_stubs.cpp',
     'test/localizer_test.cpp',
     'test/mode_page_device_test.cpp',
     'test/network_util_test.cpp',
@@ -127,12 +125,23 @@ test_src = [
     'test/test_shared.cpp',
 ] + scsidump_core_src
 
+test_platform_src = []
+test_link_args = []
+if host_machine.system() == 'linux'
+    test_platform_src += [
+        'test/gpiobus_raspberry_test.cpp',
+        'test/linux_os_stubs.cpp',
+    ]
+    test_link_args += '-Wl,--wrap=fopen64'
+endif
+test_src += test_platform_src
+
 subdir('generated')
 
 if to_build.contains('piscsi')
     piscsi_bin = executable('piscsi',
         piscsi_core_src + piscsi_src + shared_src + protobuf_src + piscsi_interface_src[0],
-        dependencies : [pthread_dep, pcap_dep, protobuf_dep],
+        dependencies : common_deps + [pcap_dep, protobuf_dep],
         install : true,
     )
 endif
@@ -140,7 +149,7 @@ endif
 if to_build.contains('scsictl')
     scsictl_bin = executable('scsictl',
         scsictl_core_src + scsictl_src + shared_src + protobuf_src + piscsi_interface_src[0],
-        dependencies : [pthread_dep, protobuf_dep],
+        dependencies : common_deps + [protobuf_dep],
         install : true,
     )
 endif
@@ -148,7 +157,7 @@ endif
 if to_build.contains('scsimon')
     scsimon_bin = executable('scsimon',
         scsimon_src + shared_src,
-        dependencies : [pthread_dep],
+        dependencies : common_deps,
         install : true,
     )
 endif
@@ -156,7 +165,7 @@ endif
 if to_build.contains('scsiloop')
     scsiloop_bin = executable('scsiloop',
         scsiloop_src + shared_src,
-        dependencies : [pthread_dep],
+        dependencies : common_deps,
         install : true,
     )
 endif
@@ -164,7 +173,7 @@ endif
 if connect_type == 'FULLSPEC' and to_build.contains('scsidump')
     scsidump_bin = executable('scsidump',
         scsidump_src + shared_src,
-        dependencies : [pthread_dep],
+        dependencies : common_deps,
         install : true,
     )
 endif
@@ -172,8 +181,8 @@ endif
 if gtest_dep.found() and gmock_dep.found() and to_build.contains('test')
     test_bin = executable('piscsi_test',
         piscsi_core_src + scsictl_core_src + test_src + shared_src + protobuf_src + piscsi_interface_src[0],
-        dependencies : [pthread_dep, pcap_dep, protobuf_dep, gtest_dep, gmock_dep],
-        link_args : ['-Wl,--wrap=fopen64'],
+        dependencies : common_deps + [pcap_dep, protobuf_dep, gtest_dep, gmock_dep],
+        link_args : test_link_args,
         install : false
     )
     test('unit', test_bin)

--- a/cpp/piscsi/piscsi_core.cpp
+++ b/cpp/piscsi/piscsi_core.cpp
@@ -24,6 +24,7 @@
 #include <spdlog/spdlog.h>
 #include <netinet/in.h>
 #include <csignal>
+#include <sys/stat.h>
 #include <sstream>
 #include <iostream>
 #include <fstream>

--- a/cpp/piscsi/piscsi_executor.cpp
+++ b/cpp/piscsi/piscsi_executor.cpp
@@ -34,8 +34,12 @@ bool PiscsiExecutor::ProcessDeviceCmd(const CommandContext& context, const PbDev
 
 	const PbOperation operation = context.GetCommand().operation();
 
-	// For all commands except ATTACH the device and LUN must exist
-	if (operation != ATTACH && !VerifyExistingIdAndLun(context, id, lun)) {
+	// ATTACH creates the device, so it must be handled before looking up an existing one.
+	if (operation == ATTACH) {
+		return Attach(context, pb_device, dryRun);
+	}
+
+	if (!VerifyExistingIdAndLun(context, id, lun)) {
 		return false;
 	}
 
@@ -51,9 +55,6 @@ bool PiscsiExecutor::ProcessDeviceCmd(const CommandContext& context, const PbDev
 
 		case STOP:
 			return Stop(*device, dryRun);
-
-		case ATTACH:
-			return Attach(context, pb_device, dryRun);
 
 		case DETACH:
 			return Detach(context, *device, dryRun);

--- a/cpp/piscsi/piscsi_image.cpp
+++ b/cpp/piscsi/piscsi_image.cpp
@@ -69,7 +69,10 @@ string PiscsiImage::SetDefaultFolder(string_view f)
 
 	// Resolve a potential symlink
 	if (error_code error; is_symlink(folder, error)) {
-		folder = read_symlink(folder);
+		folder = canonical(folder, error);
+		if (error) {
+			return "Can't resolve default image folder '" + folder.string() + "': " + error.message();
+		}
 	}
 
 	if (error_code error; !is_directory(folder)) {

--- a/cpp/piscsi/piscsi_response.cpp
+++ b/cpp/piscsi/piscsi_response.cpp
@@ -299,11 +299,11 @@ void PiscsiResponse::GetVersionInfo(PbVersionInfo& version_info) const
 
 void PiscsiResponse::GetLogLevelInfo(PbLogLevelInfo& log_level_info) const
 {
-	for (const auto& log_level : spdlog::level::level_string_views) {
-		log_level_info.add_log_levels(log_level.data());
+	for (int level = spdlog::level::trace; level < spdlog::level::n_levels; level++) {
+		log_level_info.add_log_levels(spdlog::level::to_string_view(static_cast<spdlog::level::level_enum>(level)).data());
 	}
 
-	log_level_info.set_current_log_level(spdlog::level::level_string_views[spdlog::get_level()].data());
+	log_level_info.set_current_log_level(spdlog::level::to_string_view(spdlog::get_level()).data());
 }
 
 void PiscsiResponse::GetNetworkInterfacesInfo(PbNetworkInterfacesInfo& network_interfaces_info) const

--- a/cpp/scsictl/scsictl_parser.cpp
+++ b/cpp/scsictl/scsictl_parser.cpp
@@ -11,6 +11,9 @@
 
 PbOperation ScsictlParser::ParseOperation(string_view operation) const
 {
+	if (operation.empty()) {
+		return NO_OPERATION;
+	}
 	const auto& it = operations.find(tolower(operation[0]));
 	return it != operations.end() ? it->second : NO_OPERATION;
 }

--- a/cpp/test/network_util_test.cpp
+++ b/cpp/test/network_util_test.cpp
@@ -22,7 +22,12 @@ TEST(NetworkUtilTest, IsInterfaceUp)
 
 TEST(NetworkUtilTest, GetNetworkInterfaces)
 {
+	// GetNetworkInterfaces() only enumerates interfaces on Linux.
+#ifdef __linux__
 	EXPECT_FALSE(GetNetworkInterfaces().empty());
+#else
+	GetNetworkInterfaces();
+#endif
 }
 
 TEST(NetworkUtilTest, ResolveHostName)

--- a/cpp/test/piscsi_executor_test.cpp
+++ b/cpp/test/piscsi_executor_test.cpp
@@ -164,6 +164,16 @@ TEST(PiscsiExecutorTest, ProcessCmd)
 	device2->set_unit(1);
 	CommandContext context_attach2(command_attach2, "", "");
 	EXPECT_FALSE(executor->ProcessCmd(context_attach2)) << "LUN 0 is missing";
+
+	PbCommand command_attach3;
+	command_attach3.set_operation(ATTACH);
+	auto *device3 = command_attach3.add_devices();
+	device3->set_type(SCHS);
+	device3->set_id(0);
+	device3->set_unit(0);
+	CommandContext context_attach3(command_attach3, "", "");
+	EXPECT_TRUE(executor->ProcessCmd(context_attach3));
+	EXPECT_TRUE(controller_manager.HasDeviceForIdAndLun(0, 0));
 }
 
 TEST(PiscsiExecutorTest, Attach)

--- a/cpp/test/piscsi_image_test.cpp
+++ b/cpp/test/piscsi_image_test.cpp
@@ -27,11 +27,34 @@ TEST(PiscsiImageTest, SetGetDefaultFolder)
 {
 	PiscsiImage image;
 
-	EXPECT_EQ(PiscsiImage::DEFAULT_IMAGE_FOLDER, image.GetDefaultFolder());
-
 	EXPECT_TRUE(!image.SetDefaultFolder("").empty());
+	EXPECT_FALSE(image.SetDefaultFolder((test_data_temp_path / "non-existent-folder").string()).empty());
 	EXPECT_TRUE(image.SetDefaultFolder(temp_directory_path().string()).empty());
 	EXPECT_EQ(temp_directory_path(), path(image.GetDefaultFolder()));
+}
+
+TEST(PiscsiImageTest, SetDefaultFolderResolvesRelativePathsAndSymlinks)
+{
+	PiscsiImage image;
+
+	EXPECT_TRUE(image.SetDefaultFolder(".").empty());
+	EXPECT_TRUE(equivalent(current_path(), path(image.GetDefaultFolder())));
+
+	const path target = test_data_temp_path / "image-folder-target";
+	const path link = test_data_temp_path / "image-folder-link";
+	error_code error;
+	remove_all(target, error);
+	remove(link, error);
+	create_directories(target, error);
+	ASSERT_FALSE(error) << error.message();
+	create_directory_symlink("image-folder-target", link, error);
+	ASSERT_FALSE(error) << error.message();
+
+	EXPECT_TRUE(image.SetDefaultFolder(link.string()).empty());
+	EXPECT_EQ(canonical(target), path(image.GetDefaultFolder()));
+
+	remove(link, error);
+	remove_all(target, error);
 }
 
 TEST(PiscsiImageTest, CreateImage)

--- a/cpp/test/piscsi_response_test.cpp
+++ b/cpp/test/piscsi_response_test.cpp
@@ -198,7 +198,7 @@ TEST(PiscsiResponseTest, GetServerInfo)
 	EXPECT_EQ(piscsi_major_version, info1.version_info().major_version());
 	EXPECT_EQ(piscsi_minor_version, info1.version_info().minor_version());
 	EXPECT_EQ(piscsi_patch_version, info1.version_info().patch_version());
-	EXPECT_EQ(level::level_string_views[get_level()], info1.log_level_info().current_log_level());
+	EXPECT_EQ(level::to_string_view(get_level()).data(), info1.log_level_info().current_log_level());
 	EXPECT_EQ("default_folder", info1.image_files_info().default_image_folder());
 	EXPECT_EQ(1234, info1.image_files_info().depth());
 	EXPECT_EQ(2, info1.reserved_ids_info().ids().size());
@@ -235,7 +235,7 @@ TEST(PiscsiResponseTest, GetLogLevelInfo)
 
 	PbLogLevelInfo info;
 	response.GetLogLevelInfo(info);
-	EXPECT_EQ(level::level_string_views[get_level()], info.current_log_level());
+	EXPECT_EQ(level::to_string_view(get_level()).data(), info.current_log_level());
 	EXPECT_EQ(7, info.log_levels().size());
 }
 
@@ -245,7 +245,12 @@ TEST(PiscsiResponseTest, GetNetworkInterfacesInfo)
 
 	PbNetworkInterfacesInfo info;
 	response.GetNetworkInterfacesInfo(info);
+	// Network interface enumeration is currently implemented for Linux only.
+#ifdef __linux__
 	EXPECT_FALSE(info.name().empty());
+#else
+	EXPECT_TRUE(info.name().empty());
+#endif
 }
 
 TEST(PiscsiResponseTest, GetMappingInfo)

--- a/cpp/test/piscsi_response_test.cpp
+++ b/cpp/test/piscsi_response_test.cpp
@@ -249,7 +249,7 @@ TEST(PiscsiResponseTest, GetNetworkInterfacesInfo)
 #ifdef __linux__
 	EXPECT_FALSE(info.name().empty());
 #else
-	EXPECT_TRUE(info.name().empty());
+	GTEST_SKIP() << "Network interface enumeration is implemented for Linux only";
 #endif
 }
 

--- a/cpp/test/piscsi_service_test.cpp
+++ b/cpp/test/piscsi_service_test.cpp
@@ -27,11 +27,39 @@ using namespace piscsi_interface;
 using namespace protobuf_util;
 using namespace network_util;
 
-void SendCommand(const PbCommand& command, PbResult& result)
+int GetAvailablePort()
+{
+	const int fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd == -1) {
+		return 0;
+	}
+
+	sockaddr_in server_addr = {};
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+#ifdef __APPLE__
+	server_addr.sin_len = sizeof(server_addr);
+#endif
+	if (::bind(fd, reinterpret_cast<const sockaddr *>(&server_addr), sizeof(server_addr)) == -1) {
+		close(fd);
+		return 0;
+	}
+
+	socklen_t addr_size = sizeof(server_addr);
+	if (getsockname(fd, reinterpret_cast<sockaddr *>(&server_addr), &addr_size) == -1) {
+		close(fd);
+		return 0;
+	}
+
+	close(fd);
+	return ntohs(server_addr.sin_port);
+}
+
+void SendCommand(const PbCommand& command, PbResult& result, int port)
 {
 	sockaddr_in server_addr = {};
 	ASSERT_TRUE(ResolveHostName("127.0.0.1", &server_addr));
-	server_addr.sin_port = htons(uint16_t(9999));
+	server_addr.sin_port = htons(static_cast<uint16_t>(port));
 
 	const int fd = socket(AF_INET, SOCK_STREAM, 0);
 	ASSERT_NE(-1, fd);
@@ -45,20 +73,28 @@ void SendCommand(const PbCommand& command, PbResult& result)
 TEST(PiscsiServiceTest, Init)
 {
 	PiscsiService service;
+	const int port = GetAvailablePort();
+	ASSERT_NE(0, port);
 
 	EXPECT_FALSE(service.Init(nullptr, 65536).empty()) << "Illegal port number";
 	EXPECT_FALSE(service.Init(nullptr, 0).empty()) << "Illegal port number";
 	EXPECT_FALSE(service.Init(nullptr, -1).empty()) << "Illegal port number";
-	EXPECT_FALSE(service.Init(nullptr, 1).empty()) << "Port 1 is only available for the root user";
-	EXPECT_TRUE(service.Init(nullptr, 9999).empty()) << "Port 9999 is expected not to be in use for this test";
+#ifdef __linux__
+	if (geteuid()) {
+		EXPECT_FALSE(service.Init(nullptr, 1).empty()) << "Port 1 is only available for the root user";
+	}
+#endif
+	EXPECT_TRUE(service.Init(nullptr, port).empty()) << "Selected port is expected not to be in use for this test";
 	service.Stop();
 }
 
 TEST(PiscsiServiceTest, IsRunning)
 {
 	PiscsiService service;
+	const int port = GetAvailablePort();
+	ASSERT_NE(0, port);
 	EXPECT_FALSE(service.IsRunning());
-	EXPECT_TRUE(service.Init(nullptr, 9999).empty()) << "Port 9999 is expected not to be in use for this test";
+	EXPECT_TRUE(service.Init(nullptr, port).empty()) << "Selected port is expected not to be in use for this test";
 	EXPECT_FALSE(service.IsRunning());
 
 	service.Start();
@@ -69,19 +105,22 @@ TEST(PiscsiServiceTest, IsRunning)
 
 TEST(PiscsiServiceTest, Execute)
 {
+	const int port = GetAvailablePort();
+	ASSERT_NE(0, port);
+
 	sockaddr_in server_addr = {};
 	ASSERT_TRUE(ResolveHostName("127.0.0.1", &server_addr));
 
 	const int fd = socket(AF_INET, SOCK_STREAM, 0);
 	ASSERT_NE(-1, fd);
 
-	server_addr.sin_port = htons(uint16_t(9999));
+	server_addr.sin_port = htons(static_cast<uint16_t>(port));
 	EXPECT_FALSE(connect(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr)) >= 0) << "Service should not be running"; //NOSONAR bit_cast is not supported by the bullseye clang++ compiler
 
 	close(fd);
 
 	PiscsiService service;
-	service.Init([] (const CommandContext& context) {
+	const string init_error = service.Init([] (const CommandContext& context) {
 		if (context.GetCommand().operation() == PbOperation::NO_OPERATION) {
 			PbResult result;
 			result.set_status(true);
@@ -91,19 +130,20 @@ TEST(PiscsiServiceTest, Execute)
 			throw io_exception("error");
 		}
 		return true;
-	}, 9999);
+	}, port);
+	ASSERT_TRUE(init_error.empty()) << init_error;
 
 	service.Start();
 
 	PbCommand command;
 	PbResult result;
 
-	SendCommand(command, result);
+	SendCommand(command, result, port);
 	command.set_operation(PbOperation::NO_OPERATION);
     EXPECT_TRUE(result.status()) << "Command should have been successful";
 
     command.set_operation(PbOperation::EJECT);
-    SendCommand(command, result);
+    SendCommand(command, result, port);
     EXPECT_FALSE(result.status()) << "Exception should have been raised";
 
     service.Stop();

--- a/cpp/test/piscsi_service_test.cpp
+++ b/cpp/test/piscsi_service_test.cpp
@@ -27,6 +27,8 @@ using namespace piscsi_interface;
 using namespace protobuf_util;
 using namespace network_util;
 
+namespace {
+
 int GetAvailablePort()
 {
 	const int fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -36,7 +38,7 @@ int GetAvailablePort()
 
 	sockaddr_in server_addr = {};
 	server_addr.sin_family = AF_INET;
-	server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 #ifdef __APPLE__
 	server_addr.sin_len = sizeof(server_addr);
 #endif
@@ -55,35 +57,49 @@ int GetAvailablePort()
 	return ntohs(server_addr.sin_port);
 }
 
-void SendCommand(const PbCommand& command, PbResult& result, int port)
+bool SendCommand(const PbCommand& command, PbResult& result, int port)
 {
 	sockaddr_in server_addr = {};
-	ASSERT_TRUE(ResolveHostName("127.0.0.1", &server_addr));
+	if (!ResolveHostName("127.0.0.1", &server_addr)) {
+		return false;
+	}
 	server_addr.sin_port = htons(static_cast<uint16_t>(port));
 
 	const int fd = socket(AF_INET, SOCK_STREAM, 0);
-	ASSERT_NE(-1, fd);
-	EXPECT_TRUE(connect(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr)) >= 0) << "Service should be running"; //NOSONAR bit_cast is not supported by the bullseye clang++ compiler
-	ASSERT_EQ(6, write(fd, "RASCSI", 6));
+	if (fd == -1) {
+		return false;
+	}
+
+	if (connect(fd, reinterpret_cast<sockaddr *>(&server_addr), sizeof(server_addr)) < 0) { //NOSONAR bit_cast is not supported by the bullseye clang++ compiler
+		close(fd);
+		return false;
+	}
+
+	if (write(fd, "RASCSI", 6) != 6) {
+		close(fd);
+		return false;
+	}
+
 	SerializeMessage(fd, command);
-    DeserializeMessage(fd, result);
-    close(fd);
+	DeserializeMessage(fd, result);
+	close(fd);
+
+	return true;
+}
+
 }
 
 TEST(PiscsiServiceTest, Init)
 {
 	PiscsiService service;
 	const int port = GetAvailablePort();
-	ASSERT_NE(0, port);
+	if (!port) {
+		GTEST_SKIP() << "Unable to bind an ephemeral TCP port";
+	}
 
 	EXPECT_FALSE(service.Init(nullptr, 65536).empty()) << "Illegal port number";
 	EXPECT_FALSE(service.Init(nullptr, 0).empty()) << "Illegal port number";
 	EXPECT_FALSE(service.Init(nullptr, -1).empty()) << "Illegal port number";
-#ifdef __linux__
-	if (geteuid()) {
-		EXPECT_FALSE(service.Init(nullptr, 1).empty()) << "Port 1 is only available for the root user";
-	}
-#endif
 	EXPECT_TRUE(service.Init(nullptr, port).empty()) << "Selected port is expected not to be in use for this test";
 	service.Stop();
 }
@@ -92,7 +108,9 @@ TEST(PiscsiServiceTest, IsRunning)
 {
 	PiscsiService service;
 	const int port = GetAvailablePort();
-	ASSERT_NE(0, port);
+	if (!port) {
+		GTEST_SKIP() << "Unable to bind an ephemeral TCP port";
+	}
 	EXPECT_FALSE(service.IsRunning());
 	EXPECT_TRUE(service.Init(nullptr, port).empty()) << "Selected port is expected not to be in use for this test";
 	EXPECT_FALSE(service.IsRunning());
@@ -106,7 +124,9 @@ TEST(PiscsiServiceTest, IsRunning)
 TEST(PiscsiServiceTest, Execute)
 {
 	const int port = GetAvailablePort();
-	ASSERT_NE(0, port);
+	if (!port) {
+		GTEST_SKIP() << "Unable to bind an ephemeral TCP port";
+	}
 
 	sockaddr_in server_addr = {};
 	ASSERT_TRUE(ResolveHostName("127.0.0.1", &server_addr));
@@ -138,13 +158,13 @@ TEST(PiscsiServiceTest, Execute)
 	PbCommand command;
 	PbResult result;
 
-	SendCommand(command, result, port);
 	command.set_operation(PbOperation::NO_OPERATION);
-    EXPECT_TRUE(result.status()) << "Command should have been successful";
+	ASSERT_TRUE(SendCommand(command, result, port));
+	EXPECT_TRUE(result.status()) << "Command should have been successful";
 
-    command.set_operation(PbOperation::EJECT);
-    SendCommand(command, result, port);
-    EXPECT_FALSE(result.status()) << "Exception should have been raised";
+	command.set_operation(PbOperation::EJECT);
+	ASSERT_TRUE(SendCommand(command, result, port));
+	EXPECT_FALSE(result.status()) << "Exception should have been raised";
 
-    service.Stop();
+	service.Stop();
 }

--- a/cpp/test/protobuf_util_test.cpp
+++ b/cpp/test/protobuf_util_test.cpp
@@ -11,6 +11,7 @@
 #include "shared/protobuf_util.h"
 #include "shared/piscsi_exceptions.h"
 #include "generated/piscsi_interface.pb.h"
+#include <fcntl.h>
 #include <filesystem>
 
 using namespace piscsi_interface;

--- a/cpp/test/scsi_command_util_test.cpp
+++ b/cpp/test/scsi_command_util_test.cpp
@@ -123,11 +123,11 @@ TEST(ScsiCommandUtilTest, ModeSelectRejectsTruncatedParameterList)
 {
 	vector<int> cdb(6);
 	cdb[1] = 0x10;
-	vector<uint8_t> buf(19);
+	vector<uint8_t> buf(29);
 
 	// A complete Format Device Page is followed by one byte of a truncated page header.
 	buf[4] = 0x03;
-	buf[5] = 0x0c;
+	buf[5] = 0x16;
 	buf[16] = 0x02;
 
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb, buf, static_cast<int>(buf.size()), 512); },
@@ -135,6 +135,23 @@ TEST(ScsiCommandUtilTest, ModeSelectRejectsTruncatedParameterList)
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
 			Property(&scsi_exception::get_asc, asc::parameter_list_length_error))))
 		<< "Truncated mode page header was accepted";
+}
+
+TEST(ScsiCommandUtilTest, ModeSelectRejectsFormatDevicePageWithInvalidLength)
+{
+	vector<int> cdb(6);
+	cdb[1] = 0x10;
+	vector<uint8_t> buf(18);
+
+	buf[4] = 0x03;
+	buf[5] = 0x0c;
+	buf[16] = 0x02;
+
+	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb, buf, static_cast<int>(buf.size()), 512); },
+			Throws<scsi_exception>(AllOf(
+			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
+			Property(&scsi_exception::get_asc, asc::invalid_field_in_parameter_list))))
+		<< "Format Device Page with an invalid length was accepted";
 }
 
 TEST(ScsiCommandUtilTest, ModeSelectReportsParameterListLengthErrorForTruncation)
@@ -148,6 +165,7 @@ TEST(ScsiCommandUtilTest, ModeSelectReportsParameterListLengthErrorForTruncation
 	vector<int> cdb6(6);
 	cdb6[1] = 0x10;
 	vector<uint8_t> buf6(28);
+	expect_truncation([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb6, buf6, static_cast<int>(buf6.size()) + 1, 512); });
 	expect_truncation([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb6, buf6, 3, 512); });
 	buf6[3] = 1;
 	expect_truncation([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb6, buf6, 4, 512); });

--- a/cpp/test/scsi_command_util_test.cpp
+++ b/cpp/test/scsi_command_util_test.cpp
@@ -16,7 +16,7 @@ using namespace scsi_command_util;
 
 TEST(ScsiCommandUtilTest, ModeSelect6)
 {
-	const int LENGTH = 26;
+	const int LENGTH = 30;
 
 	vector<int> cdb(6);
 	vector<uint8_t> buf(LENGTH);
@@ -28,10 +28,11 @@ TEST(ScsiCommandUtilTest, ModeSelect6)
 	cdb[0] = 0x15;
 	// PF (standard parameter format)
 	cdb[1] = 0x10;
+	// Page 3 (Format Device Page), with its 22-byte payload
+	buf[4] = 0x03;
+	buf[5] = 0x16;
 	// Request 512 bytes per sector
-	buf[9] = 0x00;
-	buf[10] = 0x02;
-	buf[11] = 0x00;
+	buf[16] = 0x02;
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb, buf, LENGTH, 256); },
 			Throws<scsi_exception>(AllOf(
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
@@ -39,7 +40,7 @@ TEST(ScsiCommandUtilTest, ModeSelect6)
 		<< "Requested sector size does not match current sector size";
 
 	// Page 0
-	buf[12] = 0x00;
+	buf[4] = 0x00;
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb, buf, LENGTH, 512); },
 			Throws<scsi_exception>(AllOf(
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
@@ -47,7 +48,8 @@ TEST(ScsiCommandUtilTest, ModeSelect6)
 		<< "Unsupported page 0 was not rejected";
 
 	// Page 3 (Format Device Page)
-	buf[12] = 0x03;
+	buf[4] = 0x03;
+	buf[16] = 0;
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb, buf, LENGTH, 512); },
 			Throws<scsi_exception>(AllOf(
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
@@ -55,11 +57,11 @@ TEST(ScsiCommandUtilTest, ModeSelect6)
 		<< "Requested sector size does not match current sector size";
 
 	// Match the requested to the current sector size
-	buf[24] = 0x02;
+	buf[16] = 0x02;
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb, buf, LENGTH - 1, 512); },
 			Throws<scsi_exception>(AllOf(
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
-			Property(&scsi_exception::get_asc, asc::invalid_field_in_parameter_list))))
+			Property(&scsi_exception::get_asc, asc::parameter_list_length_error))))
 		<< "Not enough command parameters";
 
 	EXPECT_FALSE(ModeSelect(scsi_command::eCmdModeSelect6, cdb, buf, LENGTH, 512).empty());
@@ -67,7 +69,7 @@ TEST(ScsiCommandUtilTest, ModeSelect6)
 
 TEST(ScsiCommandUtilTest, ModeSelect10)
 {
-	const int LENGTH = 30;
+	const int LENGTH = 34;
 
 	vector<int> cdb(10);
 	vector<uint8_t> buf(LENGTH);
@@ -78,10 +80,11 @@ TEST(ScsiCommandUtilTest, ModeSelect10)
 
 	// PF (standard parameter format)
 	cdb[1] = 0x10;
+	// Page 3 (Format Device Page), with its 22-byte payload
+	buf[8] = 0x03;
+	buf[9] = 0x16;
 	// Request 512 bytes per sector
-	buf[13] = 0x00;
-	buf[14] = 0x02;
-	buf[15] = 0x00;
+	buf[20] = 0x02;
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect10, cdb, buf, LENGTH, 256); },
 			Throws<scsi_exception>(AllOf(
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
@@ -89,7 +92,7 @@ TEST(ScsiCommandUtilTest, ModeSelect10)
 		<< "Requested sector size does not match current sector size";
 
 	// Page 0
-	buf[16] = 0x00;
+	buf[8] = 0x00;
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect10, cdb, buf, LENGTH, 512); },
 			Throws<scsi_exception>(AllOf(
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
@@ -97,7 +100,8 @@ TEST(ScsiCommandUtilTest, ModeSelect10)
 		<< "Unsupported page 0 was not rejected";
 
 	// Page 3 (Format Device Page)
-	buf[16] = 0x03;
+	buf[8] = 0x03;
+	buf[20] = 0;
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect10, cdb, buf, LENGTH, 512); },
 			Throws<scsi_exception>(AllOf(
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
@@ -105,14 +109,59 @@ TEST(ScsiCommandUtilTest, ModeSelect10)
 		<< "Requested sector size does not match current sector size";
 
 	// Match the requested to the current sector size
-	buf[28] = 0x02;
+	buf[20] = 0x02;
 	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect10, cdb, buf, LENGTH - 1, 512); },
 			Throws<scsi_exception>(AllOf(
 			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
-			Property(&scsi_exception::get_asc, asc::invalid_field_in_parameter_list))))
+			Property(&scsi_exception::get_asc, asc::parameter_list_length_error))))
 		<< "Not enough command parameters";
 
 	EXPECT_FALSE(ModeSelect(scsi_command::eCmdModeSelect10, cdb, buf, LENGTH, 512).empty());
+}
+
+TEST(ScsiCommandUtilTest, ModeSelectRejectsTruncatedParameterList)
+{
+	vector<int> cdb(6);
+	cdb[1] = 0x10;
+	vector<uint8_t> buf(19);
+
+	// A complete Format Device Page is followed by one byte of a truncated page header.
+	buf[4] = 0x03;
+	buf[5] = 0x0c;
+	buf[16] = 0x02;
+
+	EXPECT_THAT([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb, buf, static_cast<int>(buf.size()), 512); },
+			Throws<scsi_exception>(AllOf(
+			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
+			Property(&scsi_exception::get_asc, asc::parameter_list_length_error))))
+		<< "Truncated mode page header was accepted";
+}
+
+TEST(ScsiCommandUtilTest, ModeSelectReportsParameterListLengthErrorForTruncation)
+{
+	const auto expect_truncation = [](const auto& operation) {
+		EXPECT_THAT(operation, Throws<scsi_exception>(AllOf(
+			Property(&scsi_exception::get_sense_key, sense_key::illegal_request),
+			Property(&scsi_exception::get_asc, asc::parameter_list_length_error))));
+	};
+
+	vector<int> cdb6(6);
+	cdb6[1] = 0x10;
+	vector<uint8_t> buf6(28);
+	expect_truncation([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb6, buf6, 3, 512); });
+	buf6[3] = 1;
+	expect_truncation([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb6, buf6, 4, 512); });
+	buf6[3] = 0;
+	buf6[4] = 0x03;
+	buf6[5] = 0x16;
+	expect_truncation([&] { ModeSelect(scsi_command::eCmdModeSelect6, cdb6, buf6, 27, 512); });
+
+	vector<int> cdb10(10);
+	cdb10[1] = 0x10;
+	vector<uint8_t> buf10(8);
+	expect_truncation([&] { ModeSelect(scsi_command::eCmdModeSelect10, cdb10, buf10, 7, 512); });
+	buf10[7] = 1;
+	expect_truncation([&] { ModeSelect(scsi_command::eCmdModeSelect10, cdb10, buf10, 8, 512); });
 }
 
 TEST(ScsiCommandUtilTest, EnrichFormatPage)

--- a/cpp/test/scsihd_test.cpp
+++ b/cpp/test/scsihd_test.cpp
@@ -113,15 +113,20 @@ TEST(ScsiHdTest, ModeSelect)
 	cmd[1] = 0x10;
 	// Page 3 (Device Format Page)
 	buf[4] = 0x03;
-	// 512 bytes per sector
+	// 22 bytes (standard format page length)
+	buf[5] = 0x16;
+	// 512 bytes per sector (offset 12 from page start = offset 16 from buffer start)
 	buf[16] = 0x02;
 	EXPECT_NO_THROW(hd.ModeSelect(scsi_command::eCmdModeSelect6, cmd, buf, 255)) << "MODE SELECT(6) is supported";
 	buf[4] = 0;
+	buf[5] = 0;
 	buf[16] = 0;
 
 	// Page 3 (Device Format Page)
 	buf[8] = 0x03;
-	// 512 bytes per sector
+	// 22 bytes (standard format page length)
+	buf[9] = 0x16;
+	// 512 bytes per sector (offset 12 from page start = offset 20 from buffer start)
 	buf[20] = 0x02;
 	EXPECT_NO_THROW(hd.ModeSelect(scsi_command::eCmdModeSelect10, cmd, buf, 255)) << "MODE SELECT(10) is supported";
 }

--- a/cpp/test/scsihd_test.cpp
+++ b/cpp/test/scsihd_test.cpp
@@ -105,7 +105,7 @@ TEST(ScsiHdTest, ModeSelect)
 {
 	MockSCSIHD hd({ 512 });
 	vector<int> cmd(10);
-	vector<uint8_t> buf(255);
+	vector<uint8_t> buf(32);
 
 	hd.SetSectorSizeInBytes(512);
 
@@ -117,7 +117,7 @@ TEST(ScsiHdTest, ModeSelect)
 	buf[5] = 0x16;
 	// 512 bytes per sector (offset 12 from page start = offset 16 from buffer start)
 	buf[16] = 0x02;
-	EXPECT_NO_THROW(hd.ModeSelect(scsi_command::eCmdModeSelect6, cmd, buf, 255)) << "MODE SELECT(6) is supported";
+	EXPECT_NO_THROW(hd.ModeSelect(scsi_command::eCmdModeSelect6, cmd, buf, 28)) << "MODE SELECT(6) is supported";
 	buf[4] = 0;
 	buf[5] = 0;
 	buf[16] = 0;
@@ -128,5 +128,5 @@ TEST(ScsiHdTest, ModeSelect)
 	buf[9] = 0x16;
 	// 512 bytes per sector (offset 12 from page start = offset 20 from buffer start)
 	buf[20] = 0x02;
-	EXPECT_NO_THROW(hd.ModeSelect(scsi_command::eCmdModeSelect10, cmd, buf, 255)) << "MODE SELECT(10) is supported";
+	EXPECT_NO_THROW(hd.ModeSelect(scsi_command::eCmdModeSelect10, cmd, buf, 32)) << "MODE SELECT(10) is supported";
 }

--- a/cpp/test/scsimo_test.cpp
+++ b/cpp/test/scsimo_test.cpp
@@ -145,14 +145,19 @@ TEST(ScsiMoTest, ModeSelect)
 	cmd[1] = 0x10;
 	// Page 3 (Device Format Page)
 	buf[4] = 0x03;
+    // 22 bytes (standard format page length)
+	buf[5] = 0x16;
 	// 2048 bytes per sector
 	buf[16] = 0x08;
 	EXPECT_NO_THROW(mo.ModeSelect(scsi_command::eCmdModeSelect6, cmd, buf, 255)) << "MODE SELECT(6) is supported";
 	buf[4] = 0;
+	buf[5] = 0;
 	buf[16] = 0;
 
 	// Page 3 (Device Format Page)
 	buf[8] = 0x03;
+    // 22 bytes (standard format page length)
+	buf[9] = 0x16;
 	// 2048 bytes per sector
 	buf[20] = 0x08;
 	EXPECT_NO_THROW(mo.ModeSelect(scsi_command::eCmdModeSelect10, cmd, buf, 255)) << "MODE SELECT(10) is supported";

--- a/cpp/test/scsimo_test.cpp
+++ b/cpp/test/scsimo_test.cpp
@@ -137,7 +137,7 @@ TEST(ScsiMoTest, ModeSelect)
 {
 	MockSCSIMO mo(0);
 	vector<int> cmd(10);
-	vector<uint8_t> buf(255);
+	vector<uint8_t> buf(32);
 
 	mo.SetSectorSizeInBytes(2048);
 
@@ -145,20 +145,20 @@ TEST(ScsiMoTest, ModeSelect)
 	cmd[1] = 0x10;
 	// Page 3 (Device Format Page)
 	buf[4] = 0x03;
-    // 22 bytes (standard format page length)
+	// 22 bytes (standard format page length)
 	buf[5] = 0x16;
 	// 2048 bytes per sector
 	buf[16] = 0x08;
-	EXPECT_NO_THROW(mo.ModeSelect(scsi_command::eCmdModeSelect6, cmd, buf, 255)) << "MODE SELECT(6) is supported";
+	EXPECT_NO_THROW(mo.ModeSelect(scsi_command::eCmdModeSelect6, cmd, buf, 28)) << "MODE SELECT(6) is supported";
 	buf[4] = 0;
 	buf[5] = 0;
 	buf[16] = 0;
 
 	// Page 3 (Device Format Page)
 	buf[8] = 0x03;
-    // 22 bytes (standard format page length)
+	// 22 bytes (standard format page length)
 	buf[9] = 0x16;
 	// 2048 bytes per sector
 	buf[20] = 0x08;
-	EXPECT_NO_THROW(mo.ModeSelect(scsi_command::eCmdModeSelect10, cmd, buf, 255)) << "MODE SELECT(10) is supported";
+	EXPECT_NO_THROW(mo.ModeSelect(scsi_command::eCmdModeSelect10, cmd, buf, 32)) << "MODE SELECT(10) is supported";
 }

--- a/cpp/test/storage_device_test.cpp
+++ b/cpp/test/storage_device_test.cpp
@@ -15,7 +15,20 @@
 
 using namespace filesystem;
 
-TEST(StorageDeviceTest, SetGetFilename)
+class StorageDeviceTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		// Clean up any previous test state before each test
+		StorageDevice::UnreserveAll();
+	}
+
+	void TearDown() override {
+		// Clean up after each test
+		StorageDevice::UnreserveAll();
+	}
+};
+
+TEST_F(StorageDeviceTest, SetGetFilename)
 {
 	MockStorageDevice device;
 
@@ -23,7 +36,7 @@ TEST(StorageDeviceTest, SetGetFilename)
 	EXPECT_EQ("filename", device.GetFilename());
 }
 
-TEST(StorageDeviceTest, ValidateFile)
+TEST_F(StorageDeviceTest, ValidateFile)
 {
 	MockStorageDevice device;
 
@@ -59,7 +72,7 @@ TEST(StorageDeviceTest, ValidateFile)
 	remove(filename);
 }
 
-TEST(StorageDeviceTest, MediumChanged)
+TEST_F(StorageDeviceTest, MediumChanged)
 {
 	MockStorageDevice device;
 
@@ -72,7 +85,7 @@ TEST(StorageDeviceTest, MediumChanged)
 	EXPECT_FALSE(device.IsMediumChanged());
 }
 
-TEST(StorageDeviceTest, GetIdsForReservedFile)
+TEST_F(StorageDeviceTest, GetIdsForReservedFile)
 {
 	const int ID = 1;
 	const int LUN = 0;
@@ -81,7 +94,6 @@ TEST(StorageDeviceTest, GetIdsForReservedFile)
 	MockAbstractController controller(bus, ID);
 	auto device = make_shared<MockSCSIHD_NEC>(LUN);
 	device->SetFilename("filename");
-	StorageDevice::UnreserveAll();
 
 	EXPECT_TRUE(controller_manager.AttachToController(*bus, ID, device));
 
@@ -100,7 +112,7 @@ TEST(StorageDeviceTest, GetIdsForReservedFile)
 	EXPECT_EQ(-1, lun3);
 }
 
-TEST(StorageDeviceTest, UnreserveAll)
+TEST_F(StorageDeviceTest, UnreserveAll)
 {
 	const int ID = 1;
 	const int LUN = 0;
@@ -119,7 +131,7 @@ TEST(StorageDeviceTest, UnreserveAll)
 	EXPECT_EQ(-1, lun);
 }
 
-TEST(StorageDeviceTest, GetSetReservedFiles)
+TEST_F(StorageDeviceTest, GetSetReservedFiles)
 {
 	const int ID = 1;
 	const int LUN = 0;
@@ -142,13 +154,13 @@ TEST(StorageDeviceTest, GetSetReservedFiles)
 	EXPECT_TRUE(reserved_files.contains("filename"));
 }
 
-TEST(StorageDeviceTest, FileExists)
+TEST_F(StorageDeviceTest, FileExists)
 {
 	EXPECT_FALSE(StorageDevice::FileExists("/non_existing_file"));
 	EXPECT_TRUE(StorageDevice::FileExists("/dev/null"));
 }
 
-TEST(StorageDeviceTest, GetFileSize)
+TEST_F(StorageDeviceTest, GetFileSize)
 {
 	MockStorageDevice device;
 

--- a/cpp/test/test_setup.cpp
+++ b/cpp/test/test_setup.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <spdlog/spdlog.h>
+#include <fcntl.h>
 
 int main(int argc, char *[])
 {

--- a/cpp/test/test_setup.cpp
+++ b/cpp/test/test_setup.cpp
@@ -12,7 +12,7 @@
 #include <spdlog/spdlog.h>
 #include <fcntl.h>
 
-int main(int argc, char *[])
+int main(int argc, char *argv[])
 {
 	const bool disable_logging = argc <= 1;
 
@@ -25,7 +25,7 @@ int main(int argc, char *[])
 		dup2(fd, STDERR_FILENO);
 	}
 
-	testing::InitGoogleTest();
+	testing::InitGoogleTest(&argc, argv);
 
 	const int result = RUN_ALL_TESTS();
 

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,40 @@
+man_pages = [
+  'piscsi.1',
+]
+
+if to_build.contains('scsictl')
+    man_pages += 'scsictl.1'
+endif
+
+if to_build.contains('scsimon')
+    man_pages += 'scsimon.1'
+endif
+
+if to_build.contains('scsidump')
+    man_pages += 'scsidump.1'
+endif
+
+if to_build.contains('scsiloop')
+    man_pages += 'scsiloop.1'
+endif
+
+foreach man : man_pages
+  install_data(man, install_dir : get_option('prefix') / get_option('mandir') / 'man1')
+  # Also generate a plain text version and install it into the doc/ directory in the source tree
+  txt = man.split('.')[0] + '_man_page.txt'
+  custom_target(
+    txt,
+    input : man,
+    output : txt,
+    command : [
+      'sh', '-c',
+      'echo "!!   ------ THIS FILE IS AUTO_GENERATED! DO NOT MANUALLY UPDATE!!!" && ' +
+      'echo "!!   ------ The source file is $(basename @INPUT@)" && ' +
+      'echo "" && ' +
+      'man -l @INPUT@ | col -bx'
+    ],
+    capture: true,
+    install : true,
+    install_dir : meson.project_source_root() / 'doc',
+  )
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,49 @@
+project(
+    'piscsi',
+    'cpp',
+    version : '24.4.1',
+    default_options : ['cpp_std=c++20', 'warning_level=2']
+)
+
+common_flags = [
+  '-D_FILE_OFFSET_BITS=64',
+  '-DFMT_HEADER_ONLY',
+  '-DSPDLOG_FMT_EXTERNAL',
+]
+
+if get_option('buildtype') == 'debug'
+  common_flags += '-DDEBUG'
+else
+  common_flags += '-DNDEBUG'
+endif
+
+if host_machine.system() == 'linux'
+  common_flags += '-Wno-psabi'
+endif
+
+to_build = get_option('to_build')
+connect_type = get_option('connect_type')
+common_flags += '-DCONNECT_TYPE_' + connect_type
+add_project_arguments(common_flags, language : 'cpp')
+
+# Dependencies
+protobuf_dep = dependency('protobuf', required : true)
+protoc = find_program('protoc', required : true)
+pthread_dep = dependency('threads', required : true)
+pcap_dep = dependency('pcap', required : true)
+gtest_dep = dependency('gtest', required : false)
+gmock_dep = dependency('gmock', required : false)
+
+subdir('cpp')
+subdir('doc')
+subdir('os_integration')
+
+summary(
+  {
+    'Connect type': connect_type,
+    'Build type': get_option('buildtype'),
+    'Targets': ', '.join(to_build),
+    'Prefix': get_option('prefix'),
+  },
+  section : 'Configuration'
+)

--- a/meson.build
+++ b/meson.build
@@ -7,8 +7,6 @@ project(
 
 common_flags = [
   '-D_FILE_OFFSET_BITS=64',
-  '-DFMT_HEADER_ONLY',
-  '-DSPDLOG_FMT_EXTERNAL',
 ]
 
 if get_option('buildtype') == 'debug'
@@ -31,8 +29,12 @@ protobuf_dep = dependency('protobuf', required : true)
 protoc = find_program('protoc', required : true)
 pthread_dep = dependency('threads', required : true)
 pcap_dep = dependency('pcap', required : true)
+spdlog_dep = dependency('spdlog', required : true)
+fmt_dep = dependency('fmt', required : true)
 gtest_dep = dependency('gtest', required : false)
 gmock_dep = dependency('gmock', required : false)
+
+common_deps = [pthread_dep, spdlog_dep, fmt_dep]
 
 subdir('cpp')
 subdir('doc')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,14 @@
+option(
+    'connect_type',
+    type : 'combo',
+    choices : ['AIBOM', 'FULLSPEC', 'GAMERNIUM', 'STANDARD'],
+    value : 'FULLSPEC',
+    description : 'PiSCSI board type'
+)
+option(
+    'to_build',
+    type : 'array',
+    choices : ['piscsi', 'scsictl', 'scsimon', 'scsiloop', 'scsidump', 'test'],
+    value : ['piscsi', 'scsictl', 'scsimon', 'scsiloop', 'scsidump', 'test'],
+    description : 'Binaries to build'
+)

--- a/os_integration/meson.build
+++ b/os_integration/meson.build
@@ -1,0 +1,2 @@
+install_data('piscsi.conf', install_dir : 'etc' / 'rsyslog.d')
+install_data('piscsi.service', install_dir : 'etc' / 'systemd' / 'system')


### PR DESCRIPTION
Adds a suite of meson scripts for building the C++ project. Example commands:

```
meson setup build
meson compile -C build
meson test -C build
meson install -C build
```

Running the unit tests after being built with meson revealed a number of test isolation / atomicity bugs, leading to pointer dereference and buffer overflow bugs in piscsi proper, for which fixes are included.

also, a handful of portability fixes to allow the software to be built and unit tests executed on macOS (and perhaps other similar OSes)