### PR TITLE
web UI: fallback no-js web form for file uploads (#1364)

### DIFF
--- a/python/web/src/templates/index.html
+++ b/python/web/src/templates/index.html
@@ -598,7 +598,7 @@
 </section>
 
 <section id="upload">
-    <a href="/upload" target="_blank"><p>{{ _("Upload Files (new tab)") }}</p></a>
+    <a href="/upload" target="_blank"><p>{{ _("Upload Files (new window)") }}</p></a>
 </section>
 <noscript>
     <style type="text/css">

--- a/python/web/src/templates/upload.html
+++ b/python/web/src/templates/upload.html
@@ -11,33 +11,45 @@
     <li>{{ _("PiSCSI Config") }} = {{ CFG_DIR }}</li>
 </ul>
 
-<form name="dropper" action="/files/upload" method="post" class="dropzone dz-clickable" enctype="multipart/form-data" id="dropper">
-    <fieldset>
-    <legend>{{ _("Destination") }}</legend>
-    <label for="disk_images" class="hidden">{{ _("Disk Images") }}</label>
-    <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
-    <label for="images_subdir" class="hidden">{{ _("To directory:") }}</label>
-    <select name="images_subdir" id="images_subdir">
-    {% for dir in images_subdirs %}
-    <option value="{{dir}}">{{ env['image_root_dir'] }}/{{dir}}</option>
-    {% endfor %}
-    <option value="" selected>{{ env['image_root_dir'] }}/</option>
-    </select>
-    {% if file_server_dir_exists %}
-    <label for="shared_files" class="hidden">{{ _("Shared Files") }}</label>
-    <input type="radio" name="destination" id="shared_files" value="shared_files">
-    <label for="shared_subdir" class="hidden">{{ _("To directory:") }}</label>
-    <select name="shared_subdir" id="shared_subdir">
-    {% for dir in shared_subdirs %}
-    <option value="{{dir}}">{{ env['shared_root_dir'] }}/{{dir}}</option>
-    {% endfor %}
-    <option value="" selected>{{ env['shared_root_dir'] }}/</option>
-    </select>
-    {% endif %}
-    <input type="radio" name="destination" id="piscsi_config" value="piscsi_config">
-    <label for="piscsi_config">{{ _("PiSCSI Config") }}</label>
-    </fieldset>
-</form>
+<style>
+#js-upload-form { display: none; }
+</style>
+
+<div id="js-upload-form">
+    <form name="dropper" action="/files/upload" method="post" class="dropzone dz-clickable" enctype="multipart/form-data" id="dropper">
+        <fieldset>
+        <legend>{{ _("Destination") }}</legend>
+        <label for="disk_images" class="hidden">{{ _("Disk Images") }}</label>
+        <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
+        <label for="images_subdir" class="hidden">{{ _("To directory:") }}</label>
+        <select name="images_subdir" id="images_subdir">
+        {% for dir in images_subdirs %}
+        <option value="{{dir}}">{{ env['image_root_dir'] }}/{{dir}}</option>
+        {% endfor %}
+        <option value="" selected>{{ env['image_root_dir'] }}/</option>
+        </select>
+        {% if file_server_dir_exists %}
+        <label for="shared_files" class="hidden">{{ _("Shared Files") }}</label>
+        <input type="radio" name="destination" id="shared_files" value="shared_files">
+        <label for="shared_subdir" class="hidden">{{ _("To directory:") }}</label>
+        <select name="shared_subdir" id="shared_subdir">
+        {% for dir in shared_subdirs %}
+        <option value="{{dir}}">{{ env['shared_root_dir'] }}/{{dir}}</option>
+        {% endfor %}
+        <option value="" selected>{{ env['shared_root_dir'] }}/</option>
+        </select>
+        {% endif %}
+        <input type="radio" name="destination" id="piscsi_config" value="piscsi_config">
+        <label for="piscsi_config">{{ _("PiSCSI Config") }}</label>
+        </fieldset>
+    </form>
+</div>
+
+<script type="application/javascript">
+document.addEventListener("DOMContentLoaded", function() {
+    document.getElementById("js-upload-form").style.display = "block";
+});
+</script>
 
 <script
     type="application/javascript"
@@ -82,9 +94,36 @@
 </script>
 
 <noscript>
-    <div class="noscriptmsg">
-        {{ _("The file uploading functionality requires JavaScript.") }}
-    </div>
+    <form id="uploadForm" action="/files/uploadform/" onchange="fileSelect(event)" method="post" enctype="multipart/form-data">
+        <fieldset>
+            <legend>{{ _("Destination") }}</legend>
+            <label for="disk_images" class="hidden">{{ _("Disk Images") }}</label>
+            <input type="radio" name="destination" id="disk_images" value="disk_images" checked="checked">
+            <label for="images_subdir" class="hidden">{{ _("To directory:") }}</label>
+            <select name="images_subdir" id="images_subdir">
+            {% for dir in images_subdirs %}
+            <option value="{{dir}}">{{ env['image_root_dir'] }}/{{dir}}</option>
+            {% endfor %}
+            <option value="" selected>{{ env['image_root_dir'] }}/</option>
+            </select>
+            {% if file_server_dir_exists %}
+            <label for="shared_files" class="hidden">{{ _("Shared Files") }}</label>
+            <input type="radio" name="destination" id="shared_files" value="shared_files">
+            <label for="shared_subdir" class="hidden">{{ _("To directory:") }}</label>
+            <select name="shared_subdir" id="shared_subdir">
+            {% for dir in shared_subdirs %}
+            <option value="{{dir}}">{{ env['shared_root_dir'] }}/{{dir}}</option>
+            {% endfor %}
+            <option value="" selected>{{ env['shared_root_dir'] }}/</option>
+            </select>
+            {% endif %}
+            <input type="radio" name="destination" id="piscsi_config" value="piscsi_config">
+            <label for="piscsi_config">{{ _("PiSCSI Config") }}</label>
+        </fieldset>
+        <label for="file">File:</label>
+        <input type="file" name="file"/>
+        <input type="submit" value="Upload" />
+    </form>
 </noscript>
 
 {% endblock content %}


### PR DESCRIPTION
This makes it possible to upload files from a vintage browser, for instance

Note that you have to explicitly turn off javascript in the user agent to get the fallback form