### PR TITLE
easyinstall: fallback when hfsutils package is not found

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -13,7 +13,7 @@ COPY --chown=pi:pi easyinstall.sh .
 COPY --chown=pi:pi cpp cpp
 COPY --chown=pi:pi doc doc
 COPY --chown=pi:pi proto proto
-RUN ./easyinstall.sh --run_choice=16 --cores=`nproc`
+RUN ./easyinstall.sh --run_choice=15 --cores=`nproc`
 
 FROM debian:bullseye-slim AS runner
 USER root

--- a/shell_scripts/netatalk_install.sh
+++ b/shell_scripts/netatalk_install.sh
@@ -251,6 +251,12 @@ while [ "$1" != "" ]; do
         -p | --share-path)
             AFP_SHARE_PATH=$VALUE
             ;;
+        -N | --additional-share-name)
+            ADDITIONAL_SHARE_NAME=$VALUE
+            ;;
+        -P | --additional-share-path)
+            ADDITIONAL_SHARE_PATH=$VALUE
+            ;;
         -t | --appletalk-interface)
             APPLETALK_INTERFACE=$VALUE
             ;;


### PR DESCRIPTION
Refactor the deb packages to always separate backend and frontend packages, then capture the error of a missing hfsutils (fell off Debian Trixie) at which point we clone the hfsutils source code and build it from scratch

refactoring the apt source updating routines to reduce its frequency

merge netatalk image dir sharing with netatalk installation (the previous logic was broken since upgrading to netatalk 4.x)