### PR TITLE
Downgrade Adafruit-Blinka version to 8.50.0

### DIFF
--- a/python/oled/requirements.txt
+++ b/python/oled/requirements.txt
@@ -1,5 +1,5 @@
 # commented out packages are system python libraries
-Adafruit-Blinka==8.68.0
+Adafruit-Blinka==8.50.0
 adafruit-circuitpython-busdevice==5.2.14
 adafruit-circuitpython-connectionmanager==3.1.6
 adafruit-circuitpython-framebuf==1.6.10


### PR DESCRIPTION
Adafruit-Blinka 8.50.0 is the final version of this package that works with python 3.9

8.51.0 and later introduced a dependency on the Adafruit-Blinka-Raspberry-Pi5-Neopixel package which requires python 3.11