### PR TITLE
bump platformdirs from 4.2.0 to 4.3.6

### DIFF
--- a/python/web/requirements-dev.txt
+++ b/python/web/requirements-dev.txt
@@ -13,7 +13,7 @@ mccabe==0.7.0
 mypy-extensions==1.1.0
 packaging==25.0
 pathspec==1.0.3
-platformdirs==4.2.0
+platformdirs==4.3.6
 pluggy==1.6.0
 pycodestyle==2.14.0
 pyflakes==3.4.0


### PR DESCRIPTION
v4.3.6 is the final version of this library that support python 3.8