### PR TITLE
Fix logging for unknown commands

### DIFF
--- a/cpp/controllers/scsi_controller.cpp
+++ b/cpp/controllers/scsi_controller.cpp
@@ -144,7 +144,7 @@ void ScsiController::Command()
 		const int actual_count = GetBus().CommandHandShake(GetBuffer());
 		if (actual_count == 0) {
 			stringstream s;
-			s << "Received unknown command: $" << setfill('0') << setw(2) << hex << GetBuffer()[0];
+			s << "Received unknown command: $" << setfill('0') << setw(2) << hex << static_cast<unsigned int>(GetBuffer()[0]);
 			LogTrace(s.str());
 
 			Error(sense_key::illegal_request, asc::invalid_command_operation_code);


### PR DESCRIPTION
I'm currently debugging why NetBSD cannot access a simulated DEC RRD42 drive. The log shows this command is received:

Mar  6 09:31:55 piscsi PISCSI[479]: [2026-03-06 09:31:55.710] [trace] (ID 5) - Received unknown command: $0Q

This is actually 0x51 (= ASCII 'Q')