### PR TITLE
bound CD-ROM READ TOC allocation length to the transfer buffer

### DIFF
--- a/cpp/devices/scsicd.cpp
+++ b/cpp/devices/scsicd.cpp
@@ -249,8 +249,9 @@ int SCSICD::ReadTocInternal(cdb_t cdb, vector<uint8_t>& buf)
 	assert(!tracks.empty());
 	assert(tracks[0]);
 
-	// Get allocation length, clear buffer
-	const int length = GetInt16(cdb, 7);
+	// Get allocation length, clear buffer. The allocation length is initiator-controlled and can
+	// exceed the transfer buffer size, so it has to be limited to the buffer size.
+	const auto length = static_cast<int>(min(buf.size(), static_cast<size_t>(GetInt16(cdb, 7))));
 	fill_n(buf.data(), length, 0);
 
 	// Get MSF Flag
@@ -264,10 +265,10 @@ int SCSICD::ReadTocInternal(cdb_t cdb, vector<uint8_t>& buf)
 	}
 
 	// Check start index
-	int index = 0;
+	size_t index = 0;
 	if (cdb[6] != 0x00) {
 		// Advance the track until the track numbers match
-		while (tracks[index]) {
+		while (index < tracks.size() && tracks[index]) {
 			if (cdb[6] == tracks[index]->GetTrackNo()) {
 				break;
 			}
@@ -275,7 +276,7 @@ int SCSICD::ReadTocInternal(cdb_t cdb, vector<uint8_t>& buf)
 		}
 
 		// AA if not found or internal error
-		if (!tracks[index]) {
+		if (index == tracks.size() || !tracks[index]) {
 			if (cdb[6] != 0xaa) {
 				throw scsi_exception(sense_key::illegal_request, asc::invalid_field_in_cdb);
 			}
@@ -385,4 +386,3 @@ int SCSICD::SearchTrack(uint32_t lba) const
 	// Track wasn't found
 	return -1;
 }
-

--- a/cpp/test/mocks.h
+++ b/cpp/test/mocks.h
@@ -158,6 +158,8 @@ class MockAbstractController : public AbstractController //NOSONAR Having many f
 	FRIEND_TEST(HostServicesTest, ModeSense10);
 	FRIEND_TEST(HostServicesTest, SetUpModePages);
 	FRIEND_TEST(ScsiPrinterTest, Print);
+	FRIEND_TEST(ScsiCdTest, ReadToc);
+	FRIEND_TEST(ScsiCdTest, ReadTocAllocationLength);
 
 public:
 
@@ -390,6 +392,7 @@ class MockSCSICD : public SCSICD //NOSONAR Ignore inheritance hierarchy depth in
 	FRIEND_TEST(ScsiCdTest, GetSectorSizes);
 	FRIEND_TEST(ScsiCdTest, SetUpModePages);
 	FRIEND_TEST(ScsiCdTest, ReadToc);
+	FRIEND_TEST(ScsiCdTest, ReadTocAllocationLength);
 
 	using SCSICD::SCSICD;
 };

--- a/cpp/test/scsicd_test.cpp
+++ b/cpp/test/scsicd_test.cpp
@@ -132,4 +132,58 @@ TEST(ScsiCdTest, ReadToc)
 			Property(&scsi_exception::get_asc, asc::medium_not_present))));
 
 	// Further testing requires filesystem access
+	path filename = CreateTempFile(2 * 2048);
+	cd->SetFilename(string(filename));
+	cd->Open();
+	cd->SetAttn(false);
+
+	// READ TOC with start track AA requests the lead-out descriptor. This is
+	// commonly issued by CD-ROM initiators and must not walk past the last track.
+	controller->SetCmdByte(6, 0xaa);
+	controller->SetCmdByte(8, 12);
+	controller->AllocateBuffer(12);
+	EXPECT_CALL(*controller, DataIn);
+	cd->Dispatch(scsi_command::eCmdReadToc);
+
+	const auto& buf = controller->GetBuffer();
+	EXPECT_EQ(12, controller->GetLength());
+	EXPECT_EQ(0x00, buf[0]);
+	EXPECT_EQ(0x0a, buf[1]);
+	EXPECT_EQ(0x01, buf[2]);
+	EXPECT_EQ(0x01, buf[3]);
+	EXPECT_EQ(0xaa, buf[6]);
+	EXPECT_EQ(0x00, buf[10]);
+	EXPECT_EQ(0x02, buf[11]);
+
+	remove(filename);
+}
+
+// The allocation length in the CDB is initiator-controlled and can be up to 65535, while the
+// controller buffer is only DEFAULT_BUFFER_SIZE (4096) bytes. READ TOC must not write or report
+// more than the buffer holds.
+TEST(ScsiCdTest, ReadTocAllocationLength)
+{
+	auto controller = make_shared<MockAbstractController>();
+	auto cd = make_shared<MockSCSICD>(0);
+	EXPECT_TRUE(cd->Init({}));
+
+	controller->AddDevice(cd);
+	// The real controller allocates DEFAULT_BUFFER_SIZE
+	controller->AllocateBuffer(4096);
+
+	const path filename = CreateTempFile(2 * 2048);
+	cd->SetFilename(string(filename));
+	cd->Open();
+	cd->SetAttn(false);
+
+	// Request the maximum allocation length that fits in the 16 bit CDB field
+	controller->SetCmdByte(7, 0xff);
+	controller->SetCmdByte(8, 0xff);
+	EXPECT_CALL(*controller, DataIn);
+	cd->Dispatch(scsi_command::eCmdReadToc);
+
+	EXPECT_LE(controller->GetLength(), controller->GetBuffer().size())
+					<< "READ TOC must not report more data than the transfer buffer holds";
+
+	remove(filename);
 }


### PR DESCRIPTION
READ TOC receives its allocation length from the initiator’s CDB and accepts values up to 65535 bytes. The controller’s transfer buffer is normally only 4096 bytes, so using that value directly could overrun the buffer and report more data than can be transferred.

Clamp the response length to the available buffer size and clear only that bounded range before constructing the response. Also bound the start-track scan before dereferencing the track vector, allowing a lead-out (0xAA) request to safely produce its descriptor when no matching track exists.

Add regression tests for the maximum allocation length and for READ TOC lead-out handling.